### PR TITLE
CI run on OSX needs binutils

### DIFF
--- a/zproject_ci.gsl
+++ b/zproject_ci.gsl
@@ -20,6 +20,9 @@ env:
 - BUILD_TYPE=default
 - BUILD_TYPE=qt-android
 
+before_install:
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi
+
 # Build and check this project according to the BUILD_TYPE
 script: ./ci_build.sh
 .


### PR DESCRIPTION
OSX does not ship with binutils, need to install it before the script
run via brew in order to be able to use greadelf, needed by the
qt-android CI script.

#209 introduced OSX build in the generated project, but since the qt-android build is present greadelf is needed by default as well.