### PR TITLE
Problem: need to signal to zproto when using generated header

### DIFF
--- a/build-class.gsl
+++ b/build-class.gsl
@@ -88,6 +88,7 @@ endfunction
 //  Opaque class structures to allow forward references
 .for project.class where !defined (class.private)
 typedef struct _$(class.name)_t $(class.name)_t;
+#define $(CLASS.NAME)_T_DEFINED
 .endfor
 
 .for constant where !defined (constant.private)


### PR DESCRIPTION
Otherwise zproto regenerates typedefs for opaque types, in message
and client codecs.

Solution: define macro when defining typedefs. Needs matching change
in zproto.
