### PR TITLE
Problem: Travis CI runs dependencies self tests

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -62,7 +62,7 @@ if [ $BUILD_TYPE == "default" ]; then
     # Clone and build dependencies
 .for use where defined (use.repository)
     git clone --depth 1 $(use.repository) $(use.project)
-    ( cd $(use.project) && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make check && make install ) || exit 1
+    ( cd $(use.project) && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make install ) || exit 1
 
 .endfor
     # Build and check this project


### PR DESCRIPTION
Solution: do not run make check for dependencies, they are already
ran in their own CI and thus it is a waste of time to repeat those
tests again

I think it's not worth running dependencies tests, they are already run in their own repo. Especially with projects with many dependencies built from sources, like Malamute, it slows down a CI run by good chunk.