### PR TITLE
Problem: commit #edef8e not done fully

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -115,7 +115,7 @@ AC_SUBST(PACKAGE_VERSION)
 # know exactly what you're doing and have read and understand
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 #
-# lib$(project.name) -version-info
+# lib$(project.prefix) -version-info
 LTVER="2:0:1"
 AC_SUBST(LTVER)
 
@@ -238,7 +238,7 @@ AC_MSG_RESULT([$$(project.name)_build_doc])
 AC_MSG_CHECKING([whether to install manpages])
 AC_MSG_RESULT([$$(project.name)_install_man])
 
-# Set some default features required by lib$(project.name) code.
+# Set some default features required by lib$(project.prefix) code.
 CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
 
 # OS-specific tests
@@ -355,7 +355,7 @@ AC_SUBST([pkgconfigdir])
 
 # Specify output files
 .if (count (class) > 0)
-AC_CONFIG_FILES([Makefile doc/Makefile src/lib$(project.name).pc])
+AC_CONFIG_FILES([Makefile doc/Makefile src/lib$(project.prefix).pc])
 .else
 AC_CONFIG_FILES([Makefile])
 .endif 

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -138,7 +138,7 @@ set ($(project.name)_sources
 )
 source_group ("Source Files" FILES ${$(project.name)_sources})
 add_library($(project.name) SHARED ${$(project.name)_sources})
-set_target_properties($(project.name) PROPERTIES DEFINE_SYMBOL "LIB$(PROJECT.NAME)_EXPORTS")
+set_target_properties($(project.name) PROPERTIES DEFINE_SYMBOL "LIB$(PROJECT.PREFIX)_EXPORTS")
 target_link_libraries($(project.name) ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES})
 
 install(TARGETS $(project.name)
@@ -156,12 +156,12 @@ set(exec_prefix "\\${prefix}")
 set(libdir "\\${prefix}/lib${LIB_SUFFIX}")
 set(includedir "\\${prefix}/include")
 configure_file(
-    ${SOURCE_DIR}/src/lib$(project.name).pc.in
-    ${BINARY_DIR}/lib$(project.name).pc
+    ${SOURCE_DIR}/src/lib$(project.prefix).pc.in
+    ${BINARY_DIR}/lib$(project.prefix).pc
 @ONLY)
 
 install(
-    FILES ${BINARY_DIR}/lib$(project.name).pc
+    FILES ${BINARY_DIR}/lib$(project.prefix).pc
     DESTINATION lib${LIB_SUFFIX}/pkgconfig
 )
 

--- a/zproject_lib.gsl
+++ b/zproject_lib.gsl
@@ -5,8 +5,8 @@
 .#  is licensed under MIT/X11.
 .#
 .if (count (class) > 0)
-.echo "Generating src/lib$(project.name).pc.in..."
-.output "src/lib$(project.name).pc.in"
+.echo "Generating src/lib$(project.prefix).pc.in..."
+.output "src/lib$(project.prefix).pc.in"
 $(project.GENERATED_WARNING_HEADER:)
 
 prefix=@prefix@
@@ -14,7 +14,7 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: lib$(project.name)
+Name: lib$(project.prefix)
 Description: $(project.description:)
 Version: @VERSION@
 

--- a/zproject_mingw32.gsl
+++ b/zproject_mingw32.gsl
@@ -16,7 +16,7 @@ CC=gcc
 PREFIX=c:/mingw/msys/1.0/local
 INCDIR=-I$\(PREFIX)/include -I.
 LIBDIR=-L$\(PREFIX)/lib
-CFLAGS=-Wall -Os -g -DLIB$(PROJECT.NAME)_EXPORTS $\(INCDIR)
+CFLAGS=-Wall -Os -g -DLIB$(PROJECT.PREFIX)_EXPORTS $\(INCDIR)
 
 OBJS =\
 .for class
@@ -26,9 +26,9 @@ OBJS =\
 %.o: ../../src/%.c
 	$\(CC) -c -o $@ $< $\(CFLAGS)
 
-all: lib$(project.name).dll $(project.prefix)_selftest.exe
+all: lib$(project.prefix).dll $(project.prefix)_selftest.exe
 
-lib$(project.name).dll: $\(OBJS)
+lib$(project.prefix).dll: $\(OBJS)
 	$\(CC) -shared -o $@ $\(OBJS) -Wl,--out-implib,$@.a $\(LIBDIR) -lzmq -lws2_32 -liphlpapi -lrpcrt4
 
 # the test functions are not exported into the DLL

--- a/zproject_qt_android.gsl
+++ b/zproject_qt_android.gsl
@@ -54,7 +54,7 @@ mkdir -p "${cache}"
 ##
 # Build $(project.name) from local source
 
-(android_build_verify_so "lib$(project.name).so"\
+(android_build_verify_so "lib$(project.prefix).so"\
 .for use where !defined (use.implied)
  "lib$(use.project).so"\
 .endfor
@@ -78,7 +78,7 @@ mkdir -p "${cache}"
 .for use
 android_build_verify_so "lib$(use.project).so"
 .endfor
-android_build_verify_so "lib$(project.name).so"\
+android_build_verify_so "lib$(project.prefix).so"\
 .for use where !defined (use.implied)
  "lib$(use.project).so"\
 .endfor


### PR DESCRIPTION
Solution: finish this properly so project library is always
lib$(project.prefix) and not lib$(project.name), as the name
can be long and verbose ("malamute" vs "mlm", for example).
