### PR TITLE
Problem: Android build is too slow

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -73,8 +73,8 @@ fi
     export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
     (cd "${cache}/$(project.name)" && ./autogen.sh \\
-        && ./configure "${ANDROID_BUILD_OPTS[@]}" \\
-        && make \\
+        && ./configure "${ANDROID_BUILD_OPTS[@]}" --without-documentation \\
+        && make -j 4 \\
         && make install) || exit 1
 }
 

--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -234,20 +234,29 @@ $(project.name:c)_on_android="no"
 # Host specific checks
 AC_CANONICAL_HOST
 
-# Determine whether or not documentation should be built and installed.
-$(project.name:c)_build_doc="yes"
-$(project.name:c)_install_man="yes"
+# Allow user to disable doc build
+AC_ARG_WITH([documentation], [AS_HELP_STRING([--without-documentation],
+    [disable documentation build even if asciidoc and xmlto are present [default=no]])])
 
-# Check for asciidoc and xmlto and don't build the docs if these are not installed.
-AC_CHECK_PROG($(project.name:c)_have_asciidoc, asciidoc, yes, no)
-AC_CHECK_PROG($(project.name:c)_have_xmlto, xmlto, yes, no)
-if test "x$$(project.name:c)_have_asciidoc" = "xno" -o "x$$(project.name:c)_have_xmlto" = "xno"; then
+if test "x$with_documentation" = "xno"; then
     $(project.name:c)_build_doc="no"
-    # Tarballs built with 'make dist' ship with prebuilt documentation.
-    if ! test -f doc/$(project.name:c).7; then
-        $(project.name:c)_install_man="no"
-        AC_MSG_WARN([You are building an unreleased version of $(PROJECT.NAME) and asciidoc or xmlto are not installed.])
-        AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])
+    $(project.name:c)_install_man="no"
+else
+    # Determine whether or not documentation should be built and installed.
+    $(project.name:c)_build_doc="yes"
+    $(project.name:c)_install_man="yes"
+
+    # Check for asciidoc and xmlto and don't build the docs if these are not installed.
+    AC_CHECK_PROG($(project.name:c)_have_asciidoc, asciidoc, yes, no)
+    AC_CHECK_PROG($(project.name:c)_have_xmlto, xmlto, yes, no)
+    if test "x$$(project.name:c)_have_asciidoc" = "xno" -o "x$$(project.name:c)_have_xmlto" = "xno"; then
+        $(project.name:c)_build_doc="no"
+        # Tarballs built with 'make dist' ship with prebuilt documentation.
+        if ! test -f doc/$(project.name:c).7; then
+            $(project.name:c)_install_man="no"
+            AC_MSG_WARN([You are building an unreleased version of $(PROJECT.NAME) and asciidoc or xmlto are not installed.])
+            AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])
+        fi
     fi
 fi
 AC_MSG_CHECKING([whether to build documentation])


### PR DESCRIPTION
Solution: use parallel make (-j 4) and don't build man pages.

Added --without-documentation switch to configure, as done in libzmq.