### PR TITLE
Problem: execution right for various build scripts is not set after generation.

### DIFF
--- a/zproject_ci.gsl
+++ b/zproject_ci.gsl
@@ -56,5 +56,7 @@ if [ $BUILD_TYPE == "default" ]; then
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi
+.close
+.chmod_x ("ci_build.sh")
 .endif # !file.exists ("ci_build.sh")
 .endif # !file.exists (".travis.yml")

--- a/zproject_qt_android.gsl
+++ b/zproject_qt_android.gsl
@@ -91,6 +91,8 @@ android_build_verify_so "$(project.libname).so"\
 
 
 $(project.GENERATED_WARNING_HEADER:)
+.close
+.chmod_x ("builds/qt-android/build.sh")
 .#
 .output "builds/qt-android/ci_build.sh"
 #!/usr/bin/env bash
@@ -132,6 +134,8 @@ git clone $(use.repository) $$(USE.PROJECT)_ROOT
 source ./build.sh
 
 $(project.GENERATED_WARNING_HEADER:)
+.close
+.chmod_x ("builds/qt-android/ci_build.sh")
 .#
 .output "builds/qt-android/android_build_helper.sh"
 #!/usr/bin/env bash
@@ -428,3 +432,5 @@ function android_build_verify_so {
 
 .endliteral
 $(project.GENERATED_WARNING_HEADER:)
+.close
+.chmod_x ("builds/qt-android/android_build_helper.sh")


### PR DESCRIPTION
Solution: use the new chmod_x gsl function to add execution rights to those files.