### PR TITLE
Problem: several issues found in generated Debian recipes

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -144,4 +144,4 @@ override_dh_auto_configure:
 %:
 	dh $@ --with=autoreconf
 
-\.PHONY: override_dh_strip override_dh_auto_test
+\.PHONY: override_dh_strip override_dh_auto_test override_dh_auto_configure

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -6,6 +6,7 @@
 .#  is licensed under MIT/X11.
 .#
 .#  This script will generate the following files:
+.#   * builds/debian/compat
 .#   * builds/debian/control
 .#   * builds/debian/$(project.name).dsc
 .#   * builds/debian/rules
@@ -14,6 +15,8 @@
 .if !file.exists ('builds/debian')
 .   directory.create('builds/debian')
 .endif
+.output "builds/debian/compat"
+9
 .output "builds/debian/control"
 #
 #    $(project.name) - $(project.description?'':)

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -10,6 +10,7 @@
 .#   * builds/debian/control
 .#   * builds/debian/$(project.name).dsc
 .#   * builds/debian/rules
+.#   * builds/debian/*.install
 .#  ===========================================================================
 .#
 .if !file.exists ('builds/debian')
@@ -150,3 +151,40 @@ override_dh_auto_configure:
 	dh $@ --with=autoreconf
 
 \.PHONY: override_dh_strip override_dh_auto_test override_dh_auto_configure
+
+.if project.has_main
+.   output ("builds/debian/$(string.replace (project.name, "_|-")).install")
+.# generate binary names
+.   for project.main where scope = "public"
+debian/tmp/usr/bin/$(main.name)
+.       if file.exists ("src/$(main.name).cfg.example")
+debian/tmp/etc/$(project.name)/$(main.name).cfg.example
+.       endif
+.   endfor
+.   for project.bin
+debian/tmp/usr/bin/$(bin.name)
+.   endfor
+.# generate service file names
+.   for project.main where main.service ?= 1 | main.services ?= 1
+.       if main.no_config ?= 0
+debian/tmp/etc/$(project.name)/$(main.name).cfg
+.       endif
+debian/tmp/usr/lib/systemd/system/$(main.name)*.service
+.   endfor
+.   for project.service
+debian/tmp/lib/systemd/system/$(service.name)*.service
+.   endfor
+
+.   for project.main where defined (main->extra)
+debian/tmp/$(main->extra.path)/$(main->extra.name)
+.   endfor
+.endif
+
+.if project.exports_classes
+.   output ("builds/debian/$(string.replace (project.libname, "_|-"))$(project->version.major).install")
+debian/tmp/usr/lib/$(project.libname).so.*
+.   output ("builds/debian/$(string.replace (project.name, "_|-"))-dev")
+debian/tmp/usr/include/*
+debian/tmp/usr/lib/$(project.libname).so
+debian/tmp/usr/lib/pkgconfig/$(project.libname).pc
+.endif

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -7,6 +7,8 @@
 .#
 .#  This script will generate the following files:
 .#   * builds/debian/control
+.#   * builds/debian/$(project.name).dsc
+.#   * builds/debian/rules
 .#  ===========================================================================
 .#
 .if !file.exists ('builds/debian')


### PR DESCRIPTION
Solution: fix issues in rules, add missing compat file a and most important - generate proper install files, so we won't end with empty library and -dev packages.