### PR TITLE
Problem: cmake and qt android handle optional dependencies as required ones

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -80,7 +80,7 @@ if (CYGWIN)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${SOURCE_DIR}")
-.for use
+.for use where use.optional = 0
 
 ########################################################################
 # $(USE.PROJECT) dependency

--- a/zproject_qt_android.gsl
+++ b/zproject_qt_android.gsl
@@ -82,7 +82,7 @@ fi
 ##
 # Verify shared libraries in prefix
 
-.for use
+.for use where use.optional = 0
 android_build_verify_so "$(use.libname).so"
 .endfor
 android_build_verify_so "$(project.libname).so"\


### PR DESCRIPTION
Solutions: exclude optional dependencies entirely

Someone with the proper knowledge about these build systems must find a better Solution