### PR TITLE
Problem: EXTRA_DIST does not use 'src/' for extras

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -48,8 +48,8 @@ noinst_LTLIBRARIES =
 TESTS =
 
 EXTRA_DIST = \\
-.for project.extra
-    $(extra.name) \\
+.for extra
+    src/$(extra.name) \\
 .endfor
     version.sh
 


### PR DESCRIPTION
Whereas this is done everywhere else. Result is that 'make dist'
fails.

Solution: use /src for these paths.