### PR TITLE
Problem: code for test command line has issues

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -156,7 +156,7 @@ typedef void (*testfn_t) (bool);
 typedef struct
 {
     const char *testname;
-    testfn_t     test;
+    testfn_t test;
 };
 
 //  -------------------------------------------------------------------------
@@ -165,11 +165,11 @@ typedef struct
 
 #define DECLARE_TEST(TEST) {#TEST, TEST}
 
-test_item_t all_tests[] = {
+test_item_t all_tests [] = {
 .for class
     DECLARE_TEST($(class.c_name)_test),
 .endfor
-    {0, 0} //Null terminator
+    {0, 0} // Null terminator
 };
 
 //  -------------------------------------------------------------------------
@@ -177,12 +177,13 @@ test_item_t all_tests[] = {
 //
 
 static inline unsigned
-test_get_number ()
+test_get_number (void)
 {
-    unsigned nb = 0;
-    for (test_item_t *p = all_tests; p->test; ++p, ++nb)
-        ;
-    return nb;
+    unsigned count = 0;
+    test_item_t *item;
+    for (item = all_tests; item->test; item++)
+        count++;
+    return count;
 }
 
 //  -------------------------------------------------------------------------
@@ -190,11 +191,14 @@ test_get_number ()
 //
 
 static inline void
-test_print_list ()
+test_print_list (void)
 {
-    unsigned i = 0;
-    for (test_item_t *p = all_tests; p->test; ++p, ++i)
-        printf ("%u:%s\n", i, p->testname);
+    unsigned count = 0;
+    test_item_t *item;
+    for (item = all_tests; item->test; item++) {
+        count++;
+        printf ("%u:%s\n", count, item->testname);
+    }
 }
 
 //  -------------------------------------------------------------------------
@@ -203,12 +207,12 @@ test_print_list ()
 //
 
 test_item_t *
-test_available (const char *test)
+test_available (const char *testname)
 {
-    for (test_item_t *p = all_tests; p->test; ++p)
-    {
-        if streq (test, p->testname)
-            return p;
+    test_item_t *item;
+    for (item = all_tests; item->test; item++) {
+        if (streq (testname, item->testname))
+            return item;
     }
     return NULL;
 }
@@ -221,8 +225,10 @@ static inline void
 test_runall (bool verbose)
 {
     printf ("Running $(project.name) selftests...\n");
-    for (test_item_t *p = all_tests; p->test; ++p)
-        p->test(verbose);
+    test_item_t *item;
+    for (item = all_tests; item->test; item++)
+        item->test (verbose);
+
     printf ("Tests passed OK\n");
 }
 
@@ -231,56 +237,50 @@ main (int argc, char *argv [])
 {
     bool verbose = false;
     test_item_t *test = 0;
-    for (int i = 1; i < argc; ++i)
-    {
-        if (streq (argv[i], "-v"))
-        {
+    for (int argn = 1; argn < argc; argn) {
+        if (streq (argv [argn], "-v"))
             verbose = true;
-        }
-        else if (streq (argv[i], "--nb")) {
-            printf("%d\n", test_get_number());
+        else
+        if (streq (argv [argn], "--nb")) {
+            printf("%d\n", test_get_number ());
             return 0;
         }
-        else if (streq (argv[i], "--list")) {
-            test_print_list();
+        else
+        if (streq (argv [argn], "--list")) {
+            test_print_list ();
             return 0;
         }
-        else if (streq (argv[i], "--test"))
-        {
-            ++i;
-            if (i >= argc)
-            {
+        else
+        if (streq (argv [argn], "--test")) {
+            argn++;
+            if (argn >= argc) {
                 fprintf (stderr, "--test needs an argument\n");
                 return 1;
             }
-            test = test_available (argv[i]);
-            if (!test)
-            {
-                fprintf (stderr, "%s is not available\n", argv[i]);
+            test = test_available (argv [argn]);
+            if (!test) {
+                fprintf (stderr, "%s is not available\n", argv [argn]);
                 return 1;
             }
         }
-        else if (streq (argv[i], "-e"))
-        {
+        else
+        if (streq (argv [argn], "-e")) {
 #ifdef _MSC_VER
             //When receiving an abort signal, only print to stderr (no dialog)
             _set_abort_behavior (0, _WRITE_ABORT_MSG);
 #endif
         }
-        else
-        {
-            printf ("Unknown option: %s\n", argv[i]);
+        else {
+            printf ("Unknown option: %s\n", argv [argn]);
             return 1;
         }
     }
 
-    if (test)
-    {
-          printf ("Running $(project.name) selftest '%s'...\n", test->testname);
-          test->test(verbose);
-    } else {
-        test_runall(verbose);
-    }
+    if (test) {
+        printf ("Running $(project.name) selftest '%s'...\n", test->testname);
+        test->test (verbose);
+    else
+        test_runall (verbose);
 
     return 0;
 }
@@ -418,7 +418,7 @@ $(PROJECT.PREFIX)_EXPORT void
 //  Structure of our class
 
 struct _$(class.c_name)_t {
-    //  TODO: Declare properties
+    int filler;     //  TODO: Declare properties
 };
 
 .for class.constructor as method


### PR DESCRIPTION
- empty function argument lists (use 'void')
- use of variables like i, p, etc. (formally disallowed)
- inline declarations in for loops (not standard C)
- action in for loops (move to body, it's cleaner)
- incorrect use of parenthesis (place opening { with statement)
- use of preincrement in for loops (why? we don't do that anywhere else)

Solution: fix these