### PR TITLE
Problem: no conversion polymorphic reference

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -428,8 +428,10 @@ $(argument.ruby_name)\
       # $(method.description:no,block)
       #
       # This is the polymorphic version of #$(method.ruby_name:).
+      #
+      # @param self_p [$(project.RubyName:)::$(class.RubyName:), #__ptr, FFI::Pointer, nil] object reference to use this method on
       def $(ruby_polymorphic_method_signature(method))
-        raise DestroyedError unless self_p
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
 .for method.argument where defined (argument.coerce_to_c)
         $(argument.ruby_name:) = $(argument.coerce_to_c:)
 .endfor


### PR DESCRIPTION
Solution: Coerce polymorphic reference, in case it respond_to?(:__ptr).
This allows one to pass instances of the generated Ruby class. They'll
get coerced into an FFI::Pointer.

Other scenarios like passing in a FFI::Pointer, or nil (for C functions
where the NULL pointer is a valid argument) are be possible too now.

This also adds a bit of documentation about this versatile parameter
(slightly YARD specific).