### PR TITLE
Problem: complicated fresh pointer handling in Ruby bindings

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -86,6 +86,12 @@ function resolve_ruby_container (container)
     elsif my.container.c_type = "const char *"
         my.container.ruby_ffi_type = "string"
         my.container.coerce_to_c = "String($(my.container.ruby_name:))"
+    elsif my.container.c_type = "char *"
+        if my.container.fresh
+            # if it's a fresh string that we have to free() when done with it,
+            # wrap pointer in an FFI::AutoPointer
+            my.container.coerce_to_ruby = "$(project.RubyName:)::FFI::AutoPointer.new($(my.container.ruby_name:))"
+        endif
     elsif my.container.c_type = "byte"
         my.container.ruby_ffi_type = "char"
         my.container.coerce_to_c = "Integer($(my.container.ruby_name:))"
@@ -246,6 +252,20 @@ require_relative 'ffi/version'
 
 module $(project.RubyName:)
   module FFI
+    module LibC
+      extend ::FFI::Library
+      ffi_lib ::FFI::Platform::LIBC
+      attach_function :free, [ :pointer ], :void, blocking: true
+    end
+
+    # Used to wrap fresh pointers so they can be free'd automatically, when the
+    # AutoPointer instance goes out of scope.
+    class AutoPointer < ::FFI::AutoPointer
+      def self.release(ptr)
+        LibC.free(ptr)
+      end
+    end
+
     extend ::FFI::Library
 
     def self.available?


### PR DESCRIPTION
Memory of fresh strings isn't free'd automatically when `FFI::Pointer` goes out of scope.

Solution: Wrap it in an `FFI::AutoPointer`.

Consider the following method API:

```xml
  <method name = "encode">
      Encode a stream of bytes into an armoured string.
      <argument name = "data" type = "buffer" />
      <argument name = "data size" type = "size" />
      <return type = "string" fresh = "1" />
  </method>
```

The corresponding C function might look like this:

```c
  char * foo_encode(const byte * data, size_t data_size)
```

Note that the return value is a "fresh" string, which means the caller is responsible for destroying it when finished with it. Also note that it's not a struct of the class defined in this API or any other class. It must be a C style, NULL-terminated string.

It would be nice to have the generated Ruby bindings to automatically release said memory as soon as its corresponding FFI::Pointer goes out of scope.

Luckily, there's FFI::AutoPointer for this. One just has to subclass it and define its `.release` method appropriately. This commit defines it to call libc's `free()`. I believe this is okay, assuming:

* libc is available on every system
* no project-specific function has to be used to `free()` a C style string

Honestly, I'm not 100% sure if this is a good idea. Are my assumptions valid?

Note that:

* this applies only to functions that have `char *` value, which is also marked "fresh"
* automatic release is already done in Ruby bindings for "freesh" class objects (like `zmsg_t` objects) (but using the class' destructor, of course)