### PR TITLE
Problem: The libname for all zproject based projects starts with "lib".

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -162,7 +162,7 @@ PREVIOUS_LIBS="${LIBS}"
 
 was_$(use.project)_check_lib_detected=no
 
-PKG_CHECK_MODULES([$(use.project:c)], [$(use.project) >= $(use.min_version)],
+PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
     [
 .  if defined (use.optional) & (use.optional = 1)
         AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used.])
@@ -190,7 +190,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.project) >= $(use.min_version)],
             fi
         fi
 
-        AC_CHECK_LIB([$(use.project)], [$(use.test)],
+        AC_CHECK_LIB([$(use.libname)], [$(use.test)],
             [
                 CFLAGS="${$(use.project)_synthetic_cflags} ${CFLAGS}"
                 LDFLAGS="${$(use.project)_synthetic_libs} ${LDFLAGS}"

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -2,26 +2,25 @@
 
     <!-- ZeroMQ Projects -->
 
-    <use project = "libzmq"
+    <use project = "libzmq" prefix = "zmq"
         repository = "https://github.com/zeromq/libzmq"
-        prefix = "zmq"
         test = "zmq_init"
         cmake_name = "ZeroMQ" />
 
-    <use project = "czmq"
+    <use project = "czmq" libname = "libczmq"
         repository = "https://github.com/zeromq/czmq"
         test = "zctx_test"
         cmake_name = "CZMQ">
         <use project = "libzmq" min_major = "2" min_minor = "2" />
     </use>
 
-    <use project = "zyre"
+    <use project = "zyre" libname = "libzyre"
         repository = "https://github.com/zeromq/zyre"
         test = "zyre_test">
         <use project = "czmq" min_major = "3" min_minor = "0" />
     </use>
 
-    <use project = "malamute"
+    <use project = "malamute" libname = "libmlm"
         repository = "https://github.com/zeromq/malamute"
         includename = "malamute"
         prefix = "mlm"
@@ -32,14 +31,14 @@
 
     <!-- Edgenet Projects -->
 
-    <use project = "drops"
+    <use project = "drops" libname = "libdrops"
         repository = "https://github.com/edgenet/drops"
         test = "drops_test">
         <use project = "czmq" />
         <use project = "zyre" />
     </use>
 
-    <use project = "hydra"
+    <use project = "hydra" libname = "libhydra"
         repository = "https://github.com/edgenet/hydra"
         test = "hydra_server_test">
         <use project = "czmq" min_major = "3" min_minor = "0" min_patch = "1" />
@@ -48,7 +47,7 @@
     <!-- Various known third-party projects
         (If you're unsure of where a project belongs, add it here) -->
 
-    <use project = "curl"
+    <use project = "libcurl"
         repository = "https://github.com/bagder/curl"
         test = "curl_easy_init"
         includename = "curl/curl" />
@@ -74,7 +73,7 @@
         repository = "https://github.com/msgpack/msgpack-c.git"
         test = "msgpack_version" />
 
-    <use project = "sodium"
+    <use project = "libsodium" prefix = "sodium"
         repository = "https://github.com/jedisct1/libsodium"
         test = "sodium_init" />
 

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -14,7 +14,9 @@ function resolve_project_dependency (use)
         my.use.cmake_name  ?= known.cmake_name?
         my.use.includename ?= known.includename?
         my.use.prefix      ?= known.prefix?
-        
+        my.use.linkname    ?= known.linkname?
+        my.use.libname     ?= known.libname?
+
         # Copy known implied dependencies into this dependency
         for known.use as implied_use
             if !count (my.use.use, use.project = implied_use.project)
@@ -27,7 +29,7 @@ function resolve_project_dependency (use)
     my.use.prefix ?= my.use.project
     my.use.linkname ?= my.use.prefix
     my.use.includename ?= my.use.prefix
-    my.use.libname ?= "lib" + my.use.linkname
+    my.use.libname ?= my.use.prefix? my.use.project
     my.use.cmake_name ?= "$(my.use.project:Pascal)"
     my.use.optional ?= 0
     


### PR DESCRIPTION
This is not necessarily the case for other libraries.
Solution: Define the libname attribute for zproject based projects. Also
renamed sodium to libsodium and curl to libcurl and set prefix
accordingly.