### PR TITLE
Revert "Problem: installation of tmpfiles.d files is hacky in zproject"

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -442,9 +442,6 @@ AC_CONFIG_FILES([Makefile
 .   for project.service
                  src/$(service.name).service
 .   endfor
-.   for project.main where main.tmpfiles ?= 1
-                 src/$(main.name).conf
-.   endfor
                  ])
 .else
 AC_CONFIG_FILES([Makefile])

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -205,10 +205,6 @@ src_$(main.name:c)_service_DATA = src/$(main.name).service
 src_$(main.name:c)_service_DATA = src/$(main.name)@.service
 .   endif
 .   endif
-.   if main.tmpfiles ?= 1
-src_$(main.name:c)_tmpfilesdir = @prefix@/lib/tmpfiles.d/
-src_$(main.name:c)_tmpfiles_DATA = src/$(main.name).conf
-.   endif
 endif
 .endfor
 .for bin
@@ -362,16 +358,6 @@ ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/%i.cfg
 [Install]
 WantedBy=multi-user.target
 .endif
-.endfor
-.# Generate tmpfiles support
-.for project.main where main.tmpfiles ?= 1
-.   if !file.exists ("src/$(main.name).conf.in")
-.       output "src/$(main.name).conf.in"
-# create runtime directories for $(main.name)
-# see http://www.freedesktop.org/software/systemd/man/tmpfiles.d.html for help
-d @localstatedir@/lib/@PACKAGE@/$(main.name) 0755 root root
-x @localstatedir@/lib/@PACKAGE@/$(main.name)*
-.   endif
 .endfor
 .close
 .-

--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -142,10 +142,6 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .for project.service
 %{_prefix}/lib/systemd/system/$(service.name)*.service
 .endfor
-.# generate tmpfiles.d file names
-.for project.main where tmpfiles ?= 1
-%{_prefix}/lib/tmpfiles.d/$(main.name).cfg
-.endfor
 .endif
 
 %changelog


### PR DESCRIPTION
This reverts commit 504a6629fcfd4530e4d4bf4ac2b0f51d2dd493c5.

Per discussion on github I do agree with @hintjens that current
solutions exposes too many low-level details in the model. Lets drop it.