### PR TITLE
Problem: CI config option --without-doc is wrong

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -65,7 +65,7 @@ if [ "$BUILD_TYPE" == "default" ]; then
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
-    CONFIG_OPTS+=("--without-docs")
+    CONFIG_OPTS+=("--with-docs=no")
     CONFIG_OPTS+=("--quiet")
 
     # Clone and build dependencies


### PR DESCRIPTION
Solution: use --with-docs=no, as expected by the generated autoconf