### PR TITLE
Problem: unecessary constant attribute printed

### DIFF
--- a/mkapi.py
+++ b/mkapi.py
@@ -243,11 +243,14 @@ def s_show_zproto_model_arguments(fp, decl_dict):
             continue
         if arg.name == "format" and arg.type == "char" and arg.ptr == "*":
             was_format = True
+
+        zproject_type = s_decl_to_zproto_type(arg)
+        constant = "const" in arg.quals and zproject_type not in ("string", "buffer")
         print("""        <argument name = "%(name)s" type = "%(type)s"%(byref)s%(constant)s%(callback)s/>""" %
                 {   "name" : arg.name,
-                    "type" : s_decl_to_zproto_type(arg),
+                    "type" : zproject_type,
                     "byref" : """ by_reference="1" """ if arg.ptr == "**" else "",
-                    "constant" : ' constant="1"' if "const" in arg.quals else "",
+                    "constant" : ' constant="1"' if constant else "",
                     "callback" : ' callback="1"' if "callback" in arg.xtra else "",
                 }, file=fp)
 


### PR DESCRIPTION
Solution: skip it for string and buffer arguments, which are imutable
by default