### PR TITLE
Generate CZMQ project.xml as part of Travis CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ CMakeFiles/
 CTestTestfile.cmake
 cmake_install.cmake
 install_manifest.txt
-ci_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Travis CI script
 language: c
 
+sudo: false
+
 script:
-- ./generate.sh && ./autogen.sh && ./configure && make && sudo make install
+- mkdir tmp && ./generate.sh && ./autogen.sh && ./configure --prefix=$PWD/tmp && make && make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ language: c
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+    - libpcre3-dev
+
 script:
 - ./ci_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ language: c
 sudo: false
 
 script:
-- mkdir tmp && ./generate.sh && ./autogen.sh && ./configure --prefix=$PWD/tmp && make && make install
+- ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -6,3 +6,9 @@ mkdir tmp
 BUILD_PREFIX=$PWD/tmp
 
 ( ./autogen.sh && ./configure --prefix=${BUILD_PREFIX} && make && make install ) || exit 1
+
+git clone --depth 1 https://github.com/imatix/gsl gsl
+( cd gsl/src && make -j4 && DESTDIR=${BUILD_PREFIX} make install ) || exit 1
+
+git clone --depth 1 https://github.com/zeromq/czmq czmq
+( cd czmq && PATH=$PATH:${BUILD_PREFIX}/bin gsl project.xml ) || exit 1

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x
+
+mkdir tmp
+BUILD_PREFIX=$PWD/tmp
+
+( ./autogen.sh && ./configure --prefix=${BUILD_PREFIX} && make && make install ) || exit 1


### PR DESCRIPTION
What do you think of this solution for a CI? Rather than building a dummy project.xml, it uses CZMQ, which has many and various APIs. Should exercise most of the capabilities.