### PR TITLE
Problem: generated python_cffi output filename clashes with ctypes-ba…

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -75,7 +75,7 @@ endfunction
 
 function generate_python_binding
     directory.create ("bindings/python_cffi")
-    output "bindings/python_cffi/$(project.name:c).py"
+    output "bindings/python_cffi/$(project.name:c)_cffi.py"
     >$(project.GENERATED_WARNING_HEADER:)
     >
     >from __future__ import print_function


### PR DESCRIPTION
…sed python binding filename

Solution: change output name format from <name>.py to <name>_cffi.py