### PR TITLE
Problem: external Ruby Libs had to call #__ptr to get the underlying pointer

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -274,6 +274,8 @@ module $(project.RubyName:)
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr


### PR DESCRIPTION
External Libs had to call #__ptr where a FFI function is expecting a pointer, #to_ptr is the way to tell FFI this Object is convertible to a FFI pointer