### PR TITLE
Problem: Ruby bindings cannot identify freshly allocated return values

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -51,7 +51,12 @@ function resolve_ruby_container (container)
                 my.container.ruby_coerce_arg = "$(my.container.ruby_name:).__ptr_give_ref"
             else
                 my.container.ruby_coerce_arg = "$(my.container.ruby_name:).__ptr if $(my.container.ruby_name:)"
-                my.container.ruby_coerce_ret = "$(class.RubyName:).__new $(my.container.ruby_name:), false"
+                my.container.ruby_coerce_ret = "$(class.RubyName:).__new $(my.container.ruby_name:), "
+                if my.container.fresh
+                    my.container.ruby_coerce_ret += "true"
+                else
+                    my.container.ruby_coerce_ret += "false"
+                endif
             endif
         endfor
     endif

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -39,6 +39,8 @@ function resolve_c_container (container)
     my.container.by_reference = conv.number (my.container.by_reference)
     my.container.callback ?= "0"
     my.container.callback = conv.number (my.container.callback)
+    my.container.fresh ?= "0"
+    my.container.fresh = conv.number (my.container.fresh)
     
     my.container.type ?= "nothing"
     if defined (my.container.c_type)


### PR DESCRIPTION
Solution: Recognize the "fresh" property in class API models
