### PR TITLE
Python binding fixes and cross-project class referencing

### DIFF
--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -15,14 +15,34 @@ if !file.exists ("bindings/python/")
    directory.create("bindings/python/")
 endif
 
-function python_register_type (struct, pointer)
-    if count(project->python_types.type, type.name = my.struct) = 0
-        new project->python_types.type
-            type.name = my.struct
-            type.pointer = my.pointer
+function python_register_import (lib, class)
+    if count (project->python_types.import, import.lib = my.lib) = 0
+        new project->python_types.import
+            import.lib = my.lib
         endnew
     endif
-    return my.pointer # We're usually referring to the pointer, so return that for convenience
+endfunction
+
+function python_register_type (container, struct, pointer)
+    for project.use
+        for use.class where class.name = my.container.type
+            my.externlib = use.project
+            last
+        endfor
+    endfor
+    if defined (my.externlib)
+        python_register_import(my.externlib, my.container.type)
+        my.container.python_type = "$(my.externlib:c).$(my.container.type:c,no)_p"
+        my.container.python_return = "$(my.externlib:c).$(my.container.type:Pascal)(<>)"
+    else
+        if count(project->python_types.type, type.name = my.struct) = 0
+            new project->python_types.type
+                type.name = my.struct
+                type.pointer = my.pointer
+            endnew
+        endif
+        my.container.python_type = my.pointer
+    endif
 endfunction
 
 function resolve_python_container (container)
@@ -54,7 +74,7 @@ function resolve_python_container (container)
     elsif my.container.type = "buffer"
         my.container.python_type = "POINTER(c_byte)"
     elsif my.container.type = "FILE"
-        my.container.python_type = python_register_type("FILE", "FILE_p")
+        python_register_type(my.container, "FILE", "FILE_p")
     elsif my.container.type = "string" | my.container.type = "format"
         if defined (my.container.fresh) & my.container.fresh = 1
             my.container.python_type = "POINTER(c_char)" # No auto-conversion to string please - we need to free the memory.
@@ -66,7 +86,7 @@ function resolve_python_container (container)
     elsif my.container.callback
         my.container.python_type = my.container.type
     else
-        my.container.python_type = python_register_type("$(my.container.type:c,no)_t", "$(my.container.type:c,no)_p")
+        python_register_type(my.container, "$(my.container.type:c,no)_t", "$(my.container.type:c,no)_p")
     endif
 
     if my.container.by_reference
@@ -150,6 +170,7 @@ function python_method_definition(method)
             callargs += ", "
         endif
     endif
+
     for my.method.argument
         if defined (argument.variadic)
             argnames += "*args"
@@ -169,7 +190,7 @@ function python_method_definition(method)
         endif
     endfor
 
-    call = "lib.$(class.name:c)_$(my.method.name:c)($(callargs))"
+    call = "lib.$(class.name:c)_$(my.method.name:c)($(callargs:))"
     if defined (my.method->return.python_return)
         call = string.replace (my.method->return.python_return, "<>|$(call:)")
     endif
@@ -198,6 +219,9 @@ output "bindings/python/$(project.name:c).py"
 >from __future__ import print_function
 >from ctypes import *
 >from ctypes.util import find_library
+for project->python_types.import
+>import $(import.lib)
+endfor
 >
 
 # libc only loaded if we use it

--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -24,6 +24,8 @@ function python_register_import (lib, class)
 endfunction
 
 function python_register_type (container, struct, pointer)
+    my.fresh_bool = my.container.fresh ?? "True" ? "False"
+
     for project.use
         for use.class where class.name = my.container.type
             my.externlib = use.project
@@ -33,7 +35,7 @@ function python_register_type (container, struct, pointer)
     if defined (my.externlib)
         python_register_import(my.externlib, my.container.type)
         my.container.python_type = "$(my.externlib:c).$(my.container.type:c,no)_p"
-        my.container.python_return = "$(my.externlib:c).$(my.container.type:Pascal)(<>)"
+        my.container.python_return = "$(my.externlib:c).$(my.container.type:Pascal)(<>, $(my.fresh_bool:))"
     else
         if count(project->python_types.type, type.name = my.struct) = 0
             new project->python_types.type
@@ -42,6 +44,9 @@ function python_register_type (container, struct, pointer)
             endnew
         endif
         my.container.python_type = my.pointer
+        for project.class where defined (class.api & class.name = my.container.type)
+            my.container.python_return = "$(my.container.type:Pascal)(<>, $(my.fresh_bool:))"
+        endfor
     endif
 endfunction
 
@@ -298,16 +303,19 @@ for class where defined (class.api)
     for constructor as method
 >    def __init__(self, *args):
 >        """$(method.description:no)"""
->        if len(args) == 1 and isinstance(args[0], $(class.name:c)_p):
+>        if len(args) == 2 and isinstance(args[0], $(class.name:c)_p) and isinstance(args[1], bool):
 >            self._as_parameter_ = args[0] # Conversion from raw type to binding
+>            self.allow_destruct = args[1] # This is a 'fresh' value, owned by us
 >        else:
 >            self._as_parameter_ = lib.$(class.name:c)_$(method.name)(*args) # Creation of new raw type
+>            self.allow_destruct = True
 >
     endfor
     for destructor as method
 >    def __del__(self):
 >        """$(method.description:no)"""
->        lib.$(class.name:c)_$(method.name)(byref(self._as_parameter_))
+>        if self.allow_destruct:
+>            lib.$(class.name:c)_$(method.name)(byref(self._as_parameter_))
 >
     endfor
     for method

--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -178,7 +178,7 @@ function python_method_definition(method)
         else
             argnames += "$(argument.name:c)"
             if defined (argument.python_coerce)
-                callargs += string.replace(argument.python_coerce, "<>|$(argument.name:c)")
+                callargs += string.search_replace(argument.python_coerce, "<>", "$(argument.name:c)")
             else
                 callargs += "$(argument.name:c)"
             endif
@@ -192,7 +192,7 @@ function python_method_definition(method)
 
     call = "lib.$(class.name:c)_$(my.method.name:c)($(callargs:))"
     if defined (my.method->return.python_return)
-        call = string.replace (my.method->return.python_return, "<>|$(call:)")
+        call = string.search_replace(my.method->return.python_return, "<>", call)
     endif
 
     if my.method.singleton


### PR DESCRIPTION
Python-only changes, this makes zproject require the latest gsl, due to the slightly crazy string.replace function in gsl.

This also changes the format for the `use` directive - including class elements within that now cause the python bindings only to reference that external projects classes.

Note this change to `use` should probably be made either a requirement for referring to classes, or at least more widely used in other bindings.