### PR TITLE
Problem: can't run mkapi on OSX

### DIFF
--- a/fake_cpp
+++ b/fake_cpp
@@ -5,8 +5,15 @@ CPP=${1}
 shift 1
 
 ${CPP} "${@}" | sed \
+    -e 's/ __asm(.*);$/;/' \
     -e 's/__attribute__ ((visibility("default"))) //' \
+    -e 's/__attribute__((unused))//' \
+    -e 's/__attribute__((aligned(8)));/;/' \
+    -e 's/__attribute__((availability(.*)));/;/' \
+    -e 's/__attribute__((availability(.*)))//' \
     -e 's/__attribute__((format.*)));$/;/' \
+    -e 's/__inline__/inline/' \
     -e 's/__THROW;$/;/' \
     -e 's/__END_DECLS//' \
-    -e 's/__BEGIN_DECLS//'
+    -e 's/__BEGIN_DECLS//' \
+    -e 's/void (\*signal(int, void (\*)(int)))(int);//'

--- a/mkapi.py
+++ b/mkapi.py
@@ -96,7 +96,13 @@ class FuncDeclVisitor(c_ast.NodeVisitor):
             if not hasattr(node.type, attr):
                 continue
             return TypeDecl(' '.join(getattr(node.type, attr)), ptr, node.quals)
-        raise AttributeError("%s do not have .type.names or .type.name" % (node.__class__.__name__))
+
+        return TypeDecl("", "void", "")
+        raise AttributeError("%s:%s:%s: %s do not have .type.names or .type.name" % (
+            node.coord.file,
+            node.coord.line,
+            node.coord.column,
+            node.__class__.__name__))
 
     @staticmethod
     def s_func_args(node):

--- a/mkapi.py
+++ b/mkapi.py
@@ -343,6 +343,16 @@ def s_detect_system_preprocessor():
 
     return None
 
+def s_expand_dirs(args):
+    ret = list()
+    for d in args.INCLUDE:
+        path = os.path.expandvars(
+                os.path.expanduser(d))
+        if not os.path.isdir(path):
+            print("W: '%s' is not directory" % path)
+        ret.append(path)
+    return ret
+
 def main(argv=sys.argv[1:]):
 
     p = argparse.ArgumentParser(description=__doc__)
@@ -351,6 +361,8 @@ def main(argv=sys.argv[1:]):
     p.add_argument("-I", "--include", help="extra includes, which will be passed to c preprocessor", dest="INCLUDE", action='append')
     p.add_argument("--cpp", help="Define c preprocessor to use (gcc -E, clang -E, auto for autodetect and none for not calling preprocessor at all", default="auto")
     args = p.parse_args(argv)
+
+    args.INCLUDE = s_expand_dirs(args)
 
     args.output = "api"
 


### PR DESCRIPTION
Solution: drop more darwin specific attributes in fake_cpp, ignore weird
complex types in function arguments as they're not compatible with CLASS
anyway.

This should fix https://github.com/vyskocilm/mkapi/issues/1
cc @paddor 