### PR TITLE
Problem: Need to install service not related to any main

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -439,6 +439,9 @@ AC_CONFIG_FILES([Makefile
 .   for project.main where main.services ?= 1
                  src/$(main.name)@.service
 .   endfor
+.   for project.service
+                 src/$(service.name).service
+.   endfor
                  ])
 .else
 AC_CONFIG_FILES([Makefile])

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -221,6 +221,18 @@ $(project.name)_SCRIPTS = \\
     $(bin.name)
 .   endif
 .endfor
+.for service
+.   if first()
+
+$(project.name)_servicesdir = @prefix@/lib/systemd/system
+$(project.name)_services_DATA = \\
+.   endif
+.   if !last()
+    src/$(service.name).service \\
+.   else
+    src/$(service.name).service
+.   endif
+.endfor
 
 .for class where defined (class.api)
 .   if first()


### PR DESCRIPTION
Solution: Add support for new <service> tag that will install whatever
is provided. Not generating it as project wide service is probably going
to be hand made.