### PR TITLE
Problem: Under OS X, configure.sh complains ‘possibly undefined macro…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS([src/platform.h])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+m4_pattern_allow([AC_PROG_LIBTOOL])
+m4_pattern_allow([AC_LIBTOOL_WIN32_DLL])
 
 # This defines PACKAGE_VERSION_... in src/platform.h
 PV_MAJOR=`echo $PACKAGE_VERSION | cut -d . -f 1`


### PR DESCRIPTION
… on AC_PROG_LIBTOOL, AC_LIBTOOL_WIN32_DLL’

Solution: Add those to m4_pattern_allow macro