### PR TITLE
Revert "Problem: unnecessary Ruby exception classes"

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -297,11 +297,6 @@ module $(project.RubyName:)
 
     extend ::FFI::Library
 
-    # Raised when one tries to use an instance of one of the classes in the
-    # {$(project.RubyName:)::FFI} namespace after the internal pointer to the
-    # native object has been nullified.
-    class DestroyedError < RuntimeError; end
-
     def self.available?
       @available
     end
@@ -363,6 +358,10 @@ module $(project.RubyName:)
     # @note This class is 100% generated using zproject.
 .    # TODO: extract boilerplate into a reusable module
     class $(class.RubyName:)
+      # Raised when one tries to use an instance of {$(class.RubyName:)} after
+      # the internal pointer to the native object has been nullified.
+      class DestroyedError < RuntimeError; end
+
       # Boilerplate for self pointer, initializer, and finalizer
       class << self
         alias :__new :new


### PR DESCRIPTION
According to discussion on
https://github.com/paddor/zproject/commit/908c355984010d3f42e518c2f6066eac33019477

This reverts commit 908c355984010d3f42e518c2f6066eac33019477.