### PR TITLE
Fix for issue #465

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -471,8 +471,10 @@ AM_CONDITIONAL([WITH_DRAFTS], [test x$with_drafts != xno])
 if test "x$with_drafts" = "xyes"; then
     AC_MSG_NOTICE([building draft, stable, and legacy API])
     AC_DEFINE(WITH_DRAFTS, 1, [Build and install draft classes and methods.])
+    AC_SUBST(pkg_config_defines, "-DWITH_DRAFTS=1")
 else
     AC_MSG_NOTICE([building stable and legacy API (no drafts)])
+    AC_SUBST(pkg_config_defines, "")
 fi
 
 # Specify output files
@@ -940,7 +942,7 @@ $(use.libname)\
 .endif
 
 Libs: -L${libdir} -l$(project.linkname)
-Cflags: -I${includedir}
+Cflags: -I${includedir} @pkg_config_defines@
 
 $(project.GENERATED_WARNING_HEADER:)
 .endmacro

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -92,28 +92,59 @@ $(project.GENERATED_WARNING_HEADER:)
 #endif
 
 //  Opaque class structures to allow forward references
-.for project.class where scope = "public"
+.for project.class where scope = "public" & !is_c_element_draft (class)
 .   if !defined (class.api)
 .       resolve_c_class(class)
 .   endif
 typedef struct _$(class.c_name)_t $(class.c_name)_t;
 #define $(CLASS.C_NAME)_T_DEFINED
 .endfor
+.if count (project.class, scope = "public" & is_c_element_draft (class))
+
+//  Draft APIs, excluded by default in stable releases
+#ifdef WITH_DRAFTS
+.   for project.class where scope = "public" & is_c_element_draft (class)
+.       if !defined (class.api)
+.           resolve_c_class(class)
+.       endif
+typedef struct _$(class.c_name)_t $(class.c_name)_t;
+#define $(CLASS.C_NAME)_T_DEFINED
+.   endfor
+#endif // WITH_DRAFTS
+.endif
 .if count (constant, scope = "public")
 
 //  Public constants
 .endif
-.for constant where scope = "public"
+.for constant where scope = "public" & !is_c_element_draft (constant)
 #define $(CONSTANT.NAME)\t$(constant.value) //  $(constant.?'')
 .endfor
+.if count (constant, scope = "public" & is_c_element_draft (constant))
+
+//  Draft APIs, excluded by default in stable releases
+#ifdef WITH_DRAFTS
+.   for constant where scope = "public" & is_c_element_draft (constant)
+#define $(CONSTANT.NAME)\t$(constant.value) //  $(constant.?'')
+.   endfor
+#endif // WITH_DRAFTS
+.endif
 
 //  Public API classes
 .for header where scope = "public"
 #include "$(header.name).h"
 .endfor
-.for class where scope = "public" & class.c_name <> "$(project.name)"
+.for class where scope = "public" & class.c_name <> "$(project.name)" & !is_c_element_draft (class)
 #include "$(class.c_name).h"
 .endfor
+.if count (project.class, scope = "public" & is_c_element_draft (class))
+
+//  Draft APIs, excluded by default in stable releases
+#ifdef WITH_DRAFTS
+.  for class where scope = "public" & class.c_name <> "$(project.name)" & is_c_element_draft (class)
+#include "$(class.c_name).h"
+.  endfor
+#endif // WITH_DRAFTS
+.endif
 
 #endif
 /*

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -240,6 +240,11 @@ set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\\${prefix}")
 set(libdir "\\${prefix}/lib${LIB_SUFFIX}")
 set(includedir "\\${prefix}/include")
+IF (WITH_DRAFTS)
+set(pkg_config_defines "-DWITH_DRAFTS=1")
+ELSE (WITH_DRAFTS)
+set(pkg_config_defines "")
+ENDIF (WITH_DRAFTS)
 configure_file(
     "${SOURCE_DIR}/src/$(project.libname).pc.in"
     "${SOURCE_DIR}/src/$(project.libname).pc"


### PR DESCRIPTION
Revert previous commit, and add -DWITH_DRAFTS=1 to pkg-config in both cmake and autotools as discussed in #465 

Tested with czmq:

    $ cat test.c 
    #include "czmq.h"
    
    main() {
    printf("%d\n", zproc_czmq_version());
    }
    $ gcc `PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/home/lboccass/git/libczmq/src pkg-config --libs --cflags libczmq` -I/home/lboccass/git/libczmq/include -L/home/lboccass/git/libczmq/src test.c -o test
    $ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/lboccass/git/libczmq/src ./test
    30003