### PR TITLE
Problem: spec with private main fails to build

### DIFF
--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -121,7 +121,7 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .endif
 %doc COPYING
 .# generate binary names
-.for project.main
+.for project.main where !defined (main.private)
 %{_bindir}/$(main.name)
 .endfor
 .# generate service file names


### PR DESCRIPTION
Solution: do not put main if private is defined to filelist