### PR TITLE
Problem: check_zproject gen fails, missing dir

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -75,6 +75,7 @@ else
 fi
 .close
 .chmod_x ("ci_build.sh")
+.directory.create ("builds/check_zproject")
 .output "builds/check_zproject/ci_build.sh"
 #!/usr/bin/env bash
 set -e


### PR DESCRIPTION
Solution: create builds/check_zproject before creating ci_build.sh