### PR TITLE
Problem: enum constant comments are not applied to the definition

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -547,7 +547,7 @@ typedef enum {
 .    else
 .        post = ","
 .    endif
-    $(CLASS.NAME:c)_$(CONSTANT.NAME:c) = $(value)$(post)
+    $(CLASS.NAME:c)_$(CONSTANT.NAME:c) = $(value)$(post)    //  $(string.trim (constant.?''):left)
 .  endfor
 } $(class.name:c)_$(enum.name:c)_t;
 .endfor


### PR DESCRIPTION
Solution: Read the comment from the xml file and add it to the enum definition

Fixes #306 