### PR TITLE
[RFC] Problem: no C++ support in generated autotools files

### DIFF
--- a/zproject.gsl
+++ b/zproject.gsl
@@ -20,6 +20,23 @@ function resolve_includes ()
 endfunction
 resolve_includes ()
 
+# Find c++ sources in the project
+function project_use_cxx ()
+    use_cxx = 0
+    for class
+        if file.exists ("src/$(name:c).cc")
+            return 1
+        endif
+    endfor
+    for main
+        if file.exists ("src/$(name:c).cc")
+            return 1
+        endif
+    endfor
+    return 0
+endfunction
+
+project.use_cxx = project_use_cxx ()
 project.name ?= "myproject"
 project.prefix ?= project.name
 project.linkname ?= project.prefix

--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -130,6 +130,10 @@ $(PROJECT.NAME:c)_ORIG_CFLAGS="${CFLAGS:-none}"
 AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
+.if project.use_cxx
+AC_PROG_CXX
+AC_PROG_CXX_C_O
+.endif
 AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
 AC_PROG_SED
@@ -349,7 +353,11 @@ AC_C_BIGENDIAN
 
 # These options are GNU compiler specific.
 if test "x$GCC" = "xyes"; then
+.if project.use_cxx
+    CPPFLAGS="-pedantic -Werror -Wall ${CPPFLAGS}"
+.else
     CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
+.endif
 fi
 
 AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -18,6 +18,12 @@ ACLOCAL_AMFLAGS = -I config
 AM_CFLAGS = \\
 	-Werror=format-security
 
+.if project.use_cxx
+AM_CXXFLAGS = \\
+    -Werror=format-security \\
+    -std=c++11
+.endif
+
 AM_CPPFLAGS = \\
 .for use
     \${$(use.project:c)_CFLAGS} \\
@@ -115,7 +121,11 @@ include_HEADERS = \\
 
 src_$(project.libname:c)_la_SOURCES = \\
 .for class
+.   if file.exists ("src/$(name:c).cc")
+    src/$(name:c).cc \\
+.   else
     src/$(name:c).c \\
+.   endif
 .endfor
 .for extra
     src/$(name) \\
@@ -123,6 +133,9 @@ src_$(project.libname:c)_la_SOURCES = \\
     src/platform.h
 
 src_$(project.libname:c)_la_CPPFLAGS = ${AM_CPPFLAGS}
+.if project.use_cxx
+src_$(project.libname:c)_la_CXXFLAGS = ${AM_CXXFLAGS}
+.endif
 
 src_$(project.libname:c)_la_LDFLAGS = \\
     -version-info @LTVER@ \\
@@ -167,7 +180,11 @@ bin_PROGRAMS += src/$(main.name)
 .   endif
 src_$(main.name:c)_CPPFLAGS = ${AM_CPPFLAGS}
 src_$(main.name:c)_LDADD = ${program_libs}
+.   if file.exists ("src/$(name:c).cc")
+src_$(name:c)_SOURCES = src/$(name:c).cc
+.   else
 src_$(name:c)_SOURCES = src/$(name:c).c
+.   endif
 .   if main.service ?= 1
 src_$(main.name:c)_configdir = \$(sysconfdir)/$(project.name)
 src_$(main.name:c)_config_DATA = src/$(main.name).cfg


### PR DESCRIPTION
Solution: detect the existence of .cc files in project and generate
proper autoconf and automake recipes.

I'd like to know your opinion if given approach sounds plausible to you.