### PR TITLE
Problem: specs don't work without README.md

### DIFF
--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -110,7 +110,16 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .if has_main
 %files
 %defattr(-,root,root)
-%doc README.md COPYING
+.if file.exists ('README.md')
+%doc README.md
+.endif
+.if file.exists ('README.txt')
+%doc README.txt
+.endif
+.if file.exists ('README.asciidoc')
+%doc README.asciidoc
+.endif
+%doc COPYING
 .# generate binary names
 .for project.main
 %{_bindir}/$(main.name)


### PR DESCRIPTION
Solution: Support other READMEs than ones written in Markdown as well
and also make the whole README support optional.