### PR TITLE
fix spaces in constant names generated by the python generator

### DIFF
--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -393,7 +393,7 @@ function generate_python_binding
         endfor
         >
         for constant
-            >    $(CONSTANT.NAME) = $(constant.value)\
+            >    $(CONSTANT.NAME:c) = $(constant.value)\
             if defined (constant.description)
                 > # $(constant.description:no)
             else


### PR DESCRIPTION
For example in malamute the protocol class contains constants with spaces which makes it invalid python code