### PR TITLE
Implement generation of builds for cygwin targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ if (MINGW)
     set(MORE_LIBRARIES -lws2_32 -lrpcrt4 -liphlpapi)
 endif()
 
+# required libraries for cygwin
+if (CYGWIN)
+    set(MORE_LIBRARIES -luuid)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${SOURCE_DIR})
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ LIBS="${PREVIOUS_LIBS}"
 
 # Platform specific checks
 myproject_on_mingw32="no"
+myproject_on_cygwin="no"
 myproject_on_android="no"
 
 # Host specific checks
@@ -169,6 +170,7 @@ case "${host_os}" in
         # Define on Cygwin to enable all library features
         CPPFLAGS="-D_GNU_SOURCE $CPPFLAGS"
         AC_DEFINE(MYPROJECT_HAVE_CYGWIN, 1, [Have Cygwin])
+        myproject_on_cygwin="yes"
         ;;
     *)
         AC_MSG_ERROR([unsupported system: ${host_os}.])
@@ -204,6 +206,7 @@ if test "x$GCC" = "xyes"; then
 fi
 
 AM_CONDITIONAL(ON_MINGW, test "x$myproject_on_mingw32" = "xyes")
+AM_CONDITIONAL(ON_MINGW, test "x$myproject_on_cygwin" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$myproject_on_android" = "xyes")
 AM_CONDITIONAL(INSTALL_MAN, test "x$myproject_install_man" = "xyes")
 AM_CONDITIONAL(BUILD_DOC, test "x$myproject_build_doc" = "xyes")

--- a/project.xml
+++ b/project.xml
@@ -5,6 +5,7 @@
         * autotool
         * cmake
         * mingw32
+        * cygwin
         * vs2008
         * vs2010
         * vs2012
@@ -112,6 +113,7 @@
     <bin name = "zproject_git.gsl" />
     <bin name = "zproject_lib.gsl" />
     <bin name = "zproject_mingw32.gsl" />
+    <bin name = "zproject_cygwin.gsl" />
     <bin name = "zproject_qt_android.gsl" />
     <bin name = "zproject_tools.gsl" />
     <bin name = "zproject_vs2008.gsl" />

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -47,6 +47,7 @@ project.generated_warning_header ?= "\
 .gsl from "zproject_git.gsl"
 .gsl from "zproject_lib.gsl"
 .gsl from "zproject_mingw32.gsl"
+.gsl from "zproject_cygwin.gsl"
 .gsl from "zproject_qt_android.gsl"
 .gsl from "zproject_tools.gsl"
 .gsl from "zproject_vs2008.gsl"

--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -207,6 +207,7 @@ LIBS="${PREVIOUS_LIBS}"
 
 # Platform specific checks
 $(project.name)_on_mingw32="no"
+$(project.name)_on_cygwin="no"
 $(project.name)_on_android="no"
 
 # Host specific checks
@@ -298,6 +299,7 @@ case "${host_os}" in
         # Define on Cygwin to enable all library features
         CPPFLAGS="-D_GNU_SOURCE $CPPFLAGS"
         AC_DEFINE($(PROJECT.NAME)_HAVE_CYGWIN, 1, [Have Cygwin])
+        $(project.name)_on_cygwin="yes"
         ;;
     *)
         AC_MSG_ERROR([unsupported system: ${host_os}.])
@@ -333,6 +335,7 @@ if test "x$GCC" = "xyes"; then
 fi
 
 AM_CONDITIONAL(ON_MINGW, test "x$$(project.name)_on_mingw32" = "xyes")
+AM_CONDITIONAL(ON_MINGW, test "x$$(project.name)_on_cygwin" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$$(project.name)_on_android" = "xyes")
 AM_CONDITIONAL(INSTALL_MAN, test "x$$(project.name)_install_man" = "xyes")
 AM_CONDITIONAL(BUILD_DOC, test "x$$(project.name)_build_doc" = "xyes")

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -106,6 +106,12 @@ src_lib$(project.prefix)_la_LDFLAGS += \\
     -avoid-version
 endif
 
+if ON_CYGWIN
+src_lib$(project.name)_la_LDFLAGS += \\
+    -no-undefined \\
+    -avoid-version
+endif
+
 src_lib$(project.prefix)_la_LIBADD = ${project_libs}
 
 .for project.main

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -74,6 +74,10 @@ if (MINGW)
     set(MORE_LIBRARIES -lws2_32 -lrpcrt4 -liphlpapi)
 endif()
 
+# required libraries for cygwin
+if (CYGWIN)
+    set(MORE_LIBRARIES -luuid)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${SOURCE_DIR})
 .for use

--- a/zproject_cygwin.gsl
+++ b/zproject_cygwin.gsl
@@ -1,0 +1,40 @@
+.#  Generate cygwin makefile for project
+.#
+.#  This is a code generator built using the iMatix GSL code generation
+.#  language. See https://github.com/imatix/gsl for details. This script
+.#  is licensed under MIT/X11.
+.#
+.echo "Generating builds/cygwin/Makefile.cygwin..."
+.if !file.exists ('builds/cygwin')
+.   directory.create('builds/cygwin')
+.endif    
+.output "builds/cygwin/Makefile.cygwin"
+$(project.GENERATED_WARNING_HEADER:)
+
+CC=gcc
+# replace the following with wherever you have installed libzmq
+PREFIX=/usr/local
+INCDIR=-I$\(PREFIX)/include -I.
+LIBDIR=-L$\(PREFIX)/lib
+CFLAGS=-Wall -Os -g -DLIB$(PROJECT.PREFIX)_EXPORTS $\(INCDIR)
+
+OBJS =\
+.for class
+ $(name).o\
+.endfor
+
+%.o: ../../src/%.c
+	$\(CC) -c -o $@ $< $\(CFLAGS)
+
+all: lib$(project.prefix).dll $(project.prefix)_selftest.exe
+
+lib$(project.prefix).dll: $\(OBJS)
+	$\(CC) -shared -o $@ $\(OBJS) -Wl,--out-implib,$@.a $\(LIBDIR) -lzmq -luuid
+
+# the test functions are not exported into the DLL
+$(project.prefix)_selftest.exe: $(project.prefix)_selftest.o $\(OBJS)
+	$\(CC) -o $@ $^ $\(LIBDIR) -lzmq -luuid
+clean:
+	del *.o *.a *.dll *.exe
+
+$(project.GENERATED_WARNING_HEADER:)

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -17,6 +17,7 @@
 *.a
 *.la
 *.pc
+*.dll.a
 
 # Shared objects (inc. Windows DLLs)
 *.dll


### PR DESCRIPTION
Hello again!

As per request, this set of changes should implement the generation of builds for cygwin targets correctly, and should have no impact on other platform targets.
