### PR TITLE
Problem: Documentation for print method sounds odd.

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -161,7 +161,7 @@ function resolve_c_class (class)
     if !count (my.class.method, method.name = "print")
         new method to my.class after my.class->destructor
             method.name = "print"
-            method.description = "Print properties of the $(my.class.c_name)."
+            method.description = "Print properties of the $(my.class.name:) object."
         endnew
     endif
 


### PR DESCRIPTION
Solution: clarify the subject of the sentence with the word 'object'.

Rationalle: In Zyre, this said "Print properties of the zyre", which
doesn't scan. "Print properties of the zyre object" works.