### PR TITLE
Problem: use of attribute exclude = "1" unclear

### DIFF
--- a/api/myclass.xml
+++ b/api/myclass.xml
@@ -48,7 +48,13 @@
         <return type = "boolean" />
     </method>
 
-    <!-- This models a method which will be excluded from generated C code and bindings -->
+    <!-- This models a method which will be excluded from generated C code and
+         bindings.
+
+         It's meant to be useful if your C code has either no constructor, no
+         destructor, no `print` method, or no `test` method, which would be
+         generated implicitly if not found in the API.
+     -->
     <method name = "print" exclude = "1">
         Get printable string for this myclass.
         <return type = "string" />


### PR DESCRIPTION
Solution: clarify its use in the example API.

This is related to the issue #310.