### PR TITLE
Problem: multiline comment in main generates invalid C skeleton code

### DIFF
--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -38,7 +38,6 @@
 
 int main (int argc, char *argv [])
 {
-    puts ("$(main.name) - $(main.?'')");
     bool verbose = false;
     int argn;
     for (argn = 1; argn < argc; argn++) {


### PR DESCRIPTION
Solution: remove the first puts. In case main is started as verbose, the
same message appears twice, which is ridiculous enough. The zsys_info
below does the multitine support well.