### PR TITLE
Fix checking for libtool on OSX

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -18,10 +18,14 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #   Script to generate all required files from fresh git checkout.
 
+# Debian and Ubuntu do not shipt libtool anymore, but OSX does not ship libtoolize.
 command -v libtoolize >/dev/null 2>&1
 if  [ $? -ne 0 ]; then
-    echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
-    exit 1
+    command -v libtool >/dev/null 2>&1
+    if  [ $? -ne 0 ]; then
+        echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
+        exit 1
+    fi
 fi
 
 command -v autoreconf >/dev/null 2>&1


### PR DESCRIPTION
Commit 6a5bafe1 changed the autogen.sh check from libtool to libtoolize
to accomodate changes in Debian and Ubuntu. But OSX does the opposite,
so we have to check for libtool. To accomodate both, check first for
libtoolize and then for libtool, and fail only if neither can be found.