### PR TITLE
Problem: C++ projects can't use inttypes.h macros

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -523,6 +523,9 @@ AM_CPPFLAGS = \\
 .for use
     \${$(use.project:c)_CFLAGS} \\
 .endfor
+.if project.use_cxx
+    -D__STDC_FORMAT_MACROS \\
+.endif
     -I\$(srcdir)/include
 
 .libs = ""


### PR DESCRIPTION
Solution: define __STDC_FORMAT_MACROS for C++ projects
note: required by http://www.open-std.org/jtc1/sc22/wg14/www/docs/n851.htm