### PR TITLE
Problem: can't freely specify additional model parameters in project.xml

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -177,7 +177,11 @@ src: src/lib$(project.prefix).la src/$(project.prefix)_selftest
 code:
 .   endif
 .   if defined (model.script)
-\tcd $\(srcdir)/src; gsl -topdir:.. -script:$(script:) -q $(name).xml
+\tcd $\(srcdir)/src; gsl -topdir:.. -script:$(script:) \
+. for model.param
+-$(param.name):$(param.value) \
+. endfor
+-q $(name).xml
 .   else
 \tcd $\(srcdir)/src; gsl -q $(name).xml
 .   endif


### PR DESCRIPTION
Solution: get additional params from nested param elements.

``` xml
<model name = "my_model" script="my_model_generator.gsl">
  <param name="special_param" value="some_value" />
</model>
```

-> `gsl -topdir:.. -script:my_model_generator.gsl -special_param:some_value -q my_model.xml`
