### PR TITLE
Problem: qt-android builds' caching can make outdated builds

### DIFF
--- a/zproject_bindings_qml.gsl
+++ b/zproject_bindings_qml.gsl
@@ -427,7 +427,7 @@ android {
     error(The $(PROJECT.NAME)_ROOT directory does not exist: $$$(PROJECT.NAME)_ROOT)
   }
   # Build the $(project.name) library for android unless it is already built
-  !system($$$(PROJECT.NAME)_ROOT/builds/qt-android/build.sh) {
+  !system(bash $$$(PROJECT.NAME)_ROOT/builds/qt-android/build.sh) {
     error(Failed to build the $(project.name) C library with $$$(PROJECT.NAME)_ROOT/builds/qt-android/build.sh)
   }
   

--- a/zproject_qt_android.gsl
+++ b/zproject_qt_android.gsl
@@ -29,7 +29,14 @@ android_build_opts
 
 # Use a temporary build directory
 cache="/tmp/android_build/${TOOLCHAIN_NAME}"
+rm -rf "${cache}"
 mkdir -p "${cache}"
+
+# Check for environment variable to clear the prefix and do a clean build
+if [[ $ANDROID_BUILD_CLEAN ]]; then
+    echo "Doing a clean build (removing previous build and depedencies)..."
+    rm -rf "${ANDROID_BUILD_PREFIX}"/*
+fi
 
 .for use where !defined (use.implied)
 ##
@@ -45,7 +52,7 @@ mkdir -p "${cache}"
         exit 1
     fi
     
-    (${$(USE.PROJECT)_ROOT}/builds/qt-android/build.sh) || exit 1
+    (bash ${$(USE.PROJECT)_ROOT}/builds/qt-android/build.sh) || exit 1
     UPSTREAM_PREFIX=${$(USE.PROJECT)_ROOT}/builds/qt-android/prefix/${TOOLCHAIN_NAME}
     cp -r ${UPSTREAM_PREFIX}/* ${ANDROID_BUILD_PREFIX}
 }


### PR DESCRIPTION
Solution: accept ANDROID_BUILD_CLEAN env var to remove cached build prefix