### PR TITLE
Problem: 'make code' does not rebuild the API

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -781,10 +781,9 @@ code:
 .   else
 \tcd $\(srcdir)/src; gsl -topdir:.. -zproject:1 -q $(name).xml
 .   endif
-.   if last ()
-
-.   endif
 .endfor
+\tgsl -target:- project.xml
+
 check-local: src/$(project.prefix)_selftest
 \t$\(LIBTOOL) --mode=execute $\(srcdir)/src/$(project.prefix)_selftest
 


### PR DESCRIPTION
E.g. if we modify an API model, we should be able to run 'make code'
and get new include files.

Solution: run 'gsl -target:- project.xml' in make code, after any
model generation.