### PR TITLE
Fix include guards.

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -33,8 +33,8 @@
     =========================================================================
 */
 
-#ifndef __$(PROJECT.NAME)_H_INCLUDED__
-#define __$(PROJECT.NAME)_H_INCLUDED__
+#ifndef $(PROJECT.NAME)_H_INCLUDED
+#define $(PROJECT.NAME)_H_INCLUDED
 
 //  Include the project library file
 #include "$(project.prefix)_library.h"
@@ -55,8 +55,8 @@ $(project.GENERATED_WARNING_HEADER:)
     =========================================================================
 */
 
-#ifndef __$(project.prefix)_library_H_INCLUDED__
-#define __$(project.prefix)_library_H_INCLUDED__
+#ifndef $(project.prefix)_library_H_INCLUDED
+#define $(project.prefix)_library_H_INCLUDED
 
 //  Set up environment for the application
 .if file.exists ("include/$(project.prelude)")
@@ -173,8 +173,8 @@ $(project.GENERATED_WARNING_HEADER:)
     =========================================================================
 */
 
-#ifndef __$(PROJECT.PREFIX)_CLASSES_H_INCLUDED__
-#define __$(PROJECT.PREFIX)_CLASSES_H_INCLUDED__
+#ifndef $(PROJECT.PREFIX)_CLASSES_H_INCLUDED
+#define $(PROJECT.PREFIX)_CLASSES_H_INCLUDED
 
 //  External API
 #include "../include/$(project.name).h"
@@ -214,8 +214,8 @@ $(project.GENERATED_WARNING_HEADER:)
     =========================================================================
 */
 
-#ifndef __$(CLASS.C_NAME)_H_INCLUDED__
-#define __$(CLASS.C_NAME)_H_INCLUDED__
+#ifndef $(CLASS.C_NAME)_H_INCLUDED
+#define $(CLASS.C_NAME)_H_INCLUDED
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The generation of include guards did not fit to [the expected naming convention of the C++ language standard](https://www.securecoding.cert.org/confluence/display/cplusplus/DCL32-CPP.+Do+not+declare+or+define+a+reserved+identifier#DCL32-CPP.Donotdeclareordefineareservedidentifier-NoncompliantCodeExample%28HeaderGuard%29 "Do not use identifiers that are reserved for the compiler implementation.").

This implementation detail can be fixed by deletion of [a few underscores](http://stackoverflow.com/questions/228783/what-are-the-rules-about-using-an-underscore-in-a-c-identifier#answer-228797 "What are the rules about using an underscore in a C++ identifier?").