### PR TITLE
Problem: ztrie uses a char in its API to pass a delimiter which is not supported by zproject's API

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -82,6 +82,8 @@ function resolve_c_container (container)
         my.stars += "*"
     elsif my.type = "byte"
         my.c_type = "byte"
+    elsif my.type = "char"
+        my.c_type = "char"
     elsif my.type = "integer"
         my.c_type = "int"
     elsif my.type = "size"


### PR DESCRIPTION
Solution: Add char as possible type