### PR TITLE
Problem: Service file generated using automake doesn't work

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -310,7 +310,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
+ExecStart=@prefix@/bin/$(main.name) @prefix@/etc/@PACKAGE@/$(main.name).cfg
 
 [Install]
 WantedBy=multi-user.target
@@ -323,7 +323,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/%i.cfg
+ExecStart=@prefix@/bin/$(main.name) @prefix@/etc/@PACKAGE@/%i.cfg
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To get into more details, service file contains path to the
configuration but during the expansion of autotools macros we end up
with variable $prefix still present after expansion.

Solution: Not trying to be extra compliant with everybody and hardcoding
config to be in ${prefix}/etc/${package}/smt.cfg