### PR TITLE
Problem: Perfect forwarding is oftentimes not supported for variadic methods.

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -190,6 +190,7 @@ function resolve_c_method (method, default_description)
             obj.variadic = "0"
             new argument to my.method as fmtargs
                 fmtargs.variadic = "1"
+                fmtargs.va_start = obj.name
                 resolve_c_container (fmtargs) # won't be included in current loop, so resolve now.
             endnew
         endif
@@ -262,11 +263,19 @@ function resolve_c_class (class)
     endfor
     for my.class.method
         resolve_c_method (method, "")
+        # Test if a variadic function has a sibling that accepts a va_list.
+        # By convention these sibling methods prepend a 'v' to the method name.
+        # This information might be used by the various language bindings.
+        method.has_va_list_sibling = "0"
+        if count (my.class.method, m.name = "v" + method.name, m)
+            method.has_va_list_sibling = "1"
+        endif
     endfor
     for my.class.constructor as method
         method.name ?= "new"
         method.singleton = "1"
         method.is_constructor = "1"
+        method.has_va_list_sibling = "0"
         # Add a new return value to the first slot - the created object
         new return to method as ret
             ret.type = my.class.c_name
@@ -278,6 +287,7 @@ function resolve_c_class (class)
         method.name ?= "destroy"
         method.singleton = "1"
         method.is_destructor = "1"
+        method.has_va_list_sibling = "0"
         # Add a new argument to the first slot - the object to be destroyed
         new argument to method as arg
             arg.type = my.class.c_name


### PR DESCRIPTION
Language bindings usually will exclude those methods except if there is
a sibling methods that supports a va_list.

Solution: Add an attribute to the method to indicate whether it has a
sibling method that supports a va_list.