### PR TITLE
Problem: Can't specify real package names for dependencies

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -35,8 +35,12 @@ Build-Depends: bison, debhelper (>= 8),
 .for project.use
 .if use.project = "libzmq"
     libzmq4-dev,
-.else
+.elsif defined(use.debian_name)
+    $(use.debian_name),
+.elsif regexp.match("^lib", use.libname)
     $(use.libname)-dev,
+.else
+    lib$(use.libname)-dev,
 .endif
 .endfor
     dh-autoreconf
@@ -57,6 +61,10 @@ Depends:
 .for project.use
 .if use.project = "libzmq"
     libzmq4-dev,
+.elsif defined(use.debian_name)
+    $(use.debian_name),
+.elsif regexp.match("^lib", use.libname)
+    $(use.libname)-dev,
 .else
     lib$(use.project)-dev,
 .endif
@@ -110,8 +118,12 @@ Build-Depends: bison, debhelper (>= 8),
 .for project.use
 .if use.project = "libzmq"
     libzmq4-dev,
-.else
+.elsif defined(use.debian_name)
+    $(use.debian_name),
+.elsif regexp.match("^lib", use.libname)
     $(use.libname)-dev,
+.else
+    lib$(use.libname)-dev,
 .endif
 .endfor
     dh-autoreconf

--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -36,6 +36,8 @@ BuildRequires:  pkg-config
 .for project.use
 .if use.project = "libzmq"
 BuildRequires:  zeromq-devel
+.elsif defined(use.spec_name)
+BuildRequires:  $(use.spec_name)
 .else
 BuildRequires:  $(use.project)-devel
 .endif
@@ -67,7 +69,13 @@ Summary:        $(project.description)
 Group:          System/Libraries
 Requires:       $(project.libname)$(project->version.major) = %{version}
 .for project.use
+.if use.project = "libzmq"
+Requires:       zeromq-devel
+.elsif defined(use.spec_name)
+Requires:       $(use.spec_name)
+.else
 Requires:       $(use.project)-devel
+.endif
 .endfor
 
 %description devel


### PR DESCRIPTION
Solution: Extend packaging templates a little bit using optional
parameters that let users to override automatic guesses.