### PR TITLE
Problem: Cannot compile czmq without libsodium

### DIFF
--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -32,7 +32,7 @@
         repository = "https://github.com/zeromq/libzmq"
         test = "zmq_init"
         cmake_name = "ZeroMQ">
-        <use project = "libsodium" />
+        <use project = "libsodium" optional = "1" implied = "1" />
     </use>
 
     <use project = "czmq" libname = "libczmq"


### PR DESCRIPTION
Solution: Make libsodium an optional dependency