### PR TITLE
Problem: lack support for zproto state machine animation

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -183,4 +183,8 @@ debug: src/$(project.prefix)_selftest
 \tlibtool --mode=execute gdb -q \\
 \t\t$\(srcdir)/src/$(project.prefix)_selftest
 
+# Run the selftest binary with verbose switch for tracing
+animate: src/$(project.prefix)_selftest
+\tlibtool --mode=execute $\(srcdir)/src/$(project.prefix)_selftest -v
+
 $(project.GENERATED_WARNING_HEADER:)


### PR DESCRIPTION
The zproto server/client state machines provide an animation option
which shows the state transitions. This is helpful for debugging any
errors in the state machines. This is enabled by passing -v to the
selftest (which passes a verbose argument to server/client classes).

Solution: add 'make animate' target that does a 'make check' with
verbose option.
