### PR TITLE
Problem: need to undefine the finalizer in Ruby binding

### DIFF
--- a/zproject_bindings_ruby.gsl
+++ b/zproject_bindings_ruby.gsl
@@ -425,10 +425,17 @@ module $(project.RubyName:)
         raise DestroyedError unless @ptr
         ptr_ptr = ::FFI::MemoryPointer.new :pointer
         ptr_ptr.write_pointer @ptr
-        ObjectSpace.undefine_finalizer self if @finalizer
-        @finalizer = nil
+        __undef_finalizer if @finalizer
         @ptr = nil
         ptr_ptr
+      end
+      # Undefines the finalizer for this object.
+      # @note Only use this if you need to and can guarantee that the native
+      #   object will be freed by other means.
+      # @return [void]
+      def __undef_finalizer
+        ObjectSpace.undefine_finalizer self
+        @finalizer = nil
       end
 .for callback_type
 


### PR DESCRIPTION
Of course it's possible to hack around this in Ruby, but it's nicer to
have it available in a method like this.

Solution: extract undefining logic into a new method #__undef_finalizer