### PR TITLE
Problem: Cannot write an api for actors without exposing the actor method to the bindings.

### DIFF
--- a/api/myclass.xml
+++ b/api/myclass.xml
@@ -1,5 +1,5 @@
 <!--
-    This model defines a public API for binding. 
+    This model defines a public API for binding.
 
     It shows a language binding developer what to expect from the API XML
     files.
@@ -33,6 +33,25 @@
         * is passed by reference
         * is marked as the self pointer for the destructor (`destructor_self = "1"`)
     </destructor>
+
+    <!-- This models an CZMQ actor. By default the actor method equals the
+         class name.
+    -->
+    <actor>
+        To work with my_actor, use the CZMQ zactor API:
+
+        Create new my_actor instance.
+
+            zactor_t *actor = zactor_new (my_actor, NULL);
+
+        Destroy my_actor instance
+
+            zactor_destroy (&amp;actor);
+
+        Enable verbose logging of commands and activity:
+
+            zstr_send (actor, "VERBOSE");
+    </actor>
 
     <!-- This models a method with no return value -->
     <method name = "sleep">

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -572,6 +572,12 @@ $(c_method_declaration (method):)
 $(c_method_declaration (method):)
 .endfor
 .-
+.for class.actor
+
+//  $(actor.description:no,block)
+$(c_actor_declaration (actor):)
+.endfor
+.-
 .for class.method
 
 //  $(method.description:no,block)

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -162,6 +162,17 @@ function resolve_c_container (container)
     my.container.c_type = my.c_type
 endfunction
 
+
+# Resolve missing or implicit details in a C method model.
+#
+# Here, "actor" refers to a <actor/> entity in the model XML.
+#
+function resolve_c_actor (actor, default_description)
+    # Resolve semantic attributes
+    my.actor.description ?= "$(string.trim (my.actor.?my.default_description):left)"
+endfunction
+
+
 # Resolve missing or implicit details in a C method model.
 #
 # Here, "method" refers to a <method/> entity in the model XML.
@@ -255,6 +266,12 @@ function resolve_c_class (class)
     # Resolve details of each method
     for my.class.callback_type as method
         resolve_c_method (method, "")
+    endfor
+
+    # Resolve details of an actor
+    for my.class.actor
+        actor.name ?= "$(class.name:c)"
+        resolve_c_actor (actor, "")
     endfor
 
     for my.class.method
@@ -400,9 +417,19 @@ if defined (project->dependencies) & count (project->dependencies.class)
     endwhile
 endif
 
+
 ##
 # The following functions are entirely C-specific code generation helpers.
 # They contain no useful information for higher-level language bindings.
+#
+# Construct the string for a actor declaration in a C header
+#
+function c_actor_declaration (method)
+    out =  "$(PROJECT.PREFIX:c)_EXPORT void\n"
+    out += "    $(actor.name:c) (zsock_t *pipe, void *args);"
+    return out
+endfunction
+
 #
 # Construct the string for a method declaration in a C header
 #
@@ -462,7 +489,9 @@ function c_method_declaration (method, implementation_style)
     return out
 endfunction
 
+#
 # Construct the string for a callback typedef in a C header
+#
 function c_callback_typedef (method)
     out = "typedef $(my.method->return.c_type:) "
     out += "($(class.c_name)_$(my.method.c_name)) ("


### PR DESCRIPTION
Solution: Declare an actor within a class. This allows the c generation
to generate the appropriate actor callback method but hides the callback
from the bindings.