### PR TITLE
Problem: Previous patch adding variables was not really necessary.

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -412,13 +412,6 @@ $(c_actor_declaration (actor):)
 $(c_method_declaration (method):)
 
 .   endfor
-.-
-.   for class.variable where draft = my.draft
-//  $(variable.description:no,block)
-$(PROJECT.PREFIX:c)_EXPORT extern volatile $(variable.c_type)
-    $(class.name:c)_verbose;
-.   endfor
-
 .endmacro
 .template 0
 #

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -367,12 +367,6 @@ function resolve_c_class (class)
         enum.description ?= "$(string.trim (enum.?""):left)"
         set_state (enum, my.class.state)
     endfor
-
-    for my.class.variable
-        variable.description ?= "$(string.trim (variable.?""):left)"
-        resolve_c_container (variable)
-        set_state (variable, my.class.state)
-    endfor
 endfunction
 
 #   Resolve all dependent data types for one container and load their API file


### PR DESCRIPTION
...as you can re-generate headers pretty easily with "make code".

Revert "Problem: Re-generating zproto headers with zproject API model drops global verbose flag"

This reverts commit 24945ab93ecee3df2c1c878ed3f6e5865204072b.