### PR TITLE
Problem: project with hyphen in name have incorrect header

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -21,8 +21,8 @@
 .if !file.exists ("include")
 .   directory.create ("include")
 .endif
-.if !file.exists ("include/$(project.name).h") & count (class, class.name = project.name) = 0
-.   output "include/$(project.name).h"
+.if !file.exists ("include/$(project.name:c).h") & count (class, class.name = project.name) = 0
+.   output "include/$(project.name:c).h"
 /*  =========================================================================
     $(project.name) - $(project.description?'':)
 


### PR DESCRIPTION
Solution: generate main header with :c name mangling (foo-bar.h ->
foo_bar.h), this is follow up of cf5c2c0b