### PR TITLE
Problem: Can't use configuration in packages

### DIFF
--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -326,10 +326,11 @@ After=network.target
 
 [Service]
 Type=simple
+Environment="prefix=@prefix@"
 .if main.no_config ?= 1
 ExecStart=@prefix@/bin/$(main.name)
 .else
-ExecStart=@prefix@/bin/$(main.name) @prefix@/etc/@PACKAGE@/$(main.name).cfg
+ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
 .endif
 
 [Install]
@@ -343,10 +344,11 @@ After=network.target
 
 [Service]
 Type=simple
+Environment="prefix=@prefix@"
 .if main.no_config ?= 1
 ExecStart=@prefix@/bin/$(main.name) %i
 .else
-ExecStart=@prefix@/bin/$(main.name) @prefix@/etc/@PACKAGE@/%i.cfg
+ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/%i.cfg
 .endif
 
 [Install]


### PR DESCRIPTION
This is different fix following up on c687d0a. c687d0a fixed service
files generated for local installation - aka just normal configure and
make install into /usr/local but it broke installation in packages where
system config directory is explicitly overridden to end up with
configuration in etc.

Solution: Return to the previous solution using sysconfdir but also
exporting prefix variable so it should work in both cases.