### PR TITLE
Problem: C: empty parameter list: no void

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -449,6 +449,9 @@ function c_method_declaration (method, implementation_style)
         endif
         my.current_argument_index += 1
     endfor
+    if my.current_argument_index = 0 # no arguments
+        out += "void" ?
+    endif
     out += ")"
     if my.format_index >= 0
         out += " CHECK_PRINTF (" + (my.format_index) + ")"

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -450,7 +450,7 @@ function c_method_declaration (method, implementation_style)
         my.current_argument_index += 1
     endfor
     if my.current_argument_index = 0 # no arguments
-        out += "void" ?
+        out += "void"
     endif
     out += ")"
     if my.format_index >= 0


### PR DESCRIPTION
generates:
```c
	zthing * zthing_new()
```
instead of:
```c
	zthing * zthing_new(void)
```

Solution: specify ```void``` if no arguments in API model