### PR TITLE
Problem: superfluous class in Ruby binding

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -90,7 +90,7 @@ function resolve_ruby_container (container)
         if my.container.fresh
             # if it's a fresh string that we have to free() when done with it,
             # wrap pointer in an FFI::AutoPointer
-            my.container.coerce_to_ruby = "$(project.RubyName:)::FFI::AutoPointer.new($(my.container.ruby_name:))"
+            my.container.coerce_to_ruby = "::FFI::AutoPointer.new($(my.container.ruby_name:), LibC.method(:free))"
         endif
     elsif my.container.c_type = "byte"
         my.container.ruby_ffi_type = "char"
@@ -256,14 +256,6 @@ module $(project.RubyName:)
       extend ::FFI::Library
       ffi_lib ::FFI::Platform::LIBC
       attach_function :free, [ :pointer ], :void, blocking: true
-    end
-
-    # Used to wrap fresh pointers so they can be free'd automatically, when the
-    # AutoPointer instance goes out of scope.
-    class AutoPointer < ::FFI::AutoPointer
-      def self.release(ptr)
-        LibC.free(ptr)
-      end
     end
 
     extend ::FFI::Library


### PR DESCRIPTION
Solution: Get rid of it and pass the relevant functionality as a Method
object (which is the preferred way according to FFI documentation
anyway).

As discussed in #322.