### PR TITLE
Problem: "clock" type name is not explicit enough

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -100,7 +100,7 @@ function resolve_c_container (container)
         my.c_type = "off_t"
     elsif my.type = "time"
         my.c_type = "time_t"
-    elsif my.type = "clock"
+    elsif my.type = "msecs"
         my.c_type = "int64_t"
     elsif my.type = "FILE"
         my.c_type = "FILE"


### PR DESCRIPTION
Solution: use "msecs" type name instead