### PR TITLE
Problem: can't create dso with versioned symbols

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -386,6 +386,39 @@ AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
     [pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
 AC_SUBST([pkgconfigdir])
 
+
+.if file.exists ("src/$(project.libname).sym")
+# Symbol versioning support: snatched and adapted from libpng:
+# http://www.opensource.apple.com/source/X11libs/X11libs-40/libpng/libpng-1.2.35/configure.ac
+AC_MSG_CHECKING([if libraries can be versioned])
+GLD="`$LD --help < /dev/null 2>/dev/null | grep version-script`"
+AS_IF([test -n "$GLD"],
+        [have_ld_version_script=yes
+         AC_MSG_RESULT(yes)],
+        [have_ld_version_script=no
+         AC_MSG_RESULT(no)
+         AC_MSG_WARN(*** You have not enabled versioned symbols.)
+])
+AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$have_ld_version_script" = "yes")
+AS_IF([test "$have_ld_version_script" = "yes"],
+        [AC_MSG_CHECKING([for symbol prefix])
+         SYMBOL_PREFIX=`echo "PREFIX=__USER_LABEL_PREFIX__" \
+                   | ${CPP-${CC-gcc} -E} - 2>&1 \
+                   | ${EGREP-grep} "^PREFIX=" \
+                   | ${SED-sed} "s:^PREFIX=::"`
+         AC_SUBST(SYMBOL_PREFIX)
+         AC_MSG_RESULT($SYMBOL_PREFIX)
+         CXXFLAG_VISIBILITY=""
+         gl_VISIBILITY
+         AS_CASE(["$CFLAG_VISIBILITY"],
+            [*-fvisibility-inlines-hidden*],[
+                CXXFLAG_VISIBILITY="$CFLAG_VISIBILITY"],
+            [*-fvisibility=hidden*],[
+                CXXFLAG_VISIBILITY="$CFLAG_VISIBILITY -fvisibility-inlines-hidden"])
+        AC_SUBST(CXXFLAG_VISIBILITY)
+])
+.endif
+
 # Specify output files
 .if count (class) + count (ac_config) > 0
 AC_CONFIG_FILES([Makefile

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -138,6 +138,16 @@ src_$(project.libname:c)_la_LDFLAGS = \\
     -version-info @LTVER@ \\
     \$(LIBTOOL_EXTRA_LDFLAGS)
 
+.if file.exists ("src/$(project.libname).sym")
+if HAVE_LD_VERSION_SCRIPT
+src_$(project.libname:c)_la_LDFLAGS += \\
+		-Wl,--version-script=\$(top_srcdir)/src/$(project.libname).sym
+else
+src_$(project.libname:c)_la_LDFLAGS += \\
+		-export-symbols \$(top_srcdir)/src/$(project.libname).sym
+endif
+.endif
+
 if ON_MINGW
 src_$(project.libname:c)_la_LDFLAGS += \\
     -no-undefined \\


### PR DESCRIPTION
Solution: (for autotools)

In case there is src/$(project.libname).sym file, do this
  1.) configure.ac: Add a check if platform linker supports version-script or not
  2.) src/Makemodule.am: append --version-script or --export-symbols to LDFLAGS while
      building a library

Do nothing if sym file does not exists. Tested with GNU linker on Linux, other platforms might need some conditionals ...