### PR TITLE
Problem: Expression "class.description" used when possibly undefined

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -198,7 +198,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .echo "Generating $(header_file)..."
 .   output header_file
 /*  =========================================================================
-    $(class.c_name) - $(class.description)
+    $(class.c_name) - $(string.trim (class.?''):no,left)
 
 .   for project.license
     $(string.trim (license.):block                                         )


### PR DESCRIPTION
Solution: Revert line to what it was before commit 2d1bc2321675
