### PR TITLE
Problem: memcheck needs Valgrind on Travis CI

### DIFF
--- a/zproject_ci.gsl
+++ b/zproject_ci.gsl
@@ -21,8 +21,13 @@ env:
 #- BUILD_TYPE=check-py
 #- BUILD_TYPE=cmake
 
+addons:
+  apt:
+    packages:
+    - valgrind
+
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils valgrind ; fi
 
 # Build and check this project according to the BUILD_TYPE
 script: ./ci_build.sh


### PR DESCRIPTION
Solution: add valgrind to Linux/OSX Travis CI build dependencies

zproject_automake.gsl explicitly calls Valgrind, so zproject_ci.gsl should add the build-dep to travis.yml