### PR TITLE
Problem: use of invalid "lib$(project.name)" construction

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -121,7 +121,7 @@ src_$(project.libname)_la_LDFLAGS += \\
 endif
 
 if ON_CYGWIN
-src_lib$(project.name)_la_LDFLAGS += \\
+src_$(project.libname)_la_LDFLAGS += \\
     -no-undefined \\
     -avoid-version
 endif


### PR DESCRIPTION
We moved to calculating project.libname some time ago, to allow
library name to be based off project prefix (e.g. mlm) instead of
full project name (czmq, zyre).

Solution: use $(project.libname) consistently.