### PR TITLE
Problem: global constant's state not defined

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -109,6 +109,9 @@ typedef struct _$(class.c_name)_t $(class.c_name)_t;
 .   endif
 .endfor
 
+.for constant
+.   resolve_c_constant (constant, "draft")
+.endfor
 .if count (constant, scope = "public")
 //  Public constants
 .endif

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -256,6 +256,16 @@ function resolve_c_method (method, default_description)
     endfor
 endfunction
 
+# Resolve C constant
+function resolve_c_constant (constant, default_state)
+    if defined (my.constant.type) & (my.constant.type = 'string')
+        my.constant.value = '"' + my.constant.value + '"'
+    endif
+    my.constant.description ?= "$(string.trim (my.constant.?""):left)"
+    resolve_c_container (my.constant)
+    set_state (my.constant, my.default_state)
+endfunction
+
 #   Resolve missing or implicit details in a C class model
 #
 #   Here, "class" refers to a <class/> entity in the model XML.
@@ -354,12 +364,7 @@ function resolve_c_class (class)
 
     # Resolve details of each constant
     for my.class.constant
-        if defined (constant.type) & (constant.type = 'string')
-            constant.value = '"' + constant.value + '"'
-        endif
-        constant.description ?= "$(string.trim (constant.?""):left)"
-        resolve_c_container (constant)
-        set_state (constant, my.class.state)
+        resolve_c_constant (constant, my.class.state)
     endfor
 
     # Resolve details of each constant


### PR DESCRIPTION
Solution: refactor the resolution of constants into a function,
and call it from zproject_class.gsl before parsing a project's
global constants, so that "state" and "draft" are defined.

This problem causes a generation failure in Zyre. If this PR is accepted, I'll send a fix for Zyre with a regeneration and another fix. Also tested on CZMQ, doesn't change any generated file.