### PR TITLE
Problem: truncates example code at first '@' character

### DIFF
--- a/zproject_mkman
+++ b/zproject_mkman
@@ -101,7 +101,7 @@ sub pull {
         while (<SOURCE>) {
             if (/$tag/) {
                 while (<SOURCE>) {
-                    last if /@[a-zA-Z0-9]+/;
+                    last if /\@discuss/ || /\@end/;
                     $_ = "    $_" if $opts eq "code";
                     s/^    // if $opts eq "left";
                     $_ = "    $_" if $opts eq "test";


### PR DESCRIPTION
Solution: correctly end only on @discuss or @end tags.
