### PR TITLE
Problem: drafts are confusing on many projects

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -118,7 +118,7 @@ AX_PROJECT_LOCAL_HOOK # Optional project-local hook (acinclude.m4)
 .endif
 # Code coverage
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
-                  [With GCC Code Coverage reporting.])],
+                  [With GCC Code Coverage reporting])],
                   [$(PROJECT.PREFIX)_GCOV="$withval"])
 
 if test "x${$(PROJECT.PREFIX)_GCOV}" == "xyes"; then
@@ -143,7 +143,7 @@ was_$(use.project:c)_check_lib_detected=no
 PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
     [
 .  if optional
-        AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used.])
+        AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
 .  endif
     ],
     [
@@ -178,12 +178,12 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
                 AC_SUBST([$(use.project:c)_LIBS],[${$(use.project:c)_synthetic_libs}])
                 was_$(use.project:c)_check_lib_detected=yes
 .       if optional
-                AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used.])
+                AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
             ],
             [])
 .       else
             ],
-            [AC_MSG_ERROR([cannot link with -l$(use.linkname), install $(use.libname).])])
+            [AC_MSG_ERROR([cannot link with -l$(use.linkname), install $(use.libname)])])
 .       endif
 .   elsif optional
         AC_MSG_WARN([Cannot find $(use.libname) $(use.min_version) or higher])
@@ -322,7 +322,7 @@ case "${host_os}" in
         $(project.name:c)_on_gnu="yes"
         ;;
     *)
-        AC_MSG_ERROR([unsupported system: ${host_os}.])
+        AC_MSG_ERROR([unsupported system: ${host_os}])
         ;;
 esac
 
@@ -373,9 +373,9 @@ AM_CONDITIONAL(BUILD_DOC, test "x$$(project.name:c)_build_doc" = "xyes")
 AC_ARG_ENABLE([$(name)],
     AS_HELP_STRING([--enable-$(name)],
 .   if scope = "public"
-        [Compile and install '$(name)' [default=yes].]),
+        [Compile and install '$(name)' [default=yes]]),
 .   else
-        [Compile '$(name)' in src [default=yes].]),
+        [Compile '$(name)' in src [default=yes]]),
 .   endif
     [enable_$(name:c)=$enableval],
     [enable_$(name:c)=yes])
@@ -429,7 +429,7 @@ AS_IF([test "$have_ld_version_script" = "yes"],
 # enable specific system integration features
 AC_ARG_WITH([systemd-units],
     AS_HELP_STRING([--with-systemd-units],
-    [Build and install with systemd units integration [default=no].]),
+    [Build and install with systemd units integration [default=no]]),
     [with_systemd_units=$withval],
     [with_systemd_units=no])
 
@@ -440,26 +440,31 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
     AC_SUBST(WITH_SYSTEMD_UNITS)],
     [])
 
+.if project.stable
 if test "x$cross_compiling" = "xyes"; then
     #   Enable draft by default when cross-compiling
-    gitmaster=yes
+    defaultval=yes
 else
     # enable draft API by default if we're in a git repository
     # else disable it by default; then allow --enable-drafts=yes/no override
-    AC_CHECK_FILE($srcdir/.git, [gitmaster=yes], [gitmaster=no])
+    AC_CHECK_FILE($srcdir/.git, [defaultval=yes], [defaultval=no])
 fi
 
 AC_ARG_ENABLE([drafts],
     AS_HELP_STRING([--enable-drafts],
-        [Build and install draft classes and methods [default=yes.]]),
+        [Build and install draft classes and methods [default=yes]]),
     [enable_drafts=$enableval],
-    [enable_drafts=$gitmaster])
+    [enable_drafts=$defaultval])
 
+.else
+#   Project has no stable classes so enable draft API by default
+enable_drafts=yes
+.endif
 AM_CONDITIONAL([ENABLE_DRAFTS], [test x$enable_drafts != xno])
 
 if test "x$enable_drafts" = "xyes"; then
     AC_MSG_NOTICE([Building stable and legacy API + draft API])
-    AC_DEFINE($(PROJECT.PREFIX)_BUILD_DRAFT_API, 1, [Provide draft classes and methods.])
+    AC_DEFINE($(PROJECT.PREFIX)_BUILD_DRAFT_API, 1, [Provide draft classes and methods])
     AC_SUBST(pkg_config_defines, "-D$(PROJECT.PREFIX)_BUILD_DRAFT_API=1")
 else
     AC_MSG_NOTICE([Building stable and legacy API (no draft API)])

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -69,7 +69,6 @@ $(project.GENERATED_WARNING_HEADER:)
 .endfor
 
 //  $(PROJECT.PREFIX) version macros for compile-time API detection
-
 #define $(PROJECT.PREFIX)_VERSION_MAJOR $(project->version.major)
 #define $(PROJECT.PREFIX)_VERSION_MINOR $(project->version.minor)
 #define $(PROJECT.PREFIX)_VERSION_PATCH $(project->version.patch)
@@ -91,6 +90,12 @@ $(project.GENERATED_WARNING_HEADER:)
 #   define $(PROJECT.PREFIX)_EXPORT
 #endif
 
+.if !project.stable
+//  Project has no stable classes, so we build the draft API
+#undef  $(PROJECT.PREFIX)_BUILD_DRAFT_API
+#define $(PROJECT.PREFIX)_BUILD_DRAFT_API
+
+.endif
 //  Opaque class structures to allow forward references
 //  These classes are stable or legacy and built in all releases
 .for project.class where scope = "public" & !draft
@@ -99,7 +104,7 @@ typedef struct _$(class.c_name)_t $(class.c_name)_t;
 .endfor
 .for project.class where scope = "public" & draft
 .   if first ()
-//  Draft classes are by default not built stable releases
+//  Draft classes are by default not built in stable releases
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif
 typedef struct _$(class.c_name)_t $(class.c_name)_t;

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -556,10 +556,17 @@ for project.class
         resolve_c_class (class)
     else
         # If there is no API model for this class,
-        # all we can do is resolve the name.
+        # all we can do is resolve the name and state
         class.c_name = "$(class.name:c)"
+        set_state (class, "draft")
     endif
 endfor
+
+if count (project.class, !private & !draft)
+    project.stable = 1
+else
+    project.stable = 0
+endif
 
 # Resolve the dependencies of the classes from this project and load their APIs
 #

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -29,6 +29,7 @@ set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 ########################################################################
 # options
 ########################################################################
+.if project.stable
 if (EXISTS "${SOURCE_DIR}/.git")
     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
 else ()
@@ -38,6 +39,9 @@ endif ()
 IF (ENABLE_DRAFTS)
     ADD_DEFINITIONS (-D$(PROJECT.PREFIX)_BUILD_DRAFT_API)
 ENDIF (ENABLE_DRAFTS)
+.else
+ADD_DEFINITIONS (-D$(PROJECT.PREFIX)_BUILD_DRAFT_API)
+.endif
 
 ########################################################################
 # platform.h


### PR DESCRIPTION
It's clumsy that projects that don't even care about this aspect
are forced to use it, or they don't build properly. That is, the
project header is useless on projects consisting only of draft
classes, which is the default for new projects.

Solution: always build drafts on projects that have no stable
public classes.

Fixes #550