### PR TITLE
Problem: Hard for casual users to add new known projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 
 **<a href="#toc2-46">Sample configuration</a>**
 
-**<a href="#toc2-173">Installation</a>**
-&emsp;<a href="#toc3-182">autotools</a>
+**<a href="#toc2-171">Installation</a>**
+&emsp;<a href="#toc3-180">autotools</a>
 
-**<a href="#toc2-192">Generate build environment in your project</a>**
+**<a href="#toc2-190">Generate build environment in your project</a>**
 
-**<a href="#toc2-199">Ownership and License</a>**
+**<a href="#toc2-197">Ownership and License</a>**
 
-**<a href="#toc2-208">Removal</a>**
-&emsp;<a href="#toc3-211">autotools</a>
-&emsp;<a href="#toc3-216">Hints to Contributors</a>
-&emsp;<a href="#toc3-223">This Document</a>
+**<a href="#toc2-206">Removal</a>**
+&emsp;<a href="#toc3-209">autotools</a>
+&emsp;<a href="#toc3-214">Hints to Contributors</a>
+&emsp;<a href="#toc3-221">This Document</a>
 
 <A name="toc2-11" title="Overview" />
 ## Overview
@@ -104,18 +104,14 @@ The following snippet is the `project.xml` from zproject:
     <version major = "1" minor = "0" patch = "0" />
 
     <!--
-        Specify which other projects this depends on; these projects must be
-        known by zproject, and you do not have to specify subdependencies.
-        Known projects are zyre, czmq, and zmq.
+        Specify which other projects this depends on.
+        These projects must be known by zproject, and the list of
+        known projects is maintained in the zproject_known_projects.xml model.
+        You need not specify subdependencies if they are implied.
     <use project = "zyre" min_major= "1" min_minor = "1" min_patch = "0" />
     -->
 
-    <!-- 
-        The pkg-config based dependencies are added to _CPPFLAGS and _LDADD
-    <package_dependency name="zmq" pkg_name="libzmq" for_all="1" />
-    -->
-
-    <!-- Header Files 
+    <!-- Header Files
          name := The name the header file to include without file ending
     <header name = "myproject_prelude" />
     -->
@@ -164,12 +160,14 @@ The following snippet is the `project.xml` from zproject:
     -->
     <bin name = "zproject.gsl" />
     <bin name = "zproject_projects.gsl" />
+    <bin name = "zproject_known_projects.xml" />
     <bin name = "zproject_class_api.gsl" />
     <bin name = "zproject_mkman" />
     
     <bin name = "zproject_android.gsl" />
     <bin name = "zproject_autoconf.gsl" />
     <bin name = "zproject_automake.gsl" />
+    <bin name = "zproject_bindings_qml.gsl" />
     <bin name = "zproject_ci.gsl" />
     <bin name = "zproject_class.gsl" />
     <bin name = "zproject_cmake.gsl" />
@@ -185,7 +183,7 @@ The following snippet is the `project.xml` from zproject:
     <bin name = "zproject_vs2013.gsl" />
 </project>
 
-<A name="toc2-173" title="Installation" />
+<A name="toc2-171" title="Installation" />
 ## Installation
 
 Before you start you'll need to install the code generator GSL (https://github.com/imatix/gsl) on your system. Then execute the generate.sh script to generate the build environment files for zproject.
@@ -194,7 +192,7 @@ Before you start you'll need to install the code generator GSL (https://github.c
 
 After that proceed with your favorite build environment. (Currently only autotools!)
 
-<A name="toc3-182" title="autotools" />
+<A name="toc3-180" title="autotools" />
 ### autotools
 
 The following will install the `zproject-*.gsl` files to `/usr/local/bin` where gsl will find them if you use zproject in your project.
@@ -204,14 +202,14 @@ The following will install the `zproject-*.gsl` files to `/usr/local/bin` where 
     make
     make install
 
-<A name="toc2-192" title="Generate build environment in your project" />
+<A name="toc2-190" title="Generate build environment in your project" />
 ## Generate build environment in your project
 
 Copy the `project.xml` and `generate.sh` to your project or an empty directory and adjust the values accordingly.
 
 Run `./generate.sh`
 
-<A name="toc2-199" title="Ownership and License" />
+<A name="toc2-197" title="Ownership and License" />
 ## Ownership and License
 
 The contributors are listed in AUTHORS. This project uses the MPL v2 license, see LICENSE.
@@ -220,22 +218,22 @@ zproject uses the [C4.1 (Collective Code Construction Contract)](http://rfc.zero
 
 To report an issue, use the [zproject issue tracker](https://github.com/zeromq/zproject/issues) at github.com.
 
-<A name="toc2-208" title="Removal" />
+<A name="toc2-206" title="Removal" />
 ## Removal
 
-<A name="toc3-211" title="autotools" />
+<A name="toc3-209" title="autotools" />
 ### autotools
 
     make uninstall
 
-<A name="toc3-216" title="Hints to Contributors" />
+<A name="toc3-214" title="Hints to Contributors" />
 ### Hints to Contributors
 
 Before you commit code please make sure that the project model hides all details of backend scripts.
 
 For example don't make a user enter a header file because autoconf needs it to do AC_CHECK_LIB.
 
-<A name="toc3-223" title="This Document" />
+<A name="toc3-221" title="This Document" />
 ### This Document
 
 This document is originally at README.txt and is built using [gitdown](http://github.com/imatix/gitdown).

--- a/project.xml
+++ b/project.xml
@@ -39,18 +39,14 @@
     <version major = "1" minor = "0" patch = "0" />
 
     <!--
-        Specify which other projects this depends on; these projects must be
-        known by zproject, and you do not have to specify subdependencies.
-        Known projects are zyre, czmq, and zmq.
+        Specify which other projects this depends on.
+        These projects must be known by zproject, and the list of
+        known projects is maintained in the zproject_known_projects.xml model.
+        You need not specify subdependencies if they are implied.
     <use project = "zyre" min_major= "1" min_minor = "1" min_patch = "0" />
     -->
 
-    <!-- 
-        The pkg-config based dependencies are added to _CPPFLAGS and _LDADD
-    <package_dependency name="zmq" pkg_name="libzmq" for_all="1" />
-    -->
-
-    <!-- Header Files 
+    <!-- Header Files
          name := The name the header file to include without file ending
     <header name = "myproject_prelude" />
     -->
@@ -99,6 +95,7 @@
     -->
     <bin name = "zproject.gsl" />
     <bin name = "zproject_projects.gsl" />
+    <bin name = "zproject_known_projects.xml" />
     <bin name = "zproject_class_api.gsl" />
     <bin name = "zproject_mkman" />
     

--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -150,35 +150,33 @@ PREVIOUS_CFLAGS="${CFLAGS}"
 PREVIOUS_LIBS="${LIBS}"
 
 .for use
-.lib_name = "lib$(use.project)"
-.min_version = "$(min_major?'0').$(min_minor?'0').$(min_patch?'0')"
 
 was_$(use.project)_check_lib_detected=no
 
-.  if (min_version <> '0.0.0')
-PKG_CHECK_MODULES([$(use.project)], [$(lib_name) >= $(min_version)],,
-    [AC_MSG_ERROR([Cannot find required package for $(lib_name).  Note, pkg-config is required due to specified version >= $(min_version)])
+.  if (use.min_version <> '0.0.0')
+PKG_CHECK_MODULES([$(use.project)], [lib$(use.prefix) >= $(use.min_version)],,
+    [AC_MSG_ERROR([Cannot find required package for lib$(use.prefix). Note, pkg-config is required due to specified version >= $(use.min_version)])
   ])
 .  else
-PKG_CHECK_MODULES([$(use.project)], [$(lib_name)],,
+PKG_CHECK_MODULES([$(use.project)], [lib$(use.prefix)],,
     [
-        AC_ARG_WITH([$(lib_name)],
+        AC_ARG_WITH([lib$(use.prefix)],
             [
-                AS_HELP_STRING([--with-$(lib_name)],
-                [Specify $(lib_name) prefix])
+                AS_HELP_STRING([--with-lib$(use.prefix)],
+                [Specify lib$(use.prefix) prefix])
             ],
-            [search_$(lib_name)="yes"],
+            [search_lib$(use.prefix)="yes"],
             [])
 
         $(use.project)_synthetic_cflags=""
-        $(use.project)_synthetic_libs="-l$(use.project)"
+        $(use.project)_synthetic_libs="-l$(use.prefix)"
 
-        if test "x$search_$(lib_name)" = "xyes"; then
-            if test -r "${with_$(lib_name)}/include/$(use.project).h"; then
-                $(use.project)_synthetic_cflags="-I${with_$(lib_name)}/include"
-                $(use.project)_synthetic_libs="-L${with_$(lib_name)}/lib -l$(use.project)"
+        if test "x$search_lib$(use.prefix)" = "xyes"; then
+            if test -r "${with_lib$(use.prefix)}/include/$(use.project).h"; then
+                $(use.project)_synthetic_cflags="-I${with_lib$(use.prefix)}/include"
+                $(use.project)_synthetic_libs="-L${with_lib$(use.prefix)}/lib -l$(use.prefix)"
             else
-                AC_MSG_ERROR([${with_$(lib_name)}/include/$(use.project).h not found. Please check $(lib_name) prefix])
+                AC_MSG_ERROR([${with_lib$(use.prefix)}/include/$(use.project).h not found. Please check lib$(use.prefix) prefix])
             fi
         fi
 
@@ -192,7 +190,7 @@ PKG_CHECK_MODULES([$(use.project)], [$(lib_name)],,
                 AC_SUBST([$(use.project)_LIBS],[${$(use.project)_synthetic_libs}])
                 was_$(use.project)_check_lib_detected=yes
             ],
-            [AC_MSG_ERROR([cannot link with -l$(use.project), install $(lib_name).])])
+            [AC_MSG_ERROR([cannot link with -l$(use.prefix), install lib$(use.prefix).])])
     ])
 .  endif
 

--- a/zproject_bindings_qml.gsl
+++ b/zproject_bindings_qml.gsl
@@ -333,7 +333,7 @@ android {
   QMAKE_INCDIR += $$VENDOR_PREFIX/include
 }
 
-LIBS += -l$(project.name)
+LIBS += -l$(project.prefix)
 
 HEADERS += \\
   $$SRCDIR/$(project.qml_soname:)_plugin.h \\

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -79,25 +79,11 @@ list(APPEND CMAKE_MODULE_PATH ${SOURCE_DIR})
 .for use
 
 ########################################################################
-# $(.PROJECT) dependency
+# $(USE.PROJECT) dependency
 ########################################################################
-.  if .project ?= "zyre"
-find_package(Zyre REQUIRED)
-include_directories(${ZYRE_INCLUDE_DIRS})
-list(APPEND MORE_LIBRARIES ${ZYRE_LIBRARIES})
-.  elsif .project ?= "czmq"
-find_package(CZMQ REQUIRED)
-include_directories(${CZMQ_INCLUDE_DIRS})
-list(APPEND MORE_LIBRARIES ${CZMQ_LIBRARIES})
-.  elsif .project ?= "zmq"
-find_package(ZeroMQ REQUIRED)
-include_directories(${ZEROMQ_INCLUDE_DIRS})
-list(APPEND MORE_LIBRARIES ${ZEROMQ_LIBRARIES})
-.  else
-find_package($(.Project) REQUIRED)
-include_directories(${$(.PROJECT)_INCLUDE_DIRS})
-list(APPEND MORE_LIBRARIES ${$(.PROJECT)_LIBRARIES})
-.  endif
+find_package($(use.cmake_name:) REQUIRED)
+include_directories(${$(USE.CMAKE_NAME)_INCLUDE_DIRS})
+list(APPEND MORE_LIBRARIES ${$(USE.CMAKE_NAME)_LIBRARIES})
 .endfor
 
 ########################################################################

--- a/zproject_docs.gsl
+++ b/zproject_docs.gsl
@@ -137,7 +137,7 @@ SYNOPSIS
 ----
 #include <$(project.name).h>
 
-cc ['flags'] 'files' -lzmq -l$(project.name) ['libraries']
+cc ['flags'] 'files' -l$(project.prefix) ['libraries']
 ----
 
 

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -1,0 +1,22 @@
+
+<known_projects>
+    
+    <use project = "zmq"
+        repository = "https://github.com/zeromq/libzmq"
+        test = "zmq_init"
+        cmake_name = "ZeroMQ" />
+    
+    <use project = "czmq"
+        repository = "https://github.com/zeromq/czmq"
+        test = "zctx_test"
+        cmake_name = "CZMQ">
+        <use project = "zmq" min_major = "2" min_minor = "2" />
+    </use>
+    
+    <use project = "zyre"
+        repository = "https://github.com/zeromq/zyre"
+        test = "zyre_test">
+        <use project = "czmq" min_major = "3" />
+    </use>
+    
+</known_projects>

--- a/zproject_lib.gsl
+++ b/zproject_lib.gsl
@@ -18,25 +18,21 @@ Name: lib$(project.prefix)
 Description: $(project.description:)
 Version: @VERSION@
 
-.if (count (use) > 0)
+.if count (use)
 Requires:\
-.for use
-.min_version = "$(min_major?'0').$(min_minor?'0').$(min_patch?'0')"
-.project_require = ""
-.  if (min_version <> '0.0.0')
-.project_require = "lib$(use.project) >= $(min_version)"
-.  else
-.project_require = "lib$(use.project)"
-.  endif
-.  if !last()
-$(project_require) \
-.  else
-$(project_require)
-.  endif
-.endfor
+.   for use
+lib$(use.prefix)\
+.       if (use.min_version <> '0.0.0')
+ >= $(use.min_version)\
+.       endif
+.       if !last()
+ \
+.       endif
+.   endfor
+
 .endif
 
-Libs: -L${libdir} -l$(project.name)
+Libs: -L${libdir} -l$(project.prefix)
 Cflags: -I${includedir}
 
 $(project.GENERATED_WARNING_HEADER:)

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -4,41 +4,50 @@
 #
 #  ===========================================================================
 
-function depends_on (dependent, name, major, minor, patch)
-    if count (project.use, use.project = my.name) = 0
-        new use to project as child before my.dependent
-            child.project = my.name
-            child.min_major = my.major
-            child.min_minor = my.minor
-            child.min_patch = my.patch
-            child.implied = 1
-            return child
-        endnew
+function resolve_project_dependency (use)
+    my.known_projects = XML.load_file ("zproject_known_projects.xml")
+    
+    # Use known values to fill in gaps if it is a known project
+    for my.known_projects.use as known where known.project = my.use.project
+        my.use.repository ?= known.repository?
+        my.use.test       ?= known.test?
+        my.use.cmake_name ?= known.cmake_name?
+        
+        # Copy known implied dependencies into this dependency
+        for known.use as implied_use
+            if !count (my.use.use, use.project = implied_use.project)
+                move implied_use to my.use as use
+            endif
+        endfor
+    endfor
+    
+    # Use reasonable fallback values to fill in any remaining gaps
+    my.use.prefix ?= my.use.project
+    my.use.cmake_name ?= "$(my.use.project:Pascal)"
+    
+    # For values with no reasonable fallback, print error
+    if  !defined (my.use.repository) | \
+        !defined (my.use.test)
+        echo "Unknown project for <use project = \"$(my.use.project)\"/>.  " +\
+            "Please add $(my.use.project) to zproject_known_projects.xml " +\
+            "or add the missing properties to the <use> model locally."
     endif
-endfunction
-
-function resolve_dependency (use)
-    if my.use.project ?= "zyre"
-        my.use.repository ?= "https://github.com/zeromq/zyre"
-        my.use.test ?= "zyre_test"
-        resolve_dependency (depends_on (my.use, "czmq", 3, 0, 0))
-    elsif my.use.project ?= "czmq"
-        my.use.repository ?= "https://github.com/zeromq/czmq"
-        my.use.test ?= "zctx_test"
-        resolve_dependency (depends_on (my.use, "zmq", 2, 2, 0))
-    elsif my.use.project ?= "zmq"
-        my.use.repository ?= "https://github.com/zeromq/libzmq"
-        my.use.test ?= "zmq_init"
-    else
-        if (!defined (my.use.repository) | \
-            !defined (my.use.test))
-            echo "Unknown project for <use project = \"$(my.use.project)\"/>"
+    
+    # Calculate all non-model values from model values
+    my.use.min_version = "$(min_major?'0').$(min_minor?'0').$(min_patch?'0')"
+    
+    # Copy all dependencies implied by this one into the project
+    for my.use.use as implied_use
+        if !count (project.use, use.project = implied_use.project)
+            move implied_use before my.use as use
+            implied_use.implied = "1"
+            resolve_project_dependency (implied_use)
         endif
-    endif
+    endfor
 endfunction
 
 for use
-    resolve_dependency (use)
+    resolve_project_dependency (use)
 endfor
 
 .endtemplate

--- a/zproject_qt_android.gsl
+++ b/zproject_qt_android.gsl
@@ -35,7 +35,7 @@ mkdir -p "${cache}"
 ##
 # Make sure $(use.project) is built and copy the prefix
 
-(android_build_verify_so "lib$(use.project).so" &> /dev/null) || {
+(android_build_verify_so "lib$(use.prefix).so" &> /dev/null) || {
     # Use a default value assuming the $(use.project) project sits alongside this one
     test -z "$$(USE.PROJECT)_ROOT" && $(USE.PROJECT)_ROOT="\$(cd ../../../$(use.project) && pwd)"
     
@@ -56,7 +56,7 @@ mkdir -p "${cache}"
 
 (android_build_verify_so "lib$(project.prefix).so"\
 .for use where !defined (use.implied)
- "lib$(use.project).so"\
+ "lib$(use.prefix).so"\
 .endfor
  &> /dev/null) || {
     rm -rf "${cache}/$(project.name)"
@@ -76,11 +76,11 @@ mkdir -p "${cache}"
 # Verify shared libraries in prefix
 
 .for use
-android_build_verify_so "lib$(use.project).so"
+android_build_verify_so "lib$(use.prefix).so"
 .endfor
 android_build_verify_so "lib$(project.prefix).so"\
 .for use where !defined (use.implied)
- "lib$(use.project).so"\
+ "lib$(use.prefix).so"\
 .endfor
 
 


### PR DESCRIPTION
Solution: Add zproject_known_projects.xml to model known projects
Side-effect: Gets rid of all project-specific gsl code
Resolves #58
