### PR TITLE
Use BUILD_SHARED_LIBS to specify the library type.

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -129,7 +129,10 @@ set ($(project.name)_sources
 .endfor
 )
 source_group ("Source Files" FILES ${$(project.name)_sources})
-add_library($(project.name) SHARED ${$(project.name)_sources})
+if (NOT DEFINED BUILD_SHARED_LIBS)
+    SET(BUILD_SHARED_LIBS ON)
+endif()
+add_library($(project.name) ${$(project.name)_sources})
 set_target_properties($(project.name) PROPERTIES DEFINE_SYMBOL "$(PROJECT.LIBNAME)_EXPORTS")
 target_link_libraries($(project.name) ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES})
 


### PR DESCRIPTION
This is useful if the project is integrated in another CMake project
using add_subdirectory().  The libary type (STATIC/SHARED) can be
controlled from the master CMakeFile or from the command line
(-DBUILD_SHARED_LIBS).

This commit removes the explicit 'SHARED' type parameter.  If no type is
given explicitly the type is STATIC or SHARED based on whether the
current value of the variable BUILD_SHARED_LIBS is ON. [1]

[1] http://www.cmake.org/cmake/help/v3.0/command/add_library.html

If BUILD_SHARED_LIBS is not specified shared library is build by default.