### PR TITLE
Problem: No easy way to model string constants in class API model

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -149,6 +149,9 @@ function resolve_c_class (class)
     endfor
     
     for my.class.constant
+        if constant.?type = 'string'
+            constant.value = '"' + constant.value + '"'
+        endif
         constant.description ?= "$(string.trim (constant.?""):left)"
         resolve_c_container (constant)
     endfor


### PR DESCRIPTION
Solution: Automatically add quotes if constant type is a string
