### PR TITLE
enum types in Ruby binding and extended API XML example

### DIFF
--- a/api/myclass.xml
+++ b/api/myclass.xml
@@ -4,7 +4,7 @@
     It shows a language binding developer what to expect from the API XML
     files.
 -->
-<class name = "my class" >
+<class name = "myclass" >
     My Feature-Rich Class
 
     <include filename = "license.xml" />
@@ -20,7 +20,7 @@
 
     <!-- Constructor is optional; default one has no arguments -->
     <constructor>
-        Create a new my_class with the given name.
+        Create a new myclass with the given name.
         <argument name = "name" type = "string" />
     </constructor>
 
@@ -36,21 +36,21 @@
 
     <!-- This models a method with no return value -->
     <method name = "sleep">
-        Put the `my_class` to sleep for the given number of milliseconds.
+        Put the myclass to sleep for the given number of milliseconds.
         No messages will be processed by it during this time.
         <argument name = "duration" type = "integer" />
     </method>
 
     <!-- This models an accessor method -->
     <method name = "has feature">
-        Return true if the `my_class` has the given feature.
+        Return true if the myclass has the given feature.
         <argument name = "feature" type = "string" />
         <return type = "boolean" />
     </method>
 
     <!-- This models a method which will be excluded from generated C code and bindings -->
     <method name = "print" exclude = "1">
-        Get printable string for this `my_class` struct.
+        Get printable string for this myclass.
         <return type = "string" />
     </method>
 
@@ -74,7 +74,7 @@
 
     <!-- Callback typedefs can be declared like methods -->
     <callback_type name = "handler_fn">
-        <argument name = "self" type = "my_class" />
+        <argument name = "self" type = "myclass" />
         <argument name = "action" type = "string" />
         <return type = "boolean" />
     </callback_type>
@@ -92,9 +92,9 @@
     </method>
 
     <method name = "new thing" singleton = "1" >
-        Creates a new `my_class` struct. The caller is responsible for
-        destroying it when finished with it.
-        <return type = "my_class" fresh = "1" />
+	Creates a new myclass. The caller is responsible for destroying it when
+	finished with it.
+        <return type = "myclass" fresh = "1" />
     </method>
 
     <method name = "free" singleton = "1">
@@ -119,10 +119,10 @@
             Supported sizes are 1, 2, 4, and 8.
         </argument>
         <argument name = "a byte" type = "byte" />
-        <argument name = "conversion mode" type = "enum:my_class.mode">
+        <argument name = "conversion mode" type = "enum:myclass.mode">
             The container for this argument will get the following attributes:
             * `is_enum = 1"
-            * `enum_class = "my_class"`
+            * `enum_class = "myclass"`
             * `enum_name = "mode"`
             * `c_type = "my_class_mode_t"`
         </argument>

--- a/api/myclass.xml
+++ b/api/myclass.xml
@@ -1,39 +1,80 @@
 <!--
     This model defines a public API for binding. 
+
+    It shows a language binding developer what to expect from the API XML
+    files.
 -->
-<class name = "myclass" >
+<class name = "my class" >
     My Feature-Rich Class
 
     <include filename = "license.xml" />
 
     <constant name = "default port" value = "8080">registered with IANA</constant>
 
+    <enum name = "mode">
+        Enumeration defining different work modes. Constants are mandatory.
+        <constant name="normal" constant = "1">
+        <constant name="fast"   constant = "2">
+        <constant name="safe"   constant = "3">
+    </enum>
+
     <!-- Constructor is optional; default one has no arguments -->
     <constructor>
-        Create a new myclass with the given name.
+        Create a new my_class with the given name.
         <argument name = "name" type = "string" />
     </constructor>
 
     <!-- Destructor is optional; default one follows standard style -->
-    <destructor />
+    <destructor>
+        Destructors implicitely get a new argument prepended, which:
+
+        * is called `self_p`
+        * is of this class' type
+        * is passed by reference
+        * is marked as the self pointer for the destructor (`destructor_self = "1"`)
+    </destructor>
 
     <!-- This models a method with no return value -->
     <method name = "sleep">
-        Put the myclass to sleep for the given number of milliseconds.
-        No messages will be processed by the actor during this time.
+        Put the `my_class` to sleep for the given number of milliseconds.
+        No messages will be processed by it during this time.
         <argument name = "duration" type = "integer" />
     </method>
 
     <!-- This models an accessor method -->
     <method name = "has feature">
-        Return true if the myclass has the given feature.
+        Return true if the `my_class` has the given feature.
         <argument name = "feature" type = "string" />
+        <return type = "boolean" />
+    </method>
+
+    <!-- This models a method which will be excluded from generated C code and bindings -->
+    <method name = "print" exclude = "1">
+        Get printable string for this `my_class` struct.
+        <return type = "string" />
+    </method>
+
+    <method name = "send strings">
+        This does something with a series of strings (until NULL). The strings
+        won't be touched.
+
+        Because the next method has the same name with a prepended "v", it's
+        recognized as this method's `va_list` sibling (in GSL:
+        `method.has_va_list_sibling = "1"`). This information might be used by
+        the various language bindings.
+        <argument name = "string" type = "string" variadic = "1" constant = "1"/>
+        <return type = "boolean" />
+    </method>
+    <method name = "vsend strings">
+        This does something with a series of strings (until NULL). The strings
+        won't be touched.
+        <argument name = "string" type = "string" variadic = "1" constant = "1"/>
         <return type = "boolean" />
     </method>
 
     <!-- Callback typedefs can be declared like methods -->
     <callback_type name = "handler_fn">
-        <argument name = "self" type = "myclass" />
+        <argument name = "self" type = "my_class" />
         <argument name = "action" type = "string" />
         <return type = "boolean" />
     </callback_type>
@@ -41,7 +82,7 @@
     <!-- Callback types can be used as method arguments -->
     <method name = "add handler">
         Store the given callback function for later
-        <argument name = "handler" type = "myclass_handler_fn" callback = "1" />
+        <argument name = "handler" type = "my_class_handler_fn" callback = "1" />
     </method>
 
     <!-- If singleton = "1", no class struct pointer is required. -->
@@ -50,18 +91,73 @@
         <argument name = "verbose" type = "boolean" />
     </method>
 
+    <method name = "new thing" singleton = "1" >
+        Creates a new `my_class` struct. The caller is responsible for
+        destroying it when finished with it.
+        <return type = "my_class" fresh = "1" />
+    </method>
+
+    <method name = "free" singleton = "1">
+        Frees a provided string, and nullify the parent pointer.
+        <argument name = "string pointer" type = "string" constant = "0"
+            by_reference = "1" />
+    </method>
+
     <!-- These are the types we support
          Not all of these are supported in all language bindings;
          see each language binding's file for supported types in that
          language, and add more types as needed where appropriate.
+
+         Also, see zproject_class_api.gsl to see how they're handled exactly.
          -->
     <method name = "tutorial">
         <argument name = "void pointer" type = "anything" />
         <argument name = "standard int" type = "integer" />
         <argument name = "standard float" type = "real" />
         <argument name = "standard bool" type = "boolean" />
-        <argument name = "char pointer" type = "string" />
-        <argument name = "custom pointer" type = "myclass_t" />
+        <argument name = "fixed size unsigned integer" type = "number" size = "4">
+            Supported sizes are 1, 2, 4, and 8.
+        </argument>
+        <argument name = "a byte" type = "byte" />
+        <argument name = "conversion mode" type = "enum:my_class.mode">
+            The container for this argument will get the following attributes:
+            * `is_enum = 1"
+            * `enum_class = "my_class"`
+            * `enum_name = "mode"`
+            * `c_type = "my_class_mode_t"`
+        </argument>
+        <argument name = "char pointer to C string" type = "string" />
+        <argument name = "byte pointer to buffer" type = "buffer" />
+        <argument name = "buffer size" type = "size" />
+        <argument name = "file handle" type = "FILE" />
+        <argument name = "file size" type = "file_size" />
+        <argument name = "time" type = "time" />
+        <argument name = "format" type = "format">
+            This makes the function is variadic (will cause a new argument to be
+            added to represent the variadic arguments).
+        </argument>
+        <argument name = "variadic list argument" type = "va_list" />
+        <argument name = "custom pointer" type = "my custom class">
+            Any other type is valid, as long as there is a corresponding C
+            type, in this case `my_custom_class_t`.
+        </argument>
         <return type = "nothing">void method</return>
+    </method>
+
+    <method name = "set foo" polymorphic = "1">
+      Set attribute foo to a new value. Note that this method takes a
+      polymorphic reference (`void *`) as its first argument, which could point
+      to structs of different types.
+
+      This also means that high-level bindings might give you the choice to
+      call this method directly on an instance, or with an explicit receiver.
+      <argument name = "new value" type="integer" />
+    </method>
+
+    <method name = "set bar">
+        This method takes an argument type of the (descriptive) type `foo`, but
+        resolving it to a corresponding C type will be skipped because it's
+        overridden to `foobarbaz_t` by the `c_type` attribute.
+        <argument name = "new foo" type="foo" c_type="foobarbaz_t" />
     </method>
 </class>

--- a/project.xml
+++ b/project.xml
@@ -50,7 +50,7 @@
     -->
 
     <!--
-        Classes, if the class header or source file doesn't exist this will
+        Classes, if the class header or source file doesn't exist, this will
         generate a skeletons for them.
         use private = "1" for internal classes
     <class name = "myclass">Public class description</class>
@@ -58,8 +58,8 @@
     -->
 
     <!--
-        Actors, are build using the simple actor framework from czmq. If the
-        actors class header or source file doesn't exist this will generate a
+        Actors, are built using the simple actor framework from czmq. If the
+        actors class header or source file doesn't exist, this will generate a
         skeleton for them. The generated test method of the actor will teach
         you how to use them. Also have a look at the czmq docs to learn more
         about actors.

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -10,9 +10,7 @@ function resolve_includes (xml)
             my.include_file = my.xml.load_file (filename)
             if defined (my.include_file)
                 echo "I: including XML $(filename) into $(my.xml.name)"
-                for my.include_file. as element
-                    move element before include
-                endfor
+                move my.include_file after include
             else
                 echo "E: error loading include file: $(filename): $(xml.error?)"
             endif

--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -278,6 +278,7 @@ module $(project.RubyName:)
         :$(constant.name:c), $(constant.value),
 .  endfor
       ]
+
 .endfor
 .for constructor as method
       $(ruby_ffi_attach_definition(method))

--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -24,22 +24,34 @@ for class where defined (class.api)
     class.RubyName = "$(class.ruby_require:Pascal)"
 endfor
 
+# Work out Ruby name based on container.name and and set it as
+# container.ruby_name.
+function sanitize_ruby_container_name(container)
+  my.container.ruby_name = "$(my.container.name:c)"
+
+  # Replace default value from resolve_c_container().
+  if my.container.ruby_name = "_"
+      my.container.ruby_name = my.container.variadic ?? "args" ? "result"
+  endif
+
+  ##
+  # Sanitize if it matches a Ruby keyword.
+  #
+
+  # Ruby keywords. The only keyword not listed here is 'defined?', but that
+  # won't be possible because of the 'c' pretty-print modifier above.
+  my.ruby_keywords_regexp = "^(BEGIN|END|__ENCODING__|__END__|__FILE__|__LINE__|alias|and|begin|break|case|class|def|do|else|elsif|end|ensure|false|for|if|in|module|next|nil|not|or|redo|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield)$"
+
+  if regexp.match (my.ruby_keywords_regexp, my.container.ruby_name)
+      my.container.ruby_name += "_"
+  endif
+endfunction
+
 function resolve_ruby_container (container)
+    sanitize_ruby_container_name(my.container)
+
     # Defaults
     my.container.ruby_ffi_type = "pointer"
-    my.container.ruby_name = "$(my.container.name:c)"
-    if my.container.ruby_name = "_"
-        if my.container.variadic
-            my.container.ruby_name = "args"
-        else
-            my.container.ruby_name = "result"
-        endif
-    endif
-
-    # Fix if the name matches a Ruby keyword. The only keyword not tested is defined?, but that won't be possible because of the 'c' pretty-print modifier above.
-    if regexp.match ("^(BEGIN|END|__ENCODING__|__END__|__FILE__|__LINE__|alias|and|begin|break|case|class|def|do|else|elsif|end|ensure|false|for|if|in|module|next|nil|not|or|redo|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield)$", my.container.ruby_name)
-        my.container.ruby_name += "_"
-    endif
 
     # All C types should be transformed to a type name recognized by FFI.
     # To handle more C types, add support for them here.

--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -24,6 +24,15 @@ for class where defined (class.api)
     class.RubyName = "$(class.ruby_require:Pascal)"
 endfor
 
+function resolve_ruby_enums (class)
+  for my.class.enum
+    enum.ruby_name = "$(my.class.c_name:)_$(enum.name:c)"
+
+    # useful to test existence of enum later when resolving arguments of enum type
+    enum.c_type    = "$(my.class.c_name:)_$(enum.name:c)_t"
+  endfor
+endfunction
+
 # Work out Ruby name based on container.name and and set it as
 # container.ruby_name.
 function sanitize_ruby_container_name(container)
@@ -80,6 +89,8 @@ function resolve_ruby_container (container)
     elsif my.container.c_type = "byte"
         my.container.ruby_ffi_type = "char"
         my.container.coerce_to_c = "Integer($(my.container.ruby_name:))"
+    elsif my.container.is_enum
+        my.container.ruby_ffi_type = "$(my.container.enum_class:)_$(my.container.enum_name)"
     elsif count (project.class, defined (class.RubyName) & (my.container.type = class.c_name))
         for project.class where (defined (class.RubyName) & (my.container.type = class.c_name))
             if my.container.by_reference
@@ -195,6 +206,7 @@ function ruby_polymorphic_method_signature(method)
 endfunction
 
 function resolve_ruby_class (class)
+    resolve_ruby_enums (class)
     for my.class.constructor as method
         resolve_ruby_method (method)
     endfor
@@ -259,6 +271,14 @@ module $(project.RubyName:)
       }
 .for class where defined (class.api)
 
+.for enum
+      enum :$(enum.ruby_name:), [
+.  for enum.constant
+.       # Ruby doesn't care about that last trailing comma ;-)
+        :$(constant.name:c), $(constant.value),
+.  endfor
+      ]
+.endfor
 .for constructor as method
       $(ruby_ffi_attach_definition(method))
 .endfor

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -21,8 +21,9 @@
 .if !file.exists ("include")
 .   directory.create ("include")
 .endif
-.if !file.exists ("include/$(project.name:c).h") & count (class, class.name = project.name) = 0
-.   output "include/$(project.name:c).h"
+.project_header_file = "include/$(project.name:c).h"
+.if !file.exists (project_header_file) & count (class, class.name = project.name) = 0
+.   output project_header_file
 /*  =========================================================================
     $(project.name) - $(project.description?'':)
 

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -412,7 +412,7 @@ function c_method_declaration (method, implementation_style)
     endif
     out += "$(class.c_name)_$(my.method.c_name) ("
     if !my.method.singleton
-        if defined (my.method.polymorphic)
+        if defined (my.method.polymorphic) & my.method.polymorphic
             out += "void *self"
         else
             out += "$(class.c_name)_t *self"


### PR DESCRIPTION
* add support for enums in the Ruby binding
* fix the processing of `<include ... />`
* GSL `c_method_declaration()`: don't treat all functions as polymorphic
* greatly extend the example API XML `api/myclass.xml`

Examples for the following API elements have been added:

* enums
* the implicit self pointer argument on destructors
* excluded methods (`exclude = "1"`)
* returned pointers which will be owned by the caller (`fresh = "1")
* arguments that are passed by reference (adds one more `*`)
* methods with `va_list` siblings (do_that() and vdo_that())
* arguments of type `byte`
* arguments of type `number`
* arguments of enum type (`enum:myclass.myenum`)
* arguments of type `string`
* arguments of type `buffer`
* arguments of type `size`
* arguments of type `FILE`
* arguments of type `time`
* arguments of type `format`  (which makes the method implicitly variadic)
* explicitly variadic arguments (`variadic = "1"`)
* arguments of type `va_list`
* arguments with overridden C type (`c_type = "foobar_t"`)
* methods that take a polymorphic reference (`polymorphic = "1"`)

Quite a bit of information has been added which could help a developer
of a new language binding.