### PR TITLE
Problem: Python bindings allowed generation of reserved words as meth…

### DIFF
--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -113,7 +113,7 @@ endfunction
 
 function resolve_python_method (method)
     my.method.python_name = "$(my.method.name:c)"
-    if my.method.python_name = 'is' # matches keyword
+    if regexp.match ("^(is|from)$", my.method.python_name) # matches keyword
         my.method.python_name += "_"
     endif
     for my.method.argument where !defined (argument.variadic)


### PR DESCRIPTION
…od names.

Solution: Add regex to match known keywords and decorate with _ suffix