### PR TITLE
Problem: ad-hoc calculation of project header name

### DIFF
--- a/zproject.gsl
+++ b/zproject.gsl
@@ -43,6 +43,8 @@ project.linkname ?= project.prefix
 project.libname ?= "lib" + project.linkname
 project.prelude ?= project.prefix + "_prelude.h"
 project.description ?= "Project"
+project.header ?= "$(project.name:c).h"
+
 if count (project.version) = 0
     new version to project
     endnew

--- a/zproject_actor.gsl
+++ b/zproject_actor.gsl
@@ -137,7 +137,7 @@ $(PROJECT.PREFIX)_EXPORT void
 @end
 */
 
-#include "../include/$(project.name).h"
+#include "../include/$(project.header:)"
 .   if (project.has_private_classes)
 #include "$(project.prefix)_classes.h"
 .   endif

--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -87,11 +87,11 @@ $(project.GENERATED_WARNING_HEADER:)
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.61)
 #
-# The version number is extracted from include/$(project.name).h using
+# The version number is extracted from include/$(project.header:) using
 # the version.sh script. Hence, it should be updated there.
 # The version in git should reflect the *next* version planned.
 #
-AC_INIT([$(project.name)],[m4_esyscmd([./version.sh $(project.name)])],[$(project.email)])
+AC_INIT([$(project.name)],[m4_esyscmd([./version.sh $(project.header:)])],[$(project.email)])
 
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
@@ -244,7 +244,7 @@ AC_CHECK_PROG($(project.name:c)_have_xmlto, xmlto, yes, no)
 if test "x$$(project.name:c)_have_asciidoc" = "xno" -o "x$$(project.name:c)_have_xmlto" = "xno"; then
     $(project.name:c)_build_doc="no"
     # Tarballs built with 'make dist' ship with prebuilt documentation.
-    if ! test -f doc/$(project.name).7; then
+    if ! test -f doc/$(project.name:c).7; then
         $(project.name:c)_install_man="no"
         AC_MSG_WARN([You are building an unreleased version of $(PROJECT.NAME) and asciidoc or xmlto are not installed.])
         AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -108,7 +108,7 @@ include_HEADERS = \\
     include/$(project.prelude) \\
 .endif
 .if count (class, class.name = project.name) = 0
-    include/$(project.name).h \\
+    include/$(project.header:) \\
 .endif
 .for header where !defined (header.private)
     include/$(name).h \\

--- a/zproject_bench.gsl
+++ b/zproject_bench.gsl
@@ -135,7 +135,7 @@ $(project.GENERATED_WARNING_HEADER:)
 @end
 */
 
-#include "../include/$(project.name).h"
+#include "../include/$(project.header:)"
 .   if (project.has_private_classes)
 #include "$(project.prefix)_classes.h"
 .   endif

--- a/zproject_bindings_qml.gsl
+++ b/zproject_bindings_qml.gsl
@@ -309,7 +309,7 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #include <QtQml>
 
-#include <$(project.name).h>
+#include <$(project.header:)>
 #include "$(project.qml_soname:)_plugin.h"
 
 

--- a/zproject_bindings_qt.gsl
+++ b/zproject_bindings_qt.gsl
@@ -449,7 +449,7 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #include <QObject>
 #include <QString>
-#include <$(project.name).h>
+#include <$(project.header:)>
 
 #if defined(Q_OS_WIN)
 #  if !defined(QT_$(PROJECT.NAME:c)_EXPORT) && !defined(QT_$(PROJECT.NAME:c)_IMPORT)

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -5,7 +5,7 @@
 .#   See project.xml for instructions on how to specify a class.
 .#
 .#  This script will generate the following files:
-.#      * include/$(project.name).h - public project header (once)
+.#      * include/$(project.header:) - public project header (once)
 .#      * src/$(project.prefix)_selftest.c - selftest class
 .#      * src/$(project.prefix)_classes.h - private project header
 .#      * (include|src)$(class.c_name).h - public/private header file for classes
@@ -21,7 +21,7 @@
 .if !file.exists ("include")
 .   directory.create ("include")
 .endif
-.project_header_file = "include/$(project.name:c).h"
+.project_header_file = "include/$(project.header:)"
 .if !file.exists (project_header_file) & count (class, class.name = project.name) = 0
 .   output project_header_file
 /*  =========================================================================
@@ -309,7 +309,7 @@ $(project.GENERATED_WARNING_HEADER:)
 #define $(PROJECT.PREFIX:c)_CLASSES_H_INCLUDED
 
 //  External API
-#include "../include/$(project.name:c).h"
+#include "../include/$(project.header:)"
 
 //  Internal API
 .for class where defined (class.private)
@@ -412,7 +412,7 @@ $(PROJECT.PREFIX:c)_EXPORT void
 @end
 */
 
-#include "../include/$(project.name).h"
+#include "../include/$(project.header:)"
 .   if (project.has_private_classes)
 #include "$(project.prefix)_classes.h"
 .   endif

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -25,7 +25,7 @@ foreach(which MAJOR MINOR PATCH)
     file(STRINGS "${SOURCE_DIR}/include/$(project.prefix)_library.h" $(PROJECT.NAME)_VERSION_STRING REGEX "#define $(PROJECT.NAME)_VERSION_${which}")
     string(REGEX MATCH "#define $(PROJECT.NAME)_VERSION_${which} ([0-9_]+)" $(PROJECT.NAME)_REGEX_MATCH "${$(PROJECT.NAME)_VERSION_STRING}")
     if (NOT $(PROJECT.NAME)_REGEX_MATCH)
-        message(FATAL_ERROR "failed to parse $(PROJECT.NAME)_VERSION_${which} from $(project.name).h")
+        message(FATAL_ERROR "failed to parse $(PROJECT.NAME)_VERSION_${which} from $(project.header:)")
     endif()
     set($(PROJECT.NAME)_${which}_VERSION ${CMAKE_MATCH_1})
 endforeach(which)
@@ -111,7 +111,7 @@ set ($(project.name)_headers
     include/$(project.prelude)
 .endif
 .if count (class, class.name = project.name) = 0
-    include/$(project.name:c).h
+    include/$(project.header:)
 .endif
 .for header where !defined (header.private)
     include/$(name:c).h

--- a/zproject_docs.gsl
+++ b/zproject_docs.gsl
@@ -150,7 +150,7 @@ $(project.name:c) - $(project.description:)
 SYNOPSIS
 --------
 ----
-#include <$(project.name:c).h>
+#include <$(project.header:)>
 
 cc ['flags'] 'files' -l$(project.linkname) ['libraries']
 ----

--- a/zproject_vs2008.gsl
+++ b/zproject_vs2008.gsl
@@ -317,7 +317,7 @@ $(project.GENERATED_WARNING_HEADER:)
       <File RelativePath="..\\..\\..\\..\\include\\$(project.prelude)" />
 .endif
 .if count (class, class.name = project.name) = 0
-      <File RelativePath="..\\..\\..\\..\\include\\$(project.name:c).h" />
+      <File RelativePath="..\\..\\..\\..\\include\\$(project.header:)" />
 .endif
 .for header where !defined (header.private)
       <File RelativePath="..\\..\\..\\..\\include\\$(name:c).h" />

--- a/zproject_vs2010.gsl
+++ b/zproject_vs2010.gsl
@@ -89,7 +89,7 @@ $(project.GENERATED_WARNING_HEADER:)
     <ClInclude Include="..\\..\\..\\..\\include\\$(project.prelude)" />
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h" />
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)" />
 .endif
 .for header where !defined (header.private)
     <ClInclude Include="..\\..\\..\\..\\include\\$(name:c).h" />
@@ -144,7 +144,7 @@ $(project.GENERATED_WARNING_HEADER:)
     </ClInclude>
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h">
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)">
       <Filter>include</Filter>
     </ClInclude>
 .endif

--- a/zproject_vs2012.gsl
+++ b/zproject_vs2012.gsl
@@ -89,7 +89,7 @@ $(project.GENERATED_WARNING_HEADER:)
     <ClInclude Include="..\\..\\..\\..\\include\\$(project.prelude)" />
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h" />
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)" />
 .endif
 .for header where !defined (header.private)
     <ClInclude Include="..\\..\\..\\..\\include\\$(name:c).h" />
@@ -144,7 +144,7 @@ $(project.GENERATED_WARNING_HEADER:)
     </ClInclude>
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h">
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)">
       <Filter>include</Filter>
     </ClInclude>
 .endif

--- a/zproject_vs2013.gsl
+++ b/zproject_vs2013.gsl
@@ -89,7 +89,7 @@ $(project.GENERATED_WARNING_HEADER:)
     <ClInclude Include="..\\..\\..\\..\\include\\$(project.prelude)" />
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h" />
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)" />
 .endif
 .for header where !defined (header.private)
     <ClInclude Include="..\\..\\..\\..\\include\\$(name:c).h" />
@@ -144,7 +144,7 @@ $(project.GENERATED_WARNING_HEADER:)
     </ClInclude>
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h">
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)">
       <Filter>include</Filter>
     </ClInclude>
 .endif

--- a/zproject_vs2015.gsl
+++ b/zproject_vs2015.gsl
@@ -89,7 +89,7 @@ $(project.GENERATED_WARNING_HEADER:)
     <ClInclude Include="..\\..\\..\\..\\include\\$(project.prelude)" />
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h" />
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)" />
 .endif
 .for header where !defined (header.private)
     <ClInclude Include="..\\..\\..\\..\\include\\$(name:c).h" />
@@ -144,7 +144,7 @@ $(project.GENERATED_WARNING_HEADER:)
     </ClInclude>
 .endif
 .if count (class, class.name = project.name) = 0
-    <ClInclude Include="..\\..\\..\\..\\include\\$(project.name:c).h">
+    <ClInclude Include="..\\..\\..\\..\\include\\$(project.header:)">
       <Filter>include</Filter>
     </ClInclude>
 .endif


### PR DESCRIPTION
The scripts used $(project.name:c).h in general. However for a first
class attribute of project, this seems fragile.

Solution: calculate project.header attribute at start and use in all
places it's needed.

Bonus: can be explicitly specified in project item if needed.