### PR TITLE
Problem: First-run generated class has inconsistent whitespace

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -262,6 +262,9 @@ $(PROJECT.PREFIX)_EXPORT void
 .if !file.exists (source_file)
 .echo "Generating $(source_file)..."
 .   output source_file
+.if !defined (class.api)
+.   resolve_c_class(class)
+.endif
 /*  =========================================================================
     $(class.c_name) - $(class.?'':)
 
@@ -286,6 +289,7 @@ $(PROJECT.PREFIX)_EXPORT void
 //  Structure of our class
 
 struct _$(class.c_name)_t {
+    //  TODO: Declare properties
 };
 
 .for class.constructor as method
@@ -303,41 +307,43 @@ $(c_method_declaration (method, 1):)
     return self;
 }
 .endfor
+.for class.destructor as method
 
 //  --------------------------------------------------------------------------
-//  Destroy the $(class.c_name)
+//  $(method.description:no,block)
 
-void
-$(class.c_name)_destroy ($(class.c_name)_t **self_p)
+$(c_method_declaration (method, 1):)
 {
     assert (self_p);
     if (*self_p) {
         $(class.c_name)_t *self = *self_p;
 
-        //  Free class properties
+        //  TODO: Free class properties
 
         //  Free object itself
         free (self);
         *self_p = NULL;
     }
 }
+.endfor
 
+.for class.method where !(method.name = "test")
 
 //  --------------------------------------------------------------------------
-//  Print properties of object
+//  $(method.description:no,block)
 
-void
-$(class.c_name)_print ($(class.c_name)_t *self)
+$(c_method_declaration (method, 1):)
 {
     assert (self);
 }
+.endfor
 
+.for class.method where method.name = "test"
 
 //  --------------------------------------------------------------------------
-//  Selftest
+//  $(method.description:no,block)
 
-void
-$(class.c_name)_test (bool verbose)
+$(c_method_declaration (method, 1):)
 {
     printf (" * $(class.c_name): ");
 
@@ -350,6 +356,7 @@ $(class.c_name)_test (bool verbose)
 
     printf ("OK\\n");
 }
+.endfor
 .endif
 .-
 .-  Regenerate the @interface for the class if it has an api model

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -293,7 +293,7 @@ struct _$(class.c_name)_t {
 //  --------------------------------------------------------------------------
 //  $(method.description:no,block)
 
-$(c_method_implementation (method):)
+$(c_method_declaration (method, 1):)
 {
     $(class.c_name)_t *self = ($(class.c_name)_t *) zmalloc (sizeof ($(class.c_name)_t));
     assert (self);

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -229,9 +229,7 @@ endfor
 
 # Construct the string for a method declaration in a C header
 function c_method_declaration (method, implementation_style)
-    echo my.implementation_style
     my.implementation_style ?= 0
-    echo my.implementation_style
     my.format_index = -1
     my.current_argument_index = 0
     out = ""

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -227,26 +227,37 @@ for project.class
     endif
 endfor
 
-# A function for constructng the string for a method declaration in a C header
-function c_method_implementation (method)
+# Construct the string for a method declaration in a C header
+function c_method_declaration (method, implementation_style)
+    echo my.implementation_style
+    my.implementation_style ?= 0
+    echo my.implementation_style
     my.format_index = -1
-    current_argument_index = 0
-    out = "$(my.method->return.c_type)"
-    out += "\n    $(class.c_name)_$(my.method.c_name) ("
+    my.current_argument_index = 0
+    out = ""
+    if !my.implementation_style
+        out += "$(PROJECT.PREFIX)_EXPORT "
+    endif
+    out += "$(my.method->return.c_type)\n"
+    if !my.implementation_style
+        out += "    "
+    endif
+    out += "$(class.c_name)_$(my.method.c_name) ("
     if !my.method.singleton
         if defined (my.method.polymorphic)
             out += "void *self"
         else
             out += "$(class.c_name)_t *self"
         endif
-        current_argument_index += 1
+        my.current_argument_index += 1
         if count (my.method.argument)
             out += ", "
         endif
     endif
     for my.method.argument
         if argument.is_format
-            my.format_index = current_argument_index + 1 # Next argument is the format list
+            # Next argument is the format list
+            my.format_index = my.current_argument_index + 1
         endif
         if defined (argument.variadic)
             out += "..."
@@ -260,21 +271,19 @@ function c_method_implementation (method)
                 out += ", "
             endif
         endif
-        current_argument_index += 1
+        my.current_argument_index += 1
     endfor
     out += ")"
     if my.format_index >= 0
         out += " CHECK_PRINTF (" + (my.format_index) + ")"
     endif
+    if !my.implementation_style
+        out += ";"
+    endif
     return out
 endfunction
 
-# A function for constructng the string for a method declaration in a C header
-function c_method_declaration (method)
-    return "$(PROJECT.PREFIX)_EXPORT " + c_method_implementation(method) + ";"
-endfunction
-
-# A function for constructng the string for a method declaration in a C header
+# Construct the string for a callback typedef in a C header
 function c_callback_typedef (method)
     out = "typedef $(my.method->return.c_type) "
     out += "($(class.c_name)_$(my.method.c_name)) ("


### PR DESCRIPTION
Solution: Use c_method_declaration to generate both header and implementation signature, with a parameter to choose which style