### PR TITLE
Problem: When configured with `--disable-shared` executables will not link

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -335,6 +335,7 @@ if test "x$GCC" = "xyes"; then
     CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
 fi
 
+AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$$(project.name)_on_mingw32" = "xyes")
 AM_CONDITIONAL(ON_CYGWIN, test "x$$(project.name)_on_cygwin" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$$(project.name)_on_android" = "xyes")

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -74,6 +74,11 @@ program_libs = \\
     src/$(project.libname).la
 .endif
 
+# Programs need to link the c++ runtime if everything was compiled statically.
+if !ENABLE_SHARED
+program_libs += -lstdc++
+endif
+
 lib_LTLIBRARIES += src/$(project.libname).la
 
 pkgconfig_DATA = src/$(project.libname).pc


### PR DESCRIPTION
Solution: Manually include libstdc++ in the link line if shared libaries are not enabled

re https://github.com/zeromq/czmq/issues/927