### PR TITLE
Problem: gsl project.xml fails if there's no src dir

### DIFF
--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -12,6 +12,8 @@
 
 ##  Generate main source if not already present
 
+.directory.create ('src')
+
 .macro skeleton_main_source
 . if !file.exists (main.source)
 .   echo "Generating skeleton for $(main.source)"


### PR DESCRIPTION
Solution: allways call directory.create ('src')

This fixes
(zproject_skeletons.gsl 18) Can't open output file:
src/bios_agent_asset.c