### PR TITLE
Problem: autogen.sh: reported exit code wrong

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -43,8 +43,9 @@ if [ $? -ne 0 ]; then
 fi
 
 autoreconf --install --force --verbose -I config
-if [ $? -ne 0 ]; then
-    echo "autogen.sh: error: autoreconf exited with status $?" 1>&2
+status=$?
+if [ $status -ne 0 ]; then
+    echo "autogen.sh: error: autoreconf exited with status $status" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
The second autoreconf step doesn't report back the correct exit code as
the test overrides it.

The output error mentioned error in #138 from the `autogen.sh` script is cause by this part:
```
autoreconf --install --force --verbose -I config
if [ $? -ne 0 ]; then
    echo "autogen.sh: error: autoreconf exited with status $?" 1>&2
    exit 1
fi
```
The `if [` part overrides the `$?` variable and so the echoed message contains always 0, which is misleading.
