### PR TITLE
Problem: Generating classes for the first time with API defined failed.

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -21,8 +21,8 @@
 .if !file.exists ("include")
 .   directory.create ("include")
 .endif
-.if !file.exists ("include/$(project.name).h")
-.echo "Generating include/$(project.name).h..."
+.if !file.exists ("include/$(project.name).h") & count (class, class.name = project.name) = 0
+.echo "Generating project header include/$(project.name).h..."
 .   output "include/$(project.name).h"
 /*  =========================================================================
     $(project.name) - $(project.description?'':)
@@ -253,6 +253,7 @@ $(PROJECT.PREFIX)_EXPORT void
 #endif
 
 #endif
+.close # If there is an API defined, then the file must be written so we can find and rewrite the @interface section
 .endif
 .-
 .-  Build the source file for a class


### PR DESCRIPTION
Solution: Don't write a project header if a class has the same name.
Solution: Force a save of the class header so the @interface rewrite can happen.

This happened to me when creating a single class with API for the first time in a new project.