### PR TITLE
Autoconf and CMake project-local hooks

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -137,6 +137,10 @@ AC_PROG_SED
 AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
+.if file.exists ("acinclude.m4")
+AX_PROJECT_LOCAL_HOOK # Optional project-local hook (acinclude.m4)
+.endif
+
 # Code coverage
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting.])],

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -141,6 +141,10 @@ install(TARGETS $(project.name)
     ARCHIVE DESTINATION "lib${LIB_SUFFIX}" # .lib file
     RUNTIME DESTINATION bin              # .dll file
 )
+.if file.exists ("src/CMakeLists-local.txt")
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/src/CMakeLists-local.txt) # Optional project-local hook
+.endif
 
 ########################################################################
 # pkgconfig


### PR DESCRIPTION
Add project-local hooks for CMake and autoconf, following the model already set by the automake project-local hooks.

Will be used to fix issue #199.