### PR TITLE
Avoid whitespace change without local hooks

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -139,8 +139,8 @@ PKG_PROG_PKG_CONFIG
 
 .if file.exists ("acinclude.m4")
 AX_PROJECT_LOCAL_HOOK # Optional project-local hook (acinclude.m4)
-.endif
 
+.endif
 # Code coverage
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting.])],


### PR DESCRIPTION
Sorry, I noticed a whitespace discrepancy a few seconds too late.

This commit will make sure that after ./generate.sh is run, if a project does not define local hooks then there is absolutely no change. Otherwise, an empty new line would be added to configure.ac