### PR TITLE
Problem: <use><class> is redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,21 @@
 &emsp;<a href="#toc3-502">Supported API Model Attributes</a>
 &emsp;<a href="#toc3-518">Tips</a>
 
-**<a href="#toc2-529">Removal</a>**
-&emsp;<a href="#toc3-532">autotools</a>
+**<a href="#toc2-529">Language Binding Notes</a>**
+&emsp;<a href="#toc3-532">JNI Language Binding</a>
 
-**<a href="#toc2-539">Notes for Writing Language Bindings</a>**
-&emsp;<a href="#toc3-542">Schema/Architecture Overview</a>
-&emsp;<a href="#toc3-561">Informal Summary</a>
-&emsp;<a href="#toc3-566">Semantic Attributes</a>
-&emsp;<a href="#toc3-603">Language-Specific Implementation Attributes</a>
+**<a href="#toc2-540">Removal</a>**
+&emsp;<a href="#toc3-543">autotools</a>
 
-**<a href="#toc2-614">Ownership and License</a>**
-&emsp;<a href="#toc3-623">Hints to Contributors</a>
-&emsp;<a href="#toc3-632">This Document</a>
+**<a href="#toc2-550">Notes for Writing Language Bindings</a>**
+&emsp;<a href="#toc3-553">Schema/Architecture Overview</a>
+&emsp;<a href="#toc3-572">Informal Summary</a>
+&emsp;<a href="#toc3-577">Semantic Attributes</a>
+&emsp;<a href="#toc3-614">Language-Specific Implementation Attributes</a>
+
+**<a href="#toc2-625">Ownership and License</a>**
+&emsp;<a href="#toc3-634">Hints to Contributors</a>
+&emsp;<a href="#toc3-643">This Document</a>
 
 <A name="toc2-11" title="Overview" />
 ## Overview
@@ -523,7 +526,7 @@ Language bindings will also be generated in the following languages:
 * QML
 * Qt
 * Python
-* JNI (experimental)
+* JNI
 
 The language bindings are minimal, meant to be wrapped in a handwritten idiomatic layer later.
 
@@ -554,20 +557,31 @@ echo method.string()  # will print the model as an XML string.
 method.save(filename) # will save the model as an XML string to the given file.
 ```
 
-<A name="toc2-529" title="Removal" />
+<A name="toc2-529" title="Language Binding Notes" />
+## Language Binding Notes
+
+<A name="toc3-532" title="JNI Language Binding" />
+### JNI Language Binding
+
+* Skips methods that it cannot handle properly.
+
+* To build, you need gradle (or equivalent). Run 'gradle build jar' in the bindings/jni directory.
+* To install, run 'gradle install'. This puts the files into $HOME/.m2/repository.
+
+<A name="toc2-540" title="Removal" />
 ## Removal
 
-<A name="toc3-532" title="autotools" />
+<A name="toc3-543" title="autotools" />
 ### autotools
 
 ```sh
 make uninstall
 ```
 
-<A name="toc2-539" title="Notes for Writing Language Bindings" />
+<A name="toc2-550" title="Notes for Writing Language Bindings" />
 ## Notes for Writing Language Bindings
 
-<A name="toc3-542" title="Schema/Architecture Overview" />
+<A name="toc3-553" title="Schema/Architecture Overview" />
 ### Schema/Architecture Overview
 
 * All `class`es SHALL be in the project model (`project.xml`).
@@ -586,12 +600,12 @@ make uninstall
 * Each language binding generator MAY assign values to language-specific implementation attributes of entities.
 * Each language binding generator SHOULD use a unique prefix for names of language-specific implementation attributes of entities.
 
-<A name="toc3-561" title="Informal Summary" />
+<A name="toc3-572" title="Informal Summary" />
 ### Informal Summary
 
 A `class` is always the top-level entity in an API model, and it will be merged with the corresponding `class` entity defined in the project model. A class contains `method`s, `constructor`s, and `destructor`s (collectively, "method"s), and methods contain `argument`s and `return`s (collectively, "container"s). Each entity will contain both *semantic attributes* and *language-specific implementation attributes*.
 
-<A name="toc3-566" title="Semantic Attributes" />
+<A name="toc3-577" title="Semantic Attributes" />
 ### Semantic Attributes
 
 Semantic attributes describe something intrinsic about the container.
@@ -628,7 +642,7 @@ container.variadic     # 0/1 (default: 0)
 container.va_start     # string - that holds the argment name for va_start ()
 ```
 
-<A name="toc3-603" title="Language-Specific Implementation Attributes" />
+<A name="toc3-614" title="Language-Specific Implementation Attributes" />
 ### Language-Specific Implementation Attributes
 
 Language-specific implementation attributes hold information that is not intrinsic to the concept of the container, but to the binding implementation.
@@ -639,7 +653,7 @@ However, because the container is shared between all generators, which are run i
 
 It is also important that language-specific implementation attributes use a naming convention that avoids collisions. The easiest way to avoid collisions is to prefix all language-specific attributes with the name of the language, though in principle, any collision-free convention would be acceptable.
 
-<A name="toc2-614" title="Ownership and License" />
+<A name="toc2-625" title="Ownership and License" />
 ## Ownership and License
 
 The contributors are listed in AUTHORS. This project uses the MPL v2 license, see LICENSE.
@@ -648,7 +662,7 @@ zproject uses the [C4.1 (Collective Code Construction Contract)](http://rfc.zero
 
 To report an issue, use the [zproject issue tracker](https://github.com/zeromq/zproject/issues) at github.com.
 
-<A name="toc3-623" title="Hints to Contributors" />
+<A name="toc3-634" title="Hints to Contributors" />
 ### Hints to Contributors
 
 Make sure that the project model hides all details of backend scripts. For example don't make a user enter a header file because autoconf needs it.
@@ -657,7 +671,7 @@ Do read your code after you write it and ask, "Can I make this simpler?" We do u
 
 Before opening a pull request read our [contribution guidelines](https://github.com/zeromq/zproject/blob/master/CONTRIBUTING.md). Thanks!
 
-<A name="toc3-632" title="This Document" />
+<A name="toc3-643" title="This Document" />
 ### This Document
 
 This document is originally at README.txt and is built using [gitdown](http://github.com/imatix/gitdown).

--- a/README.txt
+++ b/README.txt
@@ -210,6 +210,7 @@ method.save(filename) # will save the model as an XML string to the given file.
 * Skips methods that it cannot handle properly.
 
 * To build, you need gradle (or equivalent). Run 'gradle build jar' in the bindings/jni directory.
+* To install, run 'gradle install'. This puts the files into $HOME/.m2/repository.
 
 ## Removal
 

--- a/zproject_bindings_python.gsl
+++ b/zproject_bindings_python.gsl
@@ -28,9 +28,9 @@ function python_register_type (container, struct, pointer)
 
     # First we need to determine whether we're 'importing' this type via
     # class declarations under the 'use' node.
-    for project.use
-        for use.class where class.name = my.container.type
-            my.externlib = use.project
+    for project.dependencies
+        for class where class.name = my.container.type
+            my.externlib = class.project
             last
         endfor
     endfor

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -325,11 +325,12 @@ function resolve_container_dependencies (class_name, container)
             for dir.directory
                 api_file = directory.path + directory.name + "/"  + "$(my.container.type:c).xml"
                 if resolved = 0 & file.exists (api_file)
-                    new_dependency = XML.load_file (api_file)
-                    new_dependency.api_dir = directory.path + directory.name + "/"
-                    new_dependency.resolved = 0
-                    resolve_c_class (new_dependency)
-                    move new_dependency to project->dependencies
+                    dependency = XML.load_file (api_file)
+                    dependency.api_dir = directory.path + directory.name + "/"
+                    dependency.resolved = 0
+                    dependency.project = directory.name
+                    resolve_c_class (dependency)
+                    move dependency to project->dependencies
                     resolved = 1
                 endif
             endfor


### PR DESCRIPTION
Solution: add project attribute to dependent classes
and use this instead of asking user to list all dependent
classes again.

This removes the need to manually list dependent classes
in every used project.

Fixes #353