### PR TITLE
Fixes for inconsistencies in C class header regeneration and README for installation and use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@
 **<a href="#toc2-58">Sample API model</a>**
 
 **<a href="#toc2-99">Installation</a>**
-&emsp;<a href="#toc3-108">autotools</a>
+&emsp;<a href="#toc3-309">GSL</a>
+&emsp;<a href="#toc3-108">zproject</a>
 
-**<a href="#toc2-118">Generate build environment in your project</a>**
+**<a href="#toc2-118">Setup your project environment</a>**
 
 **<a href="#toc2-125">Ownership and License</a>**
 
@@ -306,28 +307,57 @@ The language bindings are minimal, meant to be wrapped in a handwritten idiomati
 <A name="toc2-99" title="Installation" />
 ## Installation
 
-Before you start you'll need to install the code generator GSL (https://github.com/imatix/gsl) on your system. Then execute the generate.sh script to generate the build environment files for zproject.
+<A name="toc3-309" title="gsl" />
+### GSL
 
-    ./generate.sh
+zproject uses the code generator called GSL to process its inputs and create its outputs. Before you start you'll need to install GSL (https://github.com/imatix/gsl) on your system. 
 
-After that proceed with your favorite build environment. (Currently only autotools!)
+	git clone https://github.com/imatix/gsl.git
+	cd gsl
+	./autogen.sh
+	./configure
+	make
+	make install
 
-<A name="toc3-108" title="autotools" />
-### autotools
+<A name="toc3-108" title="zproject" />
+### zproject
 
-The following will install the `zproject-*.gsl` files to `/usr/local/bin` where gsl will find them if you use zproject in your project.
+You must then install the zproject resources into your system.
 
+The following will install the zproject files to `/usr/local/bin` where gsl will find them.
+
+	git clone https://github.com/zeromq/zproject.git
+	cd zproject
     ./autogen.sh
     ./configure
     make
     make install
 
-<A name="toc2-118" title="Generate build environment in your project" />
-## Generate build environment in your project
+NB: You may need to use the `sudo` command when running `make install` to elevate your privileges, e.g.
+
+	sudo make install
+
+<A name="toc2-118" title="Setup your project environment" />
+## Setup your project environment
 
 Copy the `project.xml` and `generate.sh` to your project or an empty directory and adjust the values accordingly. You'll also need a license file. To get started you can copy `license.xml` from zproject and change the license to whatever you like. The text in the `license.xml` will be placed on every header and source file. Thus make sure not to insert the hole license but a appropriate disclaimer.
 
-Run `./generate.sh`
+	mkdir myproject
+	cd myproject
+	cp ~/zproject/project.xml .
+	cp ~/zproject/license.xml .
+	cp ~/zproject/generate.sh .
+
+Next, edit `project.xml` to your liking, then when you are ready to create/update you project
+
+	./generate.sh
+	./autogen.sh
+	./configure.sh
+	make
+
+To also build the tests (assuming you have added some), use:
+
+	make check
 
 <A name="toc2-125" title="Ownership and License" />
 ## Ownership and License

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -433,6 +433,13 @@ $(c_method_declaration (method):)
 $(c_method_declaration (method):)
 .endfor
 .-
+//  Print properties of object
+$(PROJECT.PREFIX)_EXPORT void
+    $(class.c_name)_print ($(class.c_name)_t *self);
+
+//  Self test of this class
+$(PROJECT.PREFIX)_EXPORT void
+    $(class.c_name)_test (bool verbose);
 .for class.method
 
 //  $(method.description:no,block)


### PR DESCRIPTION
When the C language class header is initially generated, it includes method declarations for {class}_print() and {class}_test.  When the class api (api/{class}.xml} is subsequently created or updated, the method declarations for test and print are erroneously stripped.

README steps for installation of zproject were inaccurate. 
