### PR TITLE
Problem: Python CFFI target broke the Python target

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -15,7 +15,7 @@
 
 register_target ("python_cffi", "Python CFFI binding")
 
-function python_register_type (struct, pointer)
+function python_cffi_register_type (struct, pointer)
     if count(project->python_types.type, type.name = my.struct) = 0
         new project->python_types.type
             type.name = my.struct
@@ -24,7 +24,7 @@ function python_register_type (struct, pointer)
     endif
 endfunction
 
-function resolve_python_container (container)
+function resolve_python_cffi_container (container)
     if my.container.variadic
     elsif my.container.is_enum
     elsif my.container.type = "nothing"
@@ -40,40 +40,40 @@ function resolve_python_container (container)
     elsif my.container.type = "string" | my.container.type = "format"
     elsif my.container.callback
     else
-        python_register_type("$(my.container.type:c,no)_t", "$(my.container.type:c,no)_p")
+        python_cffi_register_type ("$(my.container.type:c,no)_t", "$(my.container.type:c,no)_p")
     endif
 endfunction
 
-function resolve_python_method (method)
+function resolve_python_cffi_method (method)
     my.method.python_name = "$(my.method.name:c)"
     if regexp.match ("^(is|from)$", my.method.python_name) # matches keyword
         my.method.python_name += "_"
     endif
     for my.method.argument where !argument.variadic
-        resolve_python_container (argument)
+        resolve_python_cffi_container (argument)
     endfor
     for my.method.return as ret
-        resolve_python_container (ret)
+        resolve_python_cffi_container (ret)
     endfor
 endfunction
 
-function resolve_python_class (class)
-    python_register_type("$(class.c_name)_t", "$(class.c_name)_p")
+function resolve_python_cffi_class (class)
+    python_cffi_register_type("$(class.c_name)_t", "$(class.c_name)_p")
     for my.class.callback_type as method
-        resolve_python_method (method)
+        resolve_python_cffi_method (method)
     endfor
     for my.class.constructor as method
-        resolve_python_method (method)
+        resolve_python_cffi_method (method)
     endfor
     for my.class.destructor as method
-        resolve_python_method (method)
+        resolve_python_cffi_method (method)
     endfor
     for my.class.method
-        resolve_python_method (method)
+        resolve_python_cffi_method (method)
     endfor
 endfunction
 
-function generate_python_binding
+function generate_python_cffi_binding
     directory.create ("bindings/python_cffi")
     output "bindings/python_cffi/$(project.name:c)_cffi.py"
     >$(project.GENERATED_WARNING_HEADER:)
@@ -158,8 +158,8 @@ function target_python_cffi
         new python_types
         endnew
         for class where defined (class.api)
-            resolve_python_class (class)
+            resolve_python_cffi_class (class)
         endfor
-        generate_python_binding ()
+        generate_python_cffi_binding ()
     endif
 endfunction


### PR DESCRIPTION
It was using functions with the same name, however we're using
a global scope, so this broke the python target.

Solution: use unique function names.

A better solution would be to wrap each target in its own scope.
I'll experiment with this.