### PR TITLE
Problem: resolve_dependency always warns for custom 'use' in project

### DIFF
--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -27,8 +27,8 @@ function resolve_dependency (use)
         my.use.repository ?= "https://github.com/zeromq/libzmq"
         my.use.test ?= "zmq_init"
     else
-        if (!defined(my.use.repository) | \
-            !defined(my.use.test))
+        if (!defined (my.use.repository) | \
+            !defined (my.use.test))
             echo "Unknown project for <use project = \"$(my.use.project)\"/>"
         endif
     endif


### PR DESCRIPTION
Solution: only warn if the required properties are not defined
Incidental: Use "template 0" in zproject_projects.gsl for easier editing
