### PR TITLE
Revert "PROBLEM: "include/$(project.header:)" generates a wrong file name"

### DIFF
--- a/zproject.gsl
+++ b/zproject.gsl
@@ -43,7 +43,7 @@ project.linkname ?= project.prefix
 project.libname ?= "lib" + project.linkname
 project.prelude ?= project.prefix + "_prelude.h"
 project.description ?= "Project"
-project.header ?= "$(project.name:).h"
+project.header ?= "$(project.name:c).h"
 
 if count (project.version) = 0
     new version to project


### PR DESCRIPTION
Reverts zeromq/zproject#345

This is an invalid problem. CLASS does not allow a minus in file names instead everything MUST be separated by an underscore.