### PR TITLE
Problem: JNI binding traps SIGINT

### DIFF
--- a/zproject_bindings_jni.gsl
+++ b/zproject_bindings_jni.gsl
@@ -701,6 +701,10 @@ $(jni_shim_signature_c:))
 .       endif
 .   endfor
 .#
+.   if name = "new"
+    //  Disable CZMQ signal handling; allow Java to deal with it
+    zsys_handler_set (NULL);
+.   endif
 .   if ->return.type = "nothing"
     $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
 .       my.return = ""


### PR DESCRIPTION
This makes it impossible to kill a Java app using Ctrl-C.

Solution: disable CZMQ's SIGINT handling, when using JNI. A Java
app will still need to handle signals itself.

Note: this solution may not be valid; it still needs testing. The
usual technique in CZMQ apps is to trap SIGINT and then provide a
global (zsys_interrupted) that applications can check. Further, to
interrupt any blocking calls (recv) and return null.

I think we need to expose these two features to language bindings
via a new class in CZMQ.