### PR TITLE
Problem: having code coverage report is hard task

### DIFF
--- a/zproject_autoconf.gsl
+++ b/zproject_autoconf.gsl
@@ -155,6 +155,9 @@ if test "x${$(PROJECT.NAME:c)_GCOV}" == "xyes"; then
     if test "x${$(PROJECT.NAME:c)_ORIG_CFLAGS}" != "xnone"; then
         CFLAGS="${CFLAGS} ${$(PROJECT.NAME:c)_ORIG_CFLAGS}"
     fi
+    AM_CONDITIONAL(WITH_GCOV, true)
+else
+    AM_CONDITIONAL(WITH_GCOV, false)
 fi
 
 .# Archive user supplied flags

--- a/zproject_automake.gsl
+++ b/zproject_automake.gsl
@@ -296,6 +296,22 @@ debug: src/$(project.prefix)_selftest
 animate: src/$(project.prefix)_selftest
 \t$\(LIBTOOL) --mode=execute $\(srcdir)/src/$(project.prefix)_selftest -v
 
+if WITH_GCOV
+coverage: src/$(project.prefix)_selftest
+\t@echo "called configure --with-gcov"
+\tlcov --base-directory . --directory . --zerocounters -q
+\t\$(MAKE) check
+\tlcov --base-directory . --directory . --capture -o coverage.info
+\tlcov --remove coverage.info "/usr*" -o coverage.info
+\tlcov --remove coverage.info "$(project.prefix)_selftest.c" -o coverage.info
+\t\$(RM) -rf coverage/*
+\tgenhtml -o coverage/ -t "$(project.name) test coverage" --num-spaces 4 coverage.info
+else
+coverage: src/$(project.prefix)_selftest
+\t@echo "call make clean && configure --with-gcov to enable code coverage"
+\t@exit 1
+endif
+
 $(project.GENERATED_WARNING_HEADER:)
 .#
 .#  Generate infrastructure for services


### PR DESCRIPTION
Solution: add coverage target for make (autotools only), which will
generate nice html report using lcov && genhtml in coverage/ directory