### PR TITLE
Problem: it's clumsy to specify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Headers for classes are automatically added, there's no need to add them by head
 Dependencies to other libraries need three attributes. The name of the library (without lib prefix), their header file to be included and a test method to check if the library is installed. (Currently only dynamic linked libraries are supported). Below is an example for zeromq/libzmq:
 
 ```
-<dependency name="zmq" header="zmq.h" test="zmq_init" />
+<use project = "zmq" />
 ```
+
+The known/allowed projects are "zyre", "czmq", and "zmq". You can add more by patching class_projects.gsl.
 
 ## more is comming ...
 

--- a/build-autoconf.gsl
+++ b/build-autoconf.gsl
@@ -10,6 +10,26 @@
 .#      * version.sh
 .#      * configure.ac
 .#  ===========================================================================
+.#
+.macro depends_on (name)
+.   if count (project.use, use.project = my.name) = 0
+.       new use to project as child before use
+.           child.project = my.name
+.           child.implied = 1
+.       endnew
+.   endif
+.endmacro
+.include "class_projects.gsl"
+.#
+.#  These are the projects we know about (expand this list as needed)
+.#
+.for use
+.   resolve_dependency (use)
+.endfor
+.for use
+.   resolve_dependency (use)
+.endfor
+.#
 .echo "Generating autogen.sh ..."
 .output "autogen.sh"
 #!/usr/bin/env sh
@@ -168,8 +188,8 @@ if test "x${$(PROJECT.NAME)_GCOV}" == "xyes"; then
     fi
 fi
 
-.for dependency
-.lib_name = "lib$(dependency.name)"
+.for use
+.lib_name = "lib$(use.project)"
 # $(lib_name) integration
 AC_ARG_WITH([$(lib_name)],
             [AS_HELP_STRING([--with-$(lib_name)],
@@ -178,26 +198,23 @@ AC_ARG_WITH([$(lib_name)],
             [])
 
 if test "x$search_$(lib_name)" = "xyes"; then
-    if test -r "${with_$(lib_name)}/include/$(dependency.header)"; then
+    if test -r "${with_$(lib_name)}/include/$(use.project).h"; then
         CFLAGS="-I${with_$(lib_name)}/include ${CFLAGS}"
         LDFLAGS="-L${with_$(lib_name)}/lib ${LDFLAGS}"
     else
-        AC_MSG_ERROR([${with_$(lib_name)}/include/$(dependency.header) not found. Please check $(lib_name) prefix])
+        AC_MSG_ERROR([${with_$(lib_name)}/include/$(use.project).h not found. Please check $(lib_name) prefix])
     fi
 fi
 
-AC_CHECK_LIB($(dependency.name), $(dependency.test),
-    LIBS="-l$(dependency.name) $LIBS",
-    [AC_MSG_ERROR([cannot link with -l$(dependency.name), install $(lib_name).])])
-
-AC_MSG_CHECKING([whether $(lib_name) installation works])
+AC_CHECK_LIB($(use.project), $(use.test),
+    LIBS="-l$(use.project) $LIBS",
+    [AC_MSG_ERROR([cannot link with -l$(use.project), install $(lib_name).])])
 
 .endfor
-
 .for package_dependency
 PKG_CHECK_MODULES([$(package_dependency.name)], [$(package_dependency.pkg_name)])
-.endfor
 
+.endfor
 # Platform specific checks
 $(project.name)_on_mingw32="no"
 $(project.name)_on_android="no"

--- a/build-automake.gsl
+++ b/build-automake.gsl
@@ -80,14 +80,9 @@ src_lib$(project.name)_la_SOURCES = \\
 
 src_lib$(project.name)_la_CPPFLAGS = \\
 .for package_dependency where defined (package_dependency.for_lib)
-.   if last()
-    \${$(package_dependency.name)_CFLAGS}
-.   else
     \${$(package_dependency.name)_CFLAGS} \\
-.   endif
 .endfor
     ${AM_CPPFLAGS}
-
 
 src_lib$(project.name)_la_LDFLAGS = \\
     -version-info @LTVER@ \\

--- a/build-class.gsl
+++ b/build-class.gsl
@@ -12,7 +12,7 @@
 .#      * src/$(class.name).c - source code file for classes
 .#  ===========================================================================
 .#
-.#   Template to resolve xml includes
+.#   Resolve XML includes
 .#
 .template 0
 function resolve_includes ()
@@ -58,8 +58,8 @@ endfunction
 #define __$(PROJECT.NAME)_H_INCLUDED__
 
 //  External dependencies
-.for dependency
-#include <$(dependency.header)>
+.for use where !defined (implied)
+#include <$(use.project).h>
 .endfor
 
 //  $(PROJECT.NAME) version macros for compile-time API detection

--- a/class_projects.gsl
+++ b/class_projects.gsl
@@ -1,0 +1,18 @@
+.#  ===========================================================================
+.#  Resolve standard CLASS projects
+.#
+.#  ===========================================================================
+.#
+.macro resolve_dependency (use)
+.   if my.use.project ?= "zyre"
+.       depends_on ("czmq")
+.       my.use.test ?= "zsys_test"
+.   elsif my.use.project ?= "czmq"
+.       depends_on ("zmq")
+.       my.use.test ?= "zctx_test"
+.   elsif my.use.project ?= "zmq"
+.       my.use.test ?= "zmq_init"
+.   else
+.       echo "Unknown or missing 'project' for <use>"
+.   endif
+.endmacro

--- a/project.xml
+++ b/project.xml
@@ -36,13 +36,13 @@
         Current version of your project. 
         This will be used to package your distribution 
     -->
-    <version major="1" minor="0" patch="0" />
+    <version major = "1" minor = "0" patch = "0" />
 
-    <!-- 
-        The dependency are added to your project header file.
-        *** Currently only dynamically linked libaries are supported ***
-    <dependency name="zmq" header="zmq.h" test="zmq_init" />
-    <dependency name="czmq" header="czmq.h" test="zctx_test" />
+    <!--
+        Specify which other projects this depends on; these projects must be
+        known by zproject, and you do not have to specify subdependencies.
+        Known projects are zyre, czmq, and zmq.
+    <use project = "zyre" />
     -->
 
     <!-- 
@@ -93,5 +93,6 @@
     <bin name = "build-vs2012.gsl" />
     <bin name = "build-vs2013.gsl" />
     <bin name = "project.gsl" />
+    <bin name = "class_projects.gsl" />
 
 </project>


### PR DESCRIPTION
I don't like having to expose autoconf semantics in the project model.
(This also applies to package_dependency, which still needs fixing).
The project model should be a clean abstraction. If e.g. Zyre depends
on CZMQ, then it should say just that, no more. It's up to zproject
to do the rest.

Solution: build knowledge of standard projects into zproject, so the
project.xml can say,

```
<use project = "czmq" />
```

And the rest happens automatically.
- known projects are zyre, czmq, zmq
- easy to add more to class_projects.gsl
- resolves further dependencies automagically (zyre->czmq->zmq)
