### PR TITLE
Problem: the installation model is uber messy

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -487,17 +487,7 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
     [AC_CONFIG_FILES([
 .   for project.main where main.service ?= 1
                  src/$(main.name).service
-.   endfor
-.   for project.main where main.services ?= 1
-                 src/$(main.name)@.service
-.   endfor
-.   for project.service
-                 src/$(service.name).service
-.   endfor
-.   for project.main where defined (main->extra)
-.       for extra where extra.cond ?= "with_systemd_units"
-                 src/$(extra.name)
-.       endfor
+                 src/$(main.name).cfg
 .   endfor
     ])],
     [])
@@ -692,39 +682,15 @@ src_$(main.name:c)_CPPFLAGS = ${AM_CPPFLAGS}
 src_$(main.name:c)_LDADD = ${program_libs}
 src_$(name:c)_SOURCES = $(main.source)
 .#
-.#  Systemd stuff (I'd _really_ like to get rid of this/PH)
-.   if count (main, count.service ?= 1 | count.services ?= 1) \
-     | count (extra, count.cond ?= "with_systemd_units")
+.#  Systemd stuff
+.   if main.service ?= 1
 if WITH_SYSTEMD_UNITS
-.   endif
-.   if main.service ?= 1 | main.services ?= 1
 src_$(main.name:c)_servicedir = @prefix@/lib/systemd/system
-.   if ! (main.no_config ?= 1)
 src_$(main.name:c)_configdir = \$(sysconfdir)/$(project.name)
-.   if main.service ?= 1
 src_$(main.name:c)_config_DATA = src/$(main.name).cfg
-.   else
-src_$(main.name:c)_config_DATA = src/$(main.name).cfg.example
-.   endif
-.   endif
-.   if main.service ?= 1
 src_$(main.name:c)_service_DATA = src/$(main.name).service
-.   else
-src_$(main.name:c)_service_DATA = src/$(main.name)@.service
-.   endif
-.   endif
-.   for extra where extra.cond ?= "with_systemd_units"
-src_$(main.name:c)_$(extra.type:c)dir = $(extra.path)
-src_$(main.name:c)_$(extra.type:c)_DATA = src/$(extra.name)
-.   endfor
-.   if count (main, count.service ?= 1 | count.services ?= 1) \
-     | count (extra, count.cond ?= "with_systemd_units")
 endif #WITH_SYSTEMD_UNITS
 .   endif
-.   for extra where extra.cond ?<> "with_systemd_units"
-src_$(main.name:c)_$(extra.path:c)_$(extra.name:c)dir = $(extra.path)
-src_$(main.name:c)_$(extra.path:c)_$(extra.name:c)_DATA = src/$(extra.name)
-.   endfor
 endif #ENABLE_$(NAME:c)
 
 .endfor
@@ -735,13 +701,6 @@ $(project.name:c)dir = @bindir@
 $(project.name:c)_SCRIPTS = \\
 .   endif
     $(bin.name)$(last ()?? "\n"? " \\")
-.endfor
-.for service
-.   if first ()
-$(project.name:c)_servicesdir = @prefix@/lib/systemd/system
-$(project.name:c)_services_DATA = \\
-.   endif
-    src/$(service.name).service$(last ()?? "\n"? " \\")
 .endfor
 .for class where defined (class.api)
 .   if first ()
@@ -827,19 +786,9 @@ endif
 $(project.GENERATED_WARNING_HEADER:)
 .#
 .#  Generate infrastructure for services
-.for project.main where main.service ?= 1 | main.services ?= 1
-. do_cfg = 1
-.if main.service  ?= 1 & !file.exists ("src/$(main.name).cfg")
-.       output "src/$(main.name).cfg"
-.elsif main.services ?= 1 & !file.exists ("src/$(main.name).cfg.example")
-.       output "src/$(main.name).cfg.example"
-.else
-.       do_cfg = 0
-.endif
-.if main.no_config ?= 1
-. do_cfg = 0
-.endif
-.if do_cfg ?= 1
+.for project.main where main.service ?= 1
+.if !file.exists ("src/$(main.name).cfg.in")
+.       output "src/$(main.name).cfg.in"
 #   $(main.name) configuration
 
 server
@@ -848,7 +797,7 @@ server
     workdir = .         #   Working directory for daemon
     verbose = 0         #   Do verbose logging of activity?
 .endif
-.if main.service ?= 1 & !file.exists ("src/$(main.name).service.in")
+.if !file.exists ("src/$(main.name).service.in")
 .   output "src/$(main.name).service.in"
 [Unit]
 Description=$(main.name) service
@@ -857,29 +806,7 @@ After=network.target
 [Service]
 Type=simple
 Environment="prefix=@prefix@"
-.if main.no_config ?= 1
-ExecStart=@prefix@/bin/$(main.name)
-.else
 ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
-.endif
-
-[Install]
-WantedBy=multi-user.target
-.endif
-.if main.services ?= 1 & !file.exists ("src/$(main.name)@.service.in")
-.   output "src/$(main.name)@.service.in"
-[Unit]
-Description=$(main.name) service for %I
-After=network.target
-
-[Service]
-Type=simple
-Environment="prefix=@prefix@"
-.if main.no_config ?= 1
-ExecStart=@prefix@/bin/$(main.name) %i
-.else
-ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/%i.cfg
-.endif
 
 [Install]
 WantedBy=multi-user.target

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -59,17 +59,6 @@ function resolve_project_dependency (use)
     endfor
 endfunction
 
-function resolve_extra (main)
-    for extra where defined (extra.type)
-        if extra.type = "systemd-tmpfiles"
-            extra.name ?= "$(main.name).conf"
-            extra.path ?= "/usr/lib/tmpfiles.d"
-            extra.cond = "with_systemd"
-        endif
-        extra.cond ?= ""
-    endfor
-endfunction
-
 function resolve_scope (item)
     if my.item.private ?= 1
         my.item.scope = "private"
@@ -85,7 +74,6 @@ endfor
 
 for main
     resolve_scope (main)
-    resolve_extra (main)
 endfor
 
 for actor


### PR DESCRIPTION
Solution: get rid of it

This patch effectivelly drops
 * services and no_config for main
 * project.services
 * main.extra

It preserve service attribute for main with the same semantics like back
then (one service file and one config file). Installation is still behind
WITH_SYSTEMD_UNITS variable, which seems like the most usefull idea of
all the changes we did.