### PR TITLE
Problem: python bindings are not easy to install

### DIFF
--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -235,6 +235,19 @@ function python_method_definition(method)
     >
 endfunction
 
+function generate_python_setup_py
+    output "setup.py"
+    >from distutils.core import setup
+    >
+    >setup(name='$(project.name:c)',
+    >	  description="""$(project.description:no)""",
+    >	  version='0.1',
+    >	  url='$(project.repository)',
+    >	  packages=['$(project.name:c)'],
+    >	  package_dir={'': 'bindings/python'},
+    >)
+endfunction
+
 function generate_python_binding
     my.dir = "bindings/python/$(project.name:c)"
     directory.create (my.dir)
@@ -485,6 +498,7 @@ function target_python
         for class where defined (class.api)
             resolve_python_class (class)
         endfor
+        generate_python_setup_py ()
         generate_python_binding ()
     endif
 endfunction

--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -240,9 +240,13 @@ function generate_python_setup_py
     >from distutils.core import setup
     >
     >setup(name='$(project.name:c)',
+    if defined (project.description)
     >	  description="""$(project.description:no)""",
+    endif
     >	  version='0.1',
+    if defined (project.repository)
     >	  url='$(project.repository)',
+    endif
     >	  packages=['$(project.name:c)'],
     >	  package_dir={'': 'bindings/python'},
     >)


### PR DESCRIPTION
Solution: generate a setup.py script.

To install bindings, run "python setup.py install".