### PR TITLE
Problem: zproject generates bindings for private classes

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -12,6 +12,7 @@
 
 # Resolve filename for each class API (undefined if the file is not found)
 for project.class
+    class.private ?= "0"
     if defined (class.api)
         if !file.exists (class.api)
             echo "Could not read API file '$(class.api)' for '$(class.name)'"
@@ -35,6 +36,7 @@ for project.class where defined (class.api)
     else
         new_class.api = class.api
         new_class.api_dir = directory.resolve ('api/')
+        new_class.private = class.private
         new_class.scope = class.scope
         new_class.state = class.state? new_class.state?
         move new_class after class

--- a/zproject_java_lib.gsl
+++ b/zproject_java_lib.gsl
@@ -215,7 +215,7 @@ function resolve_jni_method (method)
 endfunction
 
 function resolve_java_class (class)
-    if defined (my.class.api)
+    if defined (my.class.api) & my.class.private = "0"
         my.class.jni_okay = 1
         for constructor
             resolve_jni_method (constructor)

--- a/zproject_qml.gsl
+++ b/zproject_qml.gsl
@@ -170,12 +170,12 @@ $(project.GENERATED_WARNING_HEADER:)
 #include <QQmlExtensionPlugin>
 #include <qqml.h>
 
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 class $(class.QmlName:);
 class $(class.QmlName:)Attached;
 .endfor
 
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 #include "$(class.QmlName:).h"
 .endfor
 
@@ -187,7 +187,7 @@ class $(project.QmlName)Plugin : public QQmlExtensionPlugin
 public:
     void registerTypes (const char *uri)
     {
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
         qmlRegisterType<$(class.QmlName:)> (uri, 1, 0, "$(class.QmlName:)");
         qmlRegisterType<$(class.QmlName:)Attached>();
 .endfor
@@ -200,7 +200,7 @@ public:
 $(project.GENERATED_WARNING_HEADER:)
 */
 .#
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 .output "bindings/qml/src/$(class.QmlName:).cpp"
 /*
 $(project.GENERATED_WARNING_HEADER:)
@@ -431,7 +431,7 @@ LIBS += -l$(project.linkname)
 
 HEADERS += \\
   $$SRCDIR/$(project.qml_soname:)_plugin.h \\
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
   $$SRCDIR/$(class.QmlName).h \
 .   if !last ()
 \\
@@ -440,7 +440,7 @@ HEADERS += \\
 
 
 SOURCES += \\
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
   $$SRCDIR/$(class.QmlName).cpp \
 .   if !last ()
 \\
@@ -667,11 +667,11 @@ $(project.GENERATED_WARNING_HEADER:)
 ```
 .endmacro
 
-    if count (class, defined (class.api))
+    if count (class, defined (class.api) & class.private = "0")
         project.QmlName = "Qml$(project.name:Pascal)"
         project.qml_soname = "qml_$(project.name:c)"
 
-        for class where defined (class.api)
+        for class where defined (class.api) & class.private = "0"
             class.QmlName = "Qml$(class.c_name:Pascal)"
         endfor
         generate_binding ()

--- a/zproject_qt.gsl
+++ b/zproject_qt.gsl
@@ -410,7 +410,7 @@ endfunction
 
 .macro generate_binding ()
 .directory.create ("bindings/qt/src")
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 .   output "bindings/qt/src/$(class.qtname).h"
 .   print_class_header (class)
 .   close
@@ -422,7 +422,7 @@ endfunction
 .   close
 .endfor
 .
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 .   output "bindings/qt/src/$(class.qtname).cpp"
 .   print_class_body (class)
 .   close
@@ -462,7 +462,7 @@ $(project.GENERATED_WARNING_HEADER:)
 #endif
 
 //  Opaque class structures to allow forward references
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 class $(class.QtName:);
 .endfor
 .for dependencies.class
@@ -470,7 +470,7 @@ class $(class.QtName:);
 .endfor
 
 //  Public API classes
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 #include "$(class.qtname).h"
 .endfor
 .for dependencies.class
@@ -529,7 +529,7 @@ $(project.QtName)-uselib:!$(project.QtName)-buildlib {
 } else {
     HEADERS       += \\
                      $$PWD/$(project.QtName).h \\
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 .   if !last() | count (dependencies.class) > 0
                      $$PWD/$(class.qtname).h \\
 .   else
@@ -545,7 +545,7 @@ $(project.QtName)-uselib:!$(project.QtName)-buildlib {
 .endfor
 
     SOURCES       += \\
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 .   if !last() | count (dependencies.class) > 0
                      $$PWD/$(class.qtname).cpp \\
 .   else
@@ -670,7 +670,7 @@ int main(int argc, char **argv)
 
     qDebug() << "Running $(project.QtName) selftests...\\n";
 
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
     $(class.QtName)::test (verbose);
 .endfor
 .for dependencies.class
@@ -774,9 +774,9 @@ $(project.GENERATED_WARNING_HEADER:)
 .close
 .endmacro
 
-    if count (class, defined (class.api))
+    if count (class, defined (class.api) & class.private = "0")
         project.QtName = "q$(project.name)"
-        for class where defined (class.api)
+        for class where defined (class.api) & class.private = "0"
             class.QtName = "Q$(class.c_name:Pascal)"
         endfor
         for dependencies.class

--- a/zproject_ruby.gsl
+++ b/zproject_ruby.gsl
@@ -307,7 +307,7 @@ module $(project.RubyName:)
       opts = {
         blocking: true  # only necessary on MRI to deal with the GIL.
       }
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 
 .for enum
       enum :$(enum.ruby_name:), [
@@ -369,7 +369,7 @@ end
 
 $(project.GENERATED_WARNING_HEADER:)
 .#
-.for class where defined (class.api)
+.for class where defined (class.api) & class.private = "0"
 .output "bindings/ruby/lib/$(project.name:c)/ffi/$(class.ruby_require:).rb"
 $(project.GENERATED_WARNING_HEADER:)
 
@@ -633,11 +633,11 @@ $(project.GENERATED_WARNING_HEADER:)
 .endmacro
 
     project.RubyName = "$(project.name:Pascal)"
-    for class where defined (class.api)
+    for class where defined (class.api) & class.private = "0"
         class.ruby_require = string.replace (class.c_name, "$(project.name)_|")
         class.RubyName = "$(class.ruby_require:Pascal)"
     endfor
-    for class where defined (class.api)
+    for class where defined (class.api) & class.private = "0"
         resolve_ruby_class (class)
     endfor
     generate_ruby_binding ()


### PR DESCRIPTION
Solution: exclude private classes when generating bindings

An example where this issue occurs is with czmq's zgossip_msg.