### PR TITLE
minor fix to the generation of python constructors

### DIFF
--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -392,7 +392,7 @@ for class where defined (class.api)
         callargs = ""
         for method.argument
             if argument.variadic
-                callargs += "*args[index()-1:]"
+                callargs += "*args[1:]"
             elsif defined (argument.python_coerce)
                 callargs += string.search_replace(argument.python_coerce, "<>", "args[$(index()-1)]")
             else


### PR DESCRIPTION
As mentioned on the ML by Johan Philips the Python constructor can have wrong arguments:

```
from czmq import Zpoller
from zyre import Zyre
node = Zyre("test")
node.start()
poller = Zpoller(node.socket(), None)
Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
   File "/home/jphilips/workspace/czmq/bindings/python/czmq.py [czmq.py]", line 
1782, in __init__
     self._as_parameter_ = lib.zpoller_new(args[0], *args[index()-1:]) # 
Creation of new raw type
NameError: global name 'index' is not defined
```
This PR request removes the undefined index() method.

After merge the bindings of projects might need regeneration.