### PR TITLE
Problem: Can't find .7 man page

### DIFF
--- a/zproject_docs.gsl
+++ b/zproject_docs.gsl
@@ -33,7 +33,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .endfor
 MAN1 =$(man1)
 MAN3 =$(man3)
-MAN7 = $\(srcdir)/$(project.manpage)
+MAN7 = $(project.manpage)
 MAN_DOC = $\(MAN1) $\(MAN3) $\(MAN7)
 
 MAN_TXT = $\(MAN1:%.1=%.txt)


### PR DESCRIPTION
Obnly this one is searched for in srcdir while still being generated
from txt file and thus being in builddir. Removing srcdir reference as
it breaks out of the tree build of czmq.
