### PR TITLE
Problem: build scripts don't need full git history

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -126,7 +126,7 @@ export TOOLCHAIN_ARCH="arm"
 
 .for use where defined (use.repository)
 export $(USE.PROJECT)_ROOT="/tmp/$(use.project)"
-git clone $(use.repository) $$(USE.PROJECT)_ROOT
+git clone --depth 1 $(use.repository) $$(USE.PROJECT)_ROOT
 
 .endfor
 source ./build.sh

--- a/zproject_ci.gsl
+++ b/zproject_ci.gsl
@@ -47,7 +47,7 @@ if [ $BUILD_TYPE == "default" ]; then
 
     # Clone and build dependencies
 .for use where defined (use.repository)
-    git clone $(use.repository) $(use.project)
+    git clone --depth 1 $(use.repository) $(use.project)
     ( cd $(use.project) && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make check && make install ) || exit 1
 
 .endfor


### PR DESCRIPTION
Solution: add `--depth 1` parameter to `git clone` commands
