### PR TITLE
Adding 'nolib' option for use tag

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -154,9 +154,15 @@ PREVIOUS_LIBS="${LIBS}"
 was_$(use.project)_check_lib_detected=no
 
 .  if (use.min_version <> '0.0.0')
+.    if defined(use.nolib)
+PKG_CHECK_MODULES([$(use.project)], [$(use.prefix) >= $(use.min_version)],,
+    [AC_MSG_ERROR([Cannot find required package for $(use.prefix). Note, pkg-config is required due to specified version >= $(use.min_version)])
+  ])
+.    else
 PKG_CHECK_MODULES([$(use.project)], [lib$(use.prefix) >= $(use.min_version)],,
     [AC_MSG_ERROR([Cannot find required package for lib$(use.prefix). Note, pkg-config is required due to specified version >= $(use.min_version)])
   ])
+.    endif
 .  else
 PKG_CHECK_MODULES([$(use.project)], [lib$(use.prefix)],,
     [


### PR DESCRIPTION
Problem: autoconf needs to to search external libs like glib-2.0
following format

PKG_CHECK_MODULES([glib], [glib-2.0 >= 0.0.1],, ...

note no 'lib' prefix

With this commit one can do following in project.xml for glib-2.0

<use project = "glib" prefix = "glib-2.0" test = "" repository = ""
min_major= "0" min_minor = "0" min_patch = "1" nolib = "yes" />