### PR TITLE
Problem: installation of tmpfiles.d files is hacky in zproject

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -442,6 +442,9 @@ AC_CONFIG_FILES([Makefile
 .   for project.service
                  src/$(service.name).service
 .   endfor
+.   for project.main where main.tmpfiles ?= 1
+                 src/$(main.name).conf
+.   endfor
                  ])
 .else
 AC_CONFIG_FILES([Makefile])

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -205,6 +205,10 @@ src_$(main.name:c)_service_DATA = src/$(main.name).service
 src_$(main.name:c)_service_DATA = src/$(main.name)@.service
 .   endif
 .   endif
+.   if main.tmpfiles ?= 1
+src_$(main.name:c)_tmpfilesdir = @prefix@/lib/tmpfiles.d/
+src_$(main.name:c)_tmpfiles_DATA = src/$(main.name).conf
+.   endif
 endif
 .endfor
 .for bin
@@ -358,6 +362,16 @@ ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/%i.cfg
 [Install]
 WantedBy=multi-user.target
 .endif
+.endfor
+.# Generate tmpfiles support
+.for project.main where main.tmpfiles ?= 1
+.   if !file.exists ("src/$(main.name).conf.in")
+.       output "src/$(main.name).conf.in"
+# create runtime directories for $(main.name)
+# see http://www.freedesktop.org/software/systemd/man/tmpfiles.d.html for help
+d @localstatedir@/lib/@PACKAGE@/$(main.name) 0755 root root
+x @localstatedir@/lib/@PACKAGE@/$(main.name)*
+.   endif
 .endfor
 .close
 .-

--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -142,6 +142,10 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .for project.service
 %{_prefix}/lib/systemd/system/$(service.name)*.service
 .endfor
+.# generate tmpfiles.d file names
+.for project.main where tmpfiles ?= 1
+%{_prefix}/lib/tmpfiles.d/$(main.name).cfg
+.endfor
 .endif
 
 %changelog


### PR DESCRIPTION
Solution: add support for main attribute tmpfiles = "1" (like service =
"1"), which generates template of proper tmpfiles.d config snippet.

Supported in autotools and spec generators