### PR TITLE
PROBLEM: "include/$(project.header:)" generates a wrong file name

### DIFF
--- a/zproject.gsl
+++ b/zproject.gsl
@@ -43,7 +43,7 @@ project.linkname ?= project.prefix
 project.libname ?= "lib" + project.linkname
 project.prelude ?= project.prefix + "_prelude.h"
 project.description ?= "Project"
-project.header ?= "$(project.name:c).h"
+project.header ?= "$(project.name:).h"
 
 if count (project.version) = 0
     new version to project


### PR DESCRIPTION
Project <project name = "alerts-list" ...> ... </project>
generated 'include/alerts_list.h' instead of 'include/alerts-list.h' and
`make` did not compile.

SOLUTION: fix it by having zproject generate correct name of gsl
variable 'project.header'.