### PR TITLE
Problem: CMake out-of-tree builds won't see ".git"

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -61,7 +61,7 @@ set(
 ########################################################################
 # options
 ########################################################################
-if (EXISTS ".git")
+if (EXISTS "${SOURCE_DIR}/.git")
     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
 else ()
     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" OFF)


### PR DESCRIPTION
Solution: when deciding if to enable draft APIs by default, instead of
checking for ".git" check for "${SOURCE_DIR}/.git".