### PR TITLE
Problem: spec doesn't require g++ for c++ projects

### DIFF
--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -33,6 +33,9 @@ BuildRequires:  automake
 BuildRequires:  autoconf
 BuildRequires:  libtool
 BuildRequires:  pkg-config
+.if project.use_cxx
+BuildRequires:  gcc-c++
+.endif
 .for project.use
 .if use.project = "libzmq"
 BuildRequires:  zeromq-devel


### PR DESCRIPTION
Solution: Add it when needed