### PR TITLE
Problem: Ruby binding callback functions have poor exception handling

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -316,7 +316,7 @@ $(argument.ruby_name)\
 .endfor
         result = $(project.RubyName:)::FFI.$(class.c_name:)_$(method.c_name:)$(method.ruby_args_pass:)
 .if defined (method->return.ruby_coerce_ret)
-        result = $(method->return.ruby_coerce_ret)
+        result = $(method->return.ruby_coerce_ret:)
 .endif
         result
       end
@@ -333,7 +333,7 @@ $(argument.ruby_name)\
 .endfor
         result = $(project.RubyName:)::FFI.$(class.c_name:)_$(method.c_name:)$(method.ruby_args_pass:)
 .if defined (method->return.ruby_coerce_ret)
-        result = $(method->return.ruby_coerce_ret)
+        result = $(method->return.ruby_coerce_ret:)
 .endif
         result
       end


### PR DESCRIPTION
Solution: Force the user to implement his/her own exception handling
