### PR TITLE
Problem: Class constructor not generating custom arguments in header or ...

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -288,11 +288,10 @@ $(PROJECT.PREFIX)_EXPORT void
 struct _$(class.c_name)_t {
 };
 
-//  --------------------------------------------------------------------------
-//  Create a new $(class.c_name)
+.for class.constructor as method
 
-$(class.c_name)_t *
-$(class.c_name)_new (void)
+//  $(method.description:no,block)
+$(c_method_implementation (method):)
 {
     $(class.c_name)_t *self = ($(class.c_name)_t *) zmalloc (sizeof ($(class.c_name)_t));
     assert (self);
@@ -301,7 +300,7 @@ $(class.c_name)_new (void)
 
     return self;
 }
-
+.endfor
 
 //  --------------------------------------------------------------------------
 //  Destroy the $(class.c_name)

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -228,10 +228,10 @@ for project.class
 endfor
 
 # A function for constructng the string for a method declaration in a C header
-function c_method_declaration (method)
+function c_method_implementation (method)
     my.format_index = -1
     current_argument_index = 0
-    out = "$(PROJECT.PREFIX)_EXPORT $(my.method->return.c_type)"
+    out = "$(my.method->return.c_type)"
     out += "\n    $(class.c_name)_$(my.method.c_name) ("
     if !my.method.singleton
         if defined (my.method.polymorphic)
@@ -266,8 +266,12 @@ function c_method_declaration (method)
     if my.format_index >= 0
         out += " CHECK_PRINTF (" + (my.format_index) + ")"
     endif
-    out += ";"
     return out
+endfunction
+
+# A function for constructng the string for a method declaration in a C header
+function c_method_declaration (method)
+    return "$(PROJECT.PREFIX)_EXPORT " + c_method_implementation(method) + ";"
 endfunction
 
 # A function for constructng the string for a method declaration in a C header


### PR DESCRIPTION
If the class api defined custom constructor arguments, the first pass build of the source file was not generating the correct method declaration.