### PR TITLE
CMake: let findXXX.cmake work on Windows + make selftests smarter

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -143,22 +143,145 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #include "$(project.prefix)_classes.h"
 
+//  -------------------------------------------------------------------------
+//  Prototype of test function
+//
+
+typedef void (*testfn_t) (bool);
+
+//  -------------------------------------------------------------------------
+//  Mapping of test class and test function.
+//
+
+typedef struct
+{
+    const char *testname;
+    testfn_t     test;
+};
+
+//  -------------------------------------------------------------------------
+//  Declaration of all tests
+//
+
+#define DECLARE_TEST(TEST) {#TEST, TEST}
+
+test_item_t all_tests[] = {
+.for class
+    DECLARE_TEST($(class.c_name)_test),
+.endfor
+    {0, 0} //Null terminator
+};
+
+//  -------------------------------------------------------------------------
+//  Return the number of available tests.
+//
+
+static inline unsigned
+test_get_number ()
+{
+    unsigned nb = 0;
+    for (test_item_t *p = all_tests; p->test; ++p, ++nb)
+        ;
+    return nb;
+}
+
+//  -------------------------------------------------------------------------
+//  Print names of all available tests to stdout.
+//
+
+static inline void
+test_print_list ()
+{
+    unsigned i = 0;
+    for (test_item_t *p = all_tests; p->test; ++p, ++i)
+        printf ("%u:%s\n", i, p->testname);
+}
+
+//  -------------------------------------------------------------------------
+//  Test whether a test is available.
+//  Return a pointer to a test_item_t if available, NULL otherwise.
+//
+
+test_item_t *
+test_available (const char *test)
+{
+    for (test_item_t *p = all_tests; p->test; ++p)
+    {
+        if streq (test, p->testname)
+            return p;
+    }
+    return NULL;
+}
+
+//  -------------------------------------------------------------------------
+//  Run all tests.
+//
+
+static inline void
+test_runall (bool verbose)
+{
+    printf ("Running $(project.name) selftests...\n");
+    for (test_item_t *p = all_tests; p->test; ++p)
+        p->test(verbose);
+    printf ("Tests passed OK\n");
+}
+
 int
 main (int argc, char *argv [])
 {
-    bool verbose;
-    if (argc == 2 && streq (argv [1], "-v"))
-        verbose = true;
-    else
-        verbose = false;
+    bool verbose = false;
+    test_item_t *test = 0;
+    for (int i = 1; i < argc; ++i)
+    {
+        if (streq (argv[i], "-v"))
+        {
+            verbose = true;
+        }
+        else if (streq (argv[i], "--nb")) {
+            printf("%d\n", test_get_number());
+            return 0;
+        }
+        else if (streq (argv[i], "--list")) {
+            test_print_list();
+            return 0;
+        }
+        else if (streq (argv[i], "--test"))
+        {
+            ++i;
+            if (i >= argc)
+            {
+                fprintf (stderr, "--test needs an argument\n");
+                return 1;
+            }
+            test = test_available (argv[i]);
+            if (!test)
+            {
+                fprintf (stderr, "%s is not available\n", argv[i]);
+                return 1;
+            }
+        }
+        else if (streq (argv[i], "-e"))
+        {
+#ifdef _MSC_VER
+            //When receiving an abort signal, only print to stderr (no dialog)
+            _set_abort_behavior (0, _WRITE_ABORT_MSG);
+#endif
+        }
+        else
+        {
+            printf ("Unknown option: %s\n", argv[i]);
+            return 1;
+        }
+    }
 
-    printf ("Running $(project.name) selftests...\\n");
+    if (test)
+    {
+          printf ("Running $(project.name) selftest '%s'...\n", test->testname);
+          test->test(verbose);
+    } else {
+        test_runall(verbose);
+    }
 
-.for class
-    $(class.c_name)_test (verbose);
-.endfor
-
-    printf ("Tests passed OK\\n");
     return 0;
 }
 /*

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -93,6 +93,9 @@ find_package($(use.cmake_name:))
 IF ($(USE.CMAKE_NAME)_FOUND)
 include_directories(${$(USE.CMAKE_NAME)_INCLUDE_DIRS})
 list(APPEND MORE_LIBRARIES ${$(USE.CMAKE_NAME)_LIBRARIES})
+.if use.optional = 1
+add_definition(-DHAVE_$(USE.CMAKE_NAME))
+.endif
 ENDIF ($(USE.CMAKE_NAME)_FOUND)
 .endfor
 
@@ -190,36 +193,40 @@ $(project.GENERATED_WARNING_HEADER:)
 .output "Find$(use.cmake_name:).cmake"
 $(project.GENERATED_WARNING_HEADER:)
 
-include(FindPkgConfig)
-PKG_CHECK_MODULES(PC_$(USE.CMAKE_NAME) "$(use.libname)")
-IF (NOT PC_$(USE.CMAKE_NAME)_FOUND)
-    PKG_CHECK_MODULES(PC_$(USE.CMAKE_NAME) "$(use.prefix)")
-ENDIF (NOT PC_$(USE.CMAKE_NAME)_FOUND)
+if (NOT MSVC)
+  include(FindPkgConfig)
+  pkg_check_modules(PC_$(USE.CMAKE_NAME) "$(use.libname)")
+  if (NOT PC_$(USE.CMAKE_NAME)_FOUND)
+    pkg_check_modules(PC_$(USE.CMAKE_NAME) "$(use.prefix)")
+  endif(NOT PC_$(USE.CMAKE_NAME)_FOUND)
+  if (PC_$(USE.CMAKE_NAME)_FOUND)
+    # some libraries install the headers is a subdirectory of the include dir
+    # returned by pkg-config, so use a wildcard match to improve chances of finding
+    # headers and SOs.
+    set($(USE.CMAKE_NAME)_INCLUDE_HINTS ${PC_$(USE.CMAKE_NAME)_INCLUDE_DIRS} ${PC_$(USE.CMAKE_NAME)_INCLUDE_DIRS}/*)
+    set($(USE.CMAKE_NAME)_LIBRARY_HINTS ${PC_$(USE.CMAKE_NAME)_LIBRARY_DIRS} ${PC_$(USE.CMAKE_NAME)_LIBRARY_DIRS}/*)
+  endif(NOT PC_$(USE.CMAKE_NAME)_FOUND)
+endif (NOT MSVC)
 
-# some libraries install the headers is a subdirectory of the include dir
-# returned by pkg-config, so use a wildcard match to improve chances of finding
-# headers and SOs.
 find_path(
     $(USE.CMAKE_NAME)_INCLUDE_DIRS
     NAMES $(use.prefix:c).h
-    HINTS ${PC_$(USE.CMAKE_NAME)_INCLUDE_DIRS} ${PC_$(USE.CMAKE_NAME)_INCLUDE_DIRS}/*
+    HINTS ${PC_$(USE.CMAKE_NAME)_INCLUDE_HINTS}
 )
 
 find_library(
     $(USE.CMAKE_NAME)_LIBRARIES
     NAMES $(use.prefix)
-    HINTS ${PC_$(USE.CMAKE_NAME)_LIBRARY_DIRS} ${PC_$(USE.CMAKE_NAME)_LIBRARY_DIRS}/*
+    HINTS ${PC_$(USE.CMAKE_NAME)_LIBRARY_HINTS}
 )
 
-IF (NOT $(USE.CMAKE_NAME)_INCLUDE_DIRS STREQUAL $(USE.CMAKE_NAME)_INCLUDE_DIRS-NOTFOUND AND NOT $(USE.CMAKE_NAME)_LIBRARIES STREQUAL $(USE.CMAKE_NAME)_LIBRARIES-NOTFOUND)
-.if defined (use.optional) & (use.optional = 1)
-    ADD_DEFINITIONS(-DHAVE_$(USE.LIBNAME))
-
-.endif
-    include(FindPackageHandleStandardArgs)
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS($(USE.CMAKE_NAME) DEFAULT_MSG $(USE.CMAKE_NAME)_LIBRARIES $(USE.CMAKE_NAME)_INCLUDE_DIRS)
-    mark_as_advanced($(USE.CMAKE_NAME)_LIBRARIES $(USE.CMAKE_NAME)_INCLUDE_DIRS)
-ENDIF (NOT $(USE.CMAKE_NAME)_INCLUDE_DIRS STREQUAL $(USE.CMAKE_NAME)_INCLUDE_DIRS-NOTFOUND AND NOT $(USE.CMAKE_NAME)_LIBRARIES STREQUAL $(USE.CMAKE_NAME)_LIBRARIES-NOTFOUND)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  $(USE.CMAKE_NAME)
+  FOUND_VAR $(USE.CMAKE_NAME)_FOUND
+  REQUIRED_VARS $(USE.CMAKE_NAME)_LIBRARIES $(USE.CMAKE_NAME)_INCLUDE_DIRS
+)
+mark_as_advanced($(USE.CMAKE_NAME)_FOUND $(USE.CMAKE_NAME)_LIBRARIES $(USE.CMAKE_NAME)_INCLUDE_DIRS)
 
 $(project.GENERATED_WARNING_HEADER:)
 .endfor


### PR DESCRIPTION
Changes introduces with these commits:
- The FindXXX.cmake files did not work on Windows (due to lack of pkg-config).
  So work around that.
- The selftest generator is rather simplistic. It is only possible to run them all.
  So add an argument to select one test.

**IMPORTANT**
I do not know how to run gsl on the project.
__So these commits are written without any test.__
Please review these changes carefully (@sappo).


Referenced issue; zeromq/czmq#1131