### PR TITLE
Problem: android_build_helper script license is too imposing

### DIFF
--- a/build-qt-android.gsl
+++ b/build-qt-android.gsl
@@ -133,7 +133,7 @@ source ./build.sh
 #   Please read the README.txt file if you like to do permanent changes.    #
 #############################################################################
 #
-# Copyright 2014, Joe Eli McIlvain; All rights reserved.
+# Courtesy of Joe Eli McIlvain; original code at:
 # https://github.com/jemc/android_build_helper
 #   android_build_helper.sh
 #


### PR DESCRIPTION
Solution: Use by "courtesy" instead but keep reference to original source for updates and maintenance
