### PR TITLE
[RFC] Problem: main started to gain too many low level attributes

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -442,6 +442,9 @@ AC_CONFIG_FILES([Makefile
 .   for project.service
                  src/$(service.name).service
 .   endfor
+.   for project.main where defined (main->extra)
+                 src/$(main->extra.name)
+.   endfor
                  ])
 .else
 AC_CONFIG_FILES([Makefile])

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -205,6 +205,11 @@ src_$(main.name:c)_service_DATA = src/$(main.name).service
 src_$(main.name:c)_service_DATA = src/$(main.name)@.service
 .   endif
 .   endif
+
+.for project.main where defined (main->extra)
+src_$(main.name:c)_$(main->extra.type:c)dir = $(main->extra.path)
+src_$(main.name:c)_$(main->extra.type:c)_DATA = src/$(main->extra.name)
+.endfor
 endif
 .endfor
 .for bin

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -55,4 +55,17 @@ for use
     resolve_project_dependency (use)
 endfor
 
+function resolve_extra (main)
+    for extra where defined (extra.type)
+        if main->extra.type = "systemd-tmpfiles"
+            main->extra.name ?= "$(main.name).conf"
+            main->extra.path ?= "/usr/lib/tmpfiles.d"
+        endif
+    endfor
+endfunction
+
+for main
+    resolve_extra (main)
+endfor
+
 .endtemplate

--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -142,6 +142,12 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .for project.service
 %{_prefix}/lib/systemd/system/$(service.name)*.service
 .endfor
+
+.for project.main where defined (main->extra)
+#file for type $(main->extra.type)
+%dir $(main->extra.path)
+$(main->extra.path)/$(main->extra.name)
+.endfor
 .endif
 
 %changelog


### PR DESCRIPTION
Solution: add a support for new subelement <extra
type="systemd-tmpfiles" />. This way one can define additional data to
be installed without polluting main itself.

@hintjens feel free to express your opinions before merge. However I must say I like this approach :)

This extends already existing extra element by adding type parameter.
```
    <main name = "foo" service="1"> Some daemon
        <extra type="systemd-tmpfiles" />
    </main>
```
The idea is that type will contain the name and installation location implicitly.

With this approach one can add type "systemd-service" and "systemd-service@" (or "systemd-service-template"??) and deprecate all attributes for main element.
