### PR TITLE
Problem: blank line following trailing backlash in src/Makemodule.am

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -201,8 +201,8 @@ dist_api_DATA = \\
 .   else
     $(class.api)
 .   endif
-
 .endfor
+
 .if (count (class) > 0)
 # define custom target for all products of /src
 src: src/$(project.libname).la src/$(project.prefix)_selftest


### PR DESCRIPTION
Problem: Generate blank line following trailing backlash in src/Makemodule.am

Solution: Correct blank line for section dist_api_DATA