### PR TITLE
Problem: In API models, docs show wrong type string for 'boolean'

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ This would cause the following `@interface` to be generated inside of `include/m
         myclass_destroy (myclass_t **self_p);
 
     //  Return true if the myclass has the given feature.
-    MYPROJECT_EXPORT bool_t *
+    MYPROJECT_EXPORT bool
         myclass_has_feature (myclass_t *self, const char *feature);
 
     //  Put the myclass to sleep for the given number of milliseconds.

--- a/README.txt
+++ b/README.txt
@@ -66,7 +66,7 @@ This would cause the following `@interface` to be generated inside of `include/m
         myclass_destroy (myclass_t **self_p);
 
     //  Return true if the myclass has the given feature.
-    MYPROJECT_EXPORT bool_t *
+    MYPROJECT_EXPORT bool
         myclass_has_feature (myclass_t *self, const char *feature);
 
     //  Put the myclass to sleep for the given number of milliseconds.

--- a/api/myclass.xml
+++ b/api/myclass.xml
@@ -16,7 +16,7 @@
         <method name = "has feature">
             Return true if the myclass has the given feature.
             <argument name = "feature" type = "string" />
-            <return type = "bool" />
+            <return type = "boolean" />
         </method>
         
         <method name = "sleep">


### PR DESCRIPTION
Solution: Make docs show 'boolean', not 'bool'
