### PR TITLE
make _selftest check_PROGRAMS instead of bin_PROGRAMS

### DIFF
--- a/build-automake.gsl
+++ b/build-automake.gsl
@@ -110,7 +110,7 @@ src_lib$(project.name)_la_LDFLAGS += \\
     -avoid-version
 endif
 
-bin_PROGRAMS += src/$(project.name)_selftest
+check_PROGRAMS += src/$(project.name)_selftest
 
 src_$(project.name)_selftest_CPPFLAGS = \\
 .for package_dependency where defined (package_dependency.for_test)


### PR DESCRIPTION
Test programs should presumably not be installed.
