### PR TITLE
Problem: zproject_bindings_jni fails to run

### DIFF
--- a/zproject_bindings_jni.gsl
+++ b/zproject_bindings_jni.gsl
@@ -17,6 +17,9 @@
 global.namespace ?= switches.namespace? "org.zeromq.$(project.prefix)"
 global.name_path ?= switches.name_path? "org/zeromq/$(project.prefix)"
 global.topdir ?= switches.topdir? "bindings/jni"
+if !file.exists ("$(global.topdir)")
+   directory.create("$(global.topdir)")
+endif
 
 ### Generate CMake infrastructure
 
@@ -82,6 +85,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
+.if defined (project->dependencies)
 .   for project.use
 .       if count (project->dependencies.class, class.project = use.project) > 0
     compile 'org.zeromq:$(use.project)-jni:0.1.0-SNAPSHOT'
@@ -89,6 +93,7 @@ dependencies {
 .   endfor
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
+.endif
 }
 task generateJniHeaders(type: Exec, dependsOn: 'classes') {
     def classpath = sourceSets.main.output.classesDir


### PR DESCRIPTION
Solution:
 1. create topdir if does not exists
 2. skip dependencies if project->dependencies are not defined