### PR TITLE
Problem: CZMQ has special link dependencies for some platforms

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -51,6 +51,9 @@ EXTRA_DIST = \\
     version.sh
 
 include \$(srcdir)/src/Makemodule.am
+.if file.exists ("src/Makemodule-local.am")
+include \$(srcdir)/src/Makemodule-local.am # Optional project-local hook
+.endif
 
 $(project.GENERATED_WARNING_HEADER:)
 .if !file.exists ("src")


### PR DESCRIPTION
Solution: Add an optional project-local automake script which can
perform the necessary checks and changes