### PR TITLE
Check for libtoolize instead of libtool

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -18,7 +18,7 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #   Script to generate all required files from fresh git checkout.
 
-command -v libtool >/dev/null 2>&1
+command -v libtoolize >/dev/null 2>&1
 if  [ $? -ne 0 ]; then
     echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
     exit 1


### PR DESCRIPTION
zproject_autoconf.gsl has a check for the libtool binary as a mean to
check if libtool is available. But distributions like Debian and
Ubuntu are splitting the libtool package, and the libtool binary is now
in a separate package. What autoconf actually need is not the libtool
binary, but libtoolize and other macro files. So check for libtoolize
instead.

See package content for Debian, Ubuntu and Fedora:
https://packages.debian.org/jessie/amd64/libtool/filelist
http://packages.ubuntu.com/utopic/all/libtool/filelist
https://apps.fedoraproject.org/packages/libtool/contents/

As you can see, Ubuntu and Debian no longer ship the libtool binary inside the libtool package. Fedora still does. All of them, however, ship the libtoolize binary and the macro files, which is what autoconf actually needs to run.

New standalone libtool package:
https://packages.debian.org/jessie/amd64/libtool-bin/filelist
http://packages.ubuntu.com/utopic/all/libtool-bin/filelist