### PR TITLE
Problem: Need to escape end of line '\' in template

### DIFF
--- a/build-autoconf.gsl
+++ b/build-autoconf.gsl
@@ -288,8 +288,8 @@ esac
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS(errno.h arpa/inet.h netinet/tcp.h netinet/in.h stddef.h \
-                 stdlib.h string.h sys/socket.h sys/time.h unistd.h \
+AC_CHECK_HEADERS(errno.h arpa/inet.h netinet/tcp.h netinet/in.h stddef.h \\
+                 stdlib.h string.h sys/socket.h sys/time.h unistd.h \\
                  limits.h ifaddrs.h)
 AC_CHECK_HEADERS([net/if.h net/if_media.h linux/wireless.h], [], [],
 [


### PR DESCRIPTION
Solution: Escape them
