### PR TITLE
Problem: Python bindings unable to find libc.

### DIFF
--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -243,7 +243,7 @@ endfor
 # libc only loaded if we use it
 if defined (project->python_types.uses_fresh_string)
 ># load libc to access free, etc.
->libcpath = find_library("libc")
+>libcpath = find_library("c")
 >if not libcpath:
 >    raise ImportError("Unable to find libc")
 >libc = cdll.LoadLibrary(libcpath)


### PR DESCRIPTION
Solution: Use the correct search term (you're not meant to include the
lib prefix when using find_library)