### PR TITLE
Revert "Problem: language bindings can't handle multiple constructors"

### DIFF
--- a/zproject_bindings_jni.gsl
+++ b/zproject_bindings_jni.gsl
@@ -616,7 +616,7 @@ import org.zeromq.$(use.project).*;
 
 public class $(my.class.name:pascal) \
 .   if count (my.class.constructor)
-implements AutoCloseable \
+implements AutoCloseable\
 .   endif
 {
     static {

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -279,9 +279,6 @@ function resolve_c_class (class)
             move ret before method->return # Move to first slot
         endnew
         resolve_c_method (method, "Create a new $(my.class.c_name).")
-        if item () > 1
-            move method after class->constructor as method
-        endif
     endfor
 
     for my.class.destructor as method


### PR DESCRIPTION
This reverts commit 3d9bdde4208907066338e1ad88f37a12f5e46409.

This problem seems only half valid. See #368 