### PR TITLE
Problem: The compiling process is inconsistent on different system as

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -16,6 +16,9 @@ $(project.GENERATED_WARNING_HEADER:)
 
 ACLOCAL_AMFLAGS = -I config
 
+AM_CFLAGS = \
+	-Werror=format-security
+
 AM_CPPFLAGS = \\
 .for use
     \${$(use.project)_CFLAGS} \\


### PR DESCRIPTION
the '-Werror=format-security' isn't set by default on all systems.
Solution: Add it to have a consistent compiling process.