### PR TITLE
Problem: In zproject_class.gsl error variable is not reset

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -352,6 +352,7 @@ $(class.c_name)_test (bool verbose)
     # Open the header_file for reading
     handle = file.open (header_file, "ra")
     current_loc = "prefix"
+    error = # undefined
     HEADER_FILE_PREFIX = "" # All lines preceding the @interface line
     HEADER_FILE_SUFFIX = "" # All lines following the @end line
     


### PR DESCRIPTION
Solution: Reset error to undefined at each loop iteration
