### PR TITLE
Problem: Does not add $(project.name).h to automake

### DIFF
--- a/build-automake.gsl
+++ b/build-automake.gsl
@@ -53,6 +53,9 @@ lib_LTLIBRARIES += src/lib$(project.name).la
 pkgconfig_DATA = src/lib$(project.name).pc
 
 include_HEADERS = \\
+.if count (class, class.name = project.name) = 0
+    include/$(project.name).h \\
+.endif
 .for header
     include/$(name).h \\
 .endfor


### PR DESCRIPTION
Solution: Add it unless project.name matches a class.name
