### PR TITLE
Problem: Android CI ignores dep's release branch

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -133,7 +133,11 @@ export TOOLCHAIN_ARCH="arm"
 
 .for use where defined (use.repository)
 export $(USE.PROJECT)_ROOT="/tmp/$(use.project)"
+.   if defined (use.release)
+git clone --quiet --depth 1 -b $(use.release) $(use.repository) $$(USE.PROJECT)_ROOT
+.   else
 git clone --quiet --depth 1 $(use.repository) $$(USE.PROJECT)_ROOT
+.   endif
 
 .endfor
 source ./build.sh


### PR DESCRIPTION
Solution: if project.release is defined, clone from that branch
instead of master.