### PR TITLE
Problem: cpp is not default system preprocessor on OS X

### DIFF
--- a/fake_cpp
+++ b/fake_cpp
@@ -1,7 +1,10 @@
 #!/bin/sh
 # postprocessor of C preprocessor - removes __attribute__ declarations, which are not compatible for pycparser
 
-cpp "${@}" | sed \
+CPP=${1}
+shift 1
+
+${CPP} "${@}" | sed \
     -e 's/__attribute__ ((visibility("default"))) //' \
     -e 's/__attribute__((format.*)));$/;/' \
     -e 's/__THROW;$/;/' \


### PR DESCRIPTION
Solution: specify system preprocessor via --cpp argument. Two special
values:
 * auto - try to autodetect the one (use clang on darwin/OS X, check gcc
   and clang in PATH otherwise)
 * none - don't call preprocessor at all - this expects input is already
   pre-processed

This partially fixes https://github.com/vyskocilm/mkapi/issues/1
cc @paddor 