### PR TITLE
Problem: systemd integration not enabled by default

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -43,7 +43,8 @@ Build-Depends: bison, debhelper (>= 8),
     lib$(string.replace (use.libname, "_|-"))-dev,
 .endif
 .endfor
-    dh-autoreconf
+    dh-autoreconf,
+    systemd
 
 .if project.has_classes
 Package: $(string.replace (project.libname, "_|-"))$(project->version.major)
@@ -137,6 +138,10 @@ override_dh_strip:
 
 override_dh_auto_test:
 	echo "Skipped for now"
+
+override_dh_auto_configure:
+	dh_auto_configure -- --with-systemd
+
 %:
 	dh $@ --with=autoreconf
 

--- a/zproject_spec.gsl
+++ b/zproject_spec.gsl
@@ -33,6 +33,7 @@ BuildRequires:  automake
 BuildRequires:  autoconf
 BuildRequires:  libtool
 BuildRequires:  pkg-config
+BuildRequires:  systemd-devel
 .if project.use_cxx
 BuildRequires:  gcc-c++
 .endif
@@ -97,7 +98,7 @@ This package contains development files.
 
 %build
 sh autogen.sh
-%{configure}
+%{configure} --with-systemd
 make %{_smp_mflags}
 
 %install


### PR DESCRIPTION
Solution: install systemd.pc and add --with-systemd configure flag to
both spec and debian recipes generators.