### PR TITLE
Complete quoting for parameters of some CMake commands.

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -16,8 +16,8 @@ project($(project.name))
 enable_language(C)
 enable_testing()
 
-set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 ########################################################################
 # determine version
@@ -50,7 +50,7 @@ if (NOT HAVE_NET_IF_H)
     CHECK_INCLUDE_FILE("net/if.h" HAVE_NET_IF_H)
 endif()
 
-file(WRITE ${BINARY_DIR}/platform.h.in "
+file(WRITE "${BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -58,13 +58,13 @@ file(WRITE ${BINARY_DIR}/platform.h.in "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file(${BINARY_DIR}/platform.h.in ${BINARY_DIR}/platform.h)
+configure_file("${BINARY_DIR}/platform.h.in" "${BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
 if (MSVC)
     enable_language(CXX)
-    file(GLOB sources ${SOURCE_DIR}/src/*.c)
+    file(GLOB sources "${SOURCE_DIR}/src/*.c")
     set_source_files_properties(${sources} PROPERTIES LANGUAGE CXX)
     set(MORE_LIBRARIES ws2_32 Rpcrt4 Iphlpapi)
 endif()
@@ -79,7 +79,7 @@ if (CYGWIN)
     set(MORE_LIBRARIES -luuid)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH ${SOURCE_DIR})
+list(APPEND CMAKE_MODULE_PATH "${SOURCE_DIR}")
 .for use
 
 ########################################################################
@@ -122,8 +122,7 @@ install(FILES ${$(project.name)_headers} DESTINATION include)
 ########################################################################
 # library
 ########################################################################
-include_directories(${BINARY_DIR})
-include_directories(${SOURCE_DIR}/include)
+include_directories("${BINARY_DIR}" "${SOURCE_DIR}/include")
 set ($(project.name)_sources
 .for class
     src/$(name:c).c
@@ -135,8 +134,8 @@ set_target_properties($(project.name) PROPERTIES DEFINE_SYMBOL "$(PROJECT.LIBNAM
 target_link_libraries($(project.name) ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES})
 
 install(TARGETS $(project.name)
-    LIBRARY DESTINATION lib${LIB_SUFFIX} # .so file
-    ARCHIVE DESTINATION lib${LIB_SUFFIX} # .lib file
+    LIBRARY DESTINATION "lib${LIB_SUFFIX}" # .so file
+    ARCHIVE DESTINATION "lib${LIB_SUFFIX}" # .lib file
     RUNTIME DESTINATION bin              # .dll file
 )
 
@@ -149,19 +148,19 @@ set(exec_prefix "\\${prefix}")
 set(libdir "\\${prefix}/lib${LIB_SUFFIX}")
 set(includedir "\\${prefix}/include")
 configure_file(
-    ${SOURCE_DIR}/src/$(project.libname).pc.in
-    ${BINARY_DIR}/$(project.libname).pc
+    "${SOURCE_DIR}/src/$(project.libname).pc.in"
+    "${BINARY_DIR}/$(project.libname).pc"
 @ONLY)
 
 install(
-    FILES ${BINARY_DIR}/$(project.libname).pc
-    DESTINATION lib${LIB_SUFFIX}/pkgconfig
+    FILES "${BINARY_DIR}/$(project.libname).pc"
+    DESTINATION "lib${LIB_SUFFIX}/pkgconfig"
 )
 
 ########################################################################
 # tests
 ########################################################################
-add_executable($(project.prefix)_selftest ${SOURCE_DIR}/src/$(project.prefix)_selftest.c)
+add_executable($(project.prefix)_selftest "${SOURCE_DIR}/src/$(project.prefix)_selftest.c")
 target_link_libraries($(project.prefix)_selftest $(project.name) ${ZEROMQ_LIBRARIES})
 add_test($(project.prefix)_selftest $(project.prefix)_selftest)
 


### PR DESCRIPTION
[A wiki article pointed out](http://cmake.org/Wiki/CMake/Language_Syntax#CMake_splits_arguments_unless_you_use_quotation_marks_or_escapes. "CMake splits arguments unless you use quotation marks or escapes.") that whitespace will only be preserved for parameters in CMake commands if passed strings will be appropriately quoted or escaped.

Quoting can be added so that more places should also handle file names correctly which contain semicolons eventually.