### PR TITLE
Problem: libaries with a '-' in in its name will cause autogen.sh to fail

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -162,7 +162,7 @@ PREVIOUS_LIBS="${LIBS}"
 
 was_$(use.project)_check_lib_detected=no
 
-PKG_CHECK_MODULES([$(use.project)], [$(use.libname) >= $(use.min_version)],
+PKG_CHECK_MODULES([$(use.project:c)], [$(use.project) >= $(use.min_version)],
     [
 .  if defined (use.optional) & (use.optional = 1)
         AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used.])
@@ -196,8 +196,8 @@ PKG_CHECK_MODULES([$(use.project)], [$(use.libname) >= $(use.min_version)],
                 LDFLAGS="${$(use.project)_synthetic_libs} ${LDFLAGS}"
                 LIBS="${$(use.project)_synthetic_libs} ${LIBS}"
 
-                AC_SUBST([$(use.project)_CFLAGS],[${$(use.project)_synthetic_cflags}])
-                AC_SUBST([$(use.project)_LIBS],[${$(use.project)_synthetic_libs}])
+                AC_SUBST([$(use.project:c)_CFLAGS],[${$(use.project)_synthetic_cflags}])
+                AC_SUBST([$(use.project:c)_LIBS],[${$(use.project)_synthetic_libs}])
                 was_$(use.project)_check_lib_detected=yes
 .    if defined (use.optional) & (use.optional = 1)
                 AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used.])
@@ -213,8 +213,8 @@ PKG_CHECK_MODULES([$(use.project)], [$(use.libname) >= $(use.min_version)],
     ])
 
 if test "x$was_$(use.project)_check_lib_detected" = "xno"; then
-    CFLAGS="${$(use.project)_CFLAGS} ${CFLAGS}"
-    LIBS="${$(use.project)_LIBS} ${LIBS}"
+    CFLAGS="${$(use.project:c)_CFLAGS} ${CFLAGS}"
+    LIBS="${$(use.project:c)_LIBS} ${LIBS}"
 fi
 
 .endfor

--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -182,11 +182,11 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.project) >= $(use.min_version)],
         $(use.project)_synthetic_libs="-l$(use.linkname)"
 
         if test "x$search_$(use.libname)" = "xyes"; then
-            if test -r "${with_$(use.libname)}/include/$(use.project).h"; then
+            if test -r "${with_$(use.libname)}/include/$(use.includename).h"; then
                 $(use.project)_synthetic_cflags="-I${with_$(use.libname)}/include"
                 $(use.project)_synthetic_libs="-L${with_$(use.libname)}/lib -l$(use.linkname)"
             else
-                AC_MSG_ERROR([${with_$(use.libname)}/include/$(use.project).h not found. Please check $(use.libname) prefix])
+                AC_MSG_ERROR([${with_$(use.libname)}/include/$(use.includename).h not found. Please check $(use.libname) prefix])
             fi
         fi
 

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -21,7 +21,7 @@ AM_CFLAGS = \\
 
 AM_CPPFLAGS = \\
 .for use
-    \${$(use.project)_CFLAGS} \\
+    \${$(use.project:c)_CFLAGS} \\
 .endfor
     -I\$(srcdir)/include
 
@@ -32,9 +32,9 @@ project_libs =
 .endif
 .for use
 .   if last()
-    \${$(use.project)_LIBS}
+    \${$(use.project:c)_LIBS}
 .   else
-    \${$(use.project)_LIBS} \\
+    \${$(use.project:c)_LIBS} \\
 .   endif
 .endfor
 

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -2,8 +2,9 @@
 
     <!-- ZeroMQ Projects -->
 
-    <use project = "zmq"
+    <use project = "libzmq"
         repository = "https://github.com/zeromq/libzmq"
+        prefix = "zmq"
         test = "zmq_init"
         cmake_name = "ZeroMQ" />
 
@@ -11,7 +12,7 @@
         repository = "https://github.com/zeromq/czmq"
         test = "zctx_test"
         cmake_name = "CZMQ">
-        <use project = "zmq" min_major = "2" min_minor = "2" />
+        <use project = "libzmq" min_major = "2" min_minor = "2" />
     </use>
 
     <use project = "zyre"
@@ -25,7 +26,7 @@
         includename = "malamute"
         prefix = "mlm"
         test = "mlm_server_test">
-        <use project = "zmq" min_major= "4" min_minor = "2" min_patch = "0" />
+        <use project = "libzmq" min_major= "4" min_minor = "2" min_patch = "0" />
         <use project = "czmq" min_major = "3" min_minor = "0" min_patch = "1" />
     </use>
 


### PR DESCRIPTION
Solution: use c-style

This problem also revealed that the project name for the libzmq project is wrongfully zmq which causes troubles with pkg_config_modules as a 'lib' prefix is automatically attached to cater this. The naming issue has been fixed as well.