### PR TITLE
Problem: systemd-units option is broken #546

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -427,7 +427,7 @@ AS_IF([test "$have_ld_version_script" = "yes"],
 .endif
 
 # enable specific system integration features
-AC_ARG_WITH([systemd],
+AC_ARG_WITH([systemd-units],
     AS_HELP_STRING([--with-systemd-units],
     [Build and install with systemd units integration [default=no].]),
     [with_systemd_units=$withval],


### PR DESCRIPTION
Solution: change AC_ARG_WITH parameter to be "systemd-units" from
"systemd" to be coherent with help string and variables