### PR TITLE
Problem: no need for WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,3 @@ COPY . /tmp/zproject
 WORKDIR /tmp/zproject
 RUN mkdir -p /tmp/myproject && ( ./autogen.sh; ./configure; make; make install; ldconfig ) && \
     rm -rf /tmp/myproject
-
-WORKDIR /gsl


### PR DESCRIPTION
after zeromqorg/gsl accepts $GSL_BUILD_DIR environment variable

Solution: cleanup