### PR TITLE
Problem: CMake has syntax error if class name contains space

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -236,7 +236,7 @@ set(TOTAL_TIMEOUT 20 CACHE STRING "Timout of the total testsuite")
 
 set(TEST_CLASSES
 .for class
-    $(name)
+    $(name:c)
 .endfor
 )
 


### PR DESCRIPTION
Solution: use $(name:c) appropriately