### PR TITLE
Enable container-based build

### DIFF
--- a/zproject_ci.gsl
+++ b/zproject_ci.gsl
@@ -30,6 +30,8 @@ script: ./ci_build.sh
 .output "ci_build.sh"
 #!/usr/bin/env bash
 
+set -x
+
 if [ $BUILD_TYPE == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp

--- a/zproject_ci.gsl
+++ b/zproject_ci.gsl
@@ -14,6 +14,8 @@ os:
 - linux
 - osx
 
+sudo: false
+
 env:
 - BUILD_TYPE=default
 - BUILD_TYPE=qt-android
@@ -29,15 +31,25 @@ script: ./ci_build.sh
 #!/usr/bin/env bash
 
 if [ $BUILD_TYPE == "default" ]; then
+    mkdir tmp
+    BUILD_PREFIX=$PWD/tmp
+
+    CONFIG_OPTS=()
+    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+    CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+    CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+
     # Clone and build dependencies
 .for use
     git clone $(use.repository) $(use.project)
-    ( cd $(use.project) && ./autogen.sh && ./configure && make check && sudo make install &&
-        if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+    ( cd $(use.project) && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make check && make install ) || exit 1
 
 .endfor
     # Build and check this project
-    ./autogen.sh && ./configure && make && make check && make memcheck && sudo make install
+    ( ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make && make check && make memcheck && make install ) || exit 1
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi


### PR DESCRIPTION
Hello,

As discussed in https://github.com/zeromq/libzmq/pull/1529 here's a PR to switch from VM to container based Travis CI builds. Needed changes were removing "sudo" and installing in local directory rather than in the default /usr/local.

Also -x is set in ci_build.sh, since it prints the executed commands to the log, which is very helpful when debugging.