### PR TITLE
Problem: can't pass null pointer in Ruby binding

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -94,9 +94,8 @@ function resolve_ruby_container (container)
         my.container.ruby_ffi_type = "bool"
         my.container.coerce_to_c = "!(0==$(my.container.ruby_name:)||!$(my.container.ruby_name:)) # boolean"
     elsif my.container.c_type = "const char *"
-        my.container.ruby_doc_type = "String, #to_str, #to_s"
+        my.container.ruby_doc_type = "String, #to_s, nil"
         my.container.ruby_ffi_type = "string"
-        my.container.coerce_to_c = "String($(my.container.ruby_name:))"
     elsif my.container.c_type = "char *"
         if my.container.fresh
             my.container.ruby_doc_return_type = "::FFI::AutoPointer"


### PR DESCRIPTION
This applies to the `const char *` parameters, which are declared to the FFI library as `:string`, rather than `:pointer` (for convenience).

Unfortunately, the pretty strict coercion into a String will also coerce `nil` into the empty string. Removing the coercion alltogether solves the problem, as FFI would call #to_s on the argument to coerce it anyway.

Solution: don't force coercion into a String


