### PR TITLE
Problem: String constants in class API model fail when have comments

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -158,7 +158,7 @@ function resolve_c_class (class)
     endfor
     
     for my.class.constant
-        if constant.?type = 'string'
+        if defined (constant.type) & (constant.type = 'string')
             constant.value = '"' + constant.value + '"'
         endif
         constant.description ?= "$(string.trim (constant.?""):left)"


### PR DESCRIPTION
Solution: Fix incorrect usage of GSL operators
