### PR TITLE
Problem: JNI Android jar is missing libgnustl_shared.so

### DIFF
--- a/zproject_bindings_jni.gsl
+++ b/zproject_bindings_jni.gsl
@@ -441,6 +441,7 @@ $(project.GENERATED_WARNING_HEADER:)
 #
 #     ANDROID_NDK_ROOT=$HOME/android-ndk-r10e
 #     TOOLCHAIN_NAME=arm-linux-androideabi-4.9
+#     TOOLCHAIN_VERSION=4.9
 #     TOOLCHAIN_HOST=arm-linux-androideabi
 #     TOOLCHAIN_ARCH=arm
 #     TOOLCHAIN_PATH=$ANDROID_NDK_ROOT/toolchains/$TOOLCHAIN_NAME/prebuilt/linux-x86_64/bin
@@ -487,6 +488,7 @@ unzip -q -o ../../../../../$(use.project)/bindings/jni/build/libs/$(use.project)
 mkdir -p lib/armeabi
 mv $(project.libname)jni.so lib/armeabi
 cp ../../../../builds/android/prefix/*/lib/*.so lib/armeabi
+cp $ANDROID_NDK_ROOT/sources/cxx-stl/gnu-libstdc++/$TOOLCHAIN_VERSION/libs/armeabi/libgnustl_shared.so lib/armeabi
 
 zip -r -m ../$(project.name)-android.jar lib/ org/ META-INF/
 cd ..


### PR DESCRIPTION
Solution: copy from right place in NDK