### PR TITLE
Project: system(d) files installation "leaks" to normal build

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -426,13 +426,34 @@ AS_IF([test "$have_ld_version_script" = "yes"],
 ])
 .endif
 
+# enable specific system integration features
+AC_ARG_WITH([systemd],
+    AS_HELP_STRING([--with-systemd],
+    [Build and install with systemd integration [default=no].]),
+    [with_systemd=$withval],
+    [with_systemd=no])
+
+AM_CONDITIONAL([WITH_SYSTEMD], [test x$with_systemd != xno])
+
+AM_COND_IF([WITH_SYSTEMD],
+    [PKG_CHECK_MODULES([SYSTEMD], [systemd >= 200], [],
+        [AC_MSG_ERROR([Cannot find required package for systemd. Note, pkg-config is required due to specified version >= 200])])],
+    [])
+
 # Specify output files
-.if count (class) + count (ac_config) + count (main, service ?= 1) + count (main, services ?= 1)  > 0
+.if count (class) + count (ac_config)  > 0
 AC_CONFIG_FILES([Makefile
 .   if count (class) > 0
                  doc/Makefile
                  src/$(project.libname).pc
 .   endif
+                 ])
+.else
+AC_CONFIG_FILES([Makefile])
+.endif
+
+AM_COND_IF([WITH_SYSTEMD],
+    [AC_CONFIG_FILES([
 .   for project.main where main.service ?= 1
                  src/$(main.name).service
 .   endfor
@@ -442,13 +463,12 @@ AC_CONFIG_FILES([Makefile
 .   for project.service
                  src/$(service.name).service
 .   endfor
-.   for project.main where defined (main->extra)
+.   for project.main where (defined (main->extra) & extra.type ?= systemd-tmpfiles)
                  src/$(main->extra.name)
 .   endfor
-                 ])
-.else
-AC_CONFIG_FILES([Makefile])
-.endif
-AC_OUTPUT
+    ])],
+    [])
 
+
+AC_OUTPUT
 $(project.GENERATED_WARNING_HEADER:)

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -189,6 +189,7 @@ src_$(name:c)_SOURCES = src/$(name).cc
 .   else
 src_$(name:c)_SOURCES = src/$(name).c
 .   endif
+if WITH_SYSTEMD
 .   if main.service ?= 1 | main.services ?= 1
 src_$(main.name:c)_servicedir = @prefix@/lib/systemd/system
 .   if ! (main.no_config ?= 1)
@@ -205,12 +206,13 @@ src_$(main.name:c)_service_DATA = src/$(main.name).service
 src_$(main.name:c)_service_DATA = src/$(main.name)@.service
 .   endif
 .   endif
-
-.for project.main where defined (main->extra)
+.for project.main where (defined (main->extra) & extra.type ?= systemd-tmpfiles)
 src_$(main.name:c)_$(main->extra.type:c)dir = $(main->extra.path)
 src_$(main.name:c)_$(main->extra.type:c)_DATA = src/$(main->extra.name)
 .endfor
-endif
+endif #WITH_SYSTEMD
+
+endif #WITH_$(NAME:c)
 .endfor
 .for bin
 .   if first()


### PR DESCRIPTION
Solution: "isolate" configure.ac/Makefile.am behind WITH_SYSTEMD
conditional, so service="1" and <extra type="systemd-tmpfiles"> are
built and installed only if configure --with-systemd is used.

@hintjens this implements your advice regarding system integration - it does not touch the model, just "isolates" unportable parts in build description.