### PR TITLE
Problem: draft constants, typedefs and enums not added to internal header

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -349,6 +349,34 @@ $(project.GENERATED_WARNING_HEADER:)
 $(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
 .       endif
 .   endfor
+.   for constant where draft = 1
+.      if first ()
+
+//  *** Draft constants, defined for internal use only ***
+.      endif
+#define $(CLASS.NAME:c)_$(NAME:c) $(value)  // $(constant.description:no,block)
+.   endfor
+.   for class.enum where draft = 1
+.      if first ()
+
+//  *** Draft enums, defined for internal use only ***
+.      endif
+// $(enum.description:no,block)
+typedef enum {
+.       for enum.constant
+.           comma = last ()?? ""? ","
+    $(CLASS.NAME:c)_$(CONSTANT.NAME:c) = $(value)$(comma)   //  $(string.trim (constant.?''):left)
+.       endfor
+} $(class.name:c)_$(enum.name:c)_t;
+.   endfor
+.   for class.callback_type where draft = 1
+.      if first ()
+
+//  *** Draft callbacks, defined for internal use only ***
+.      endif
+// $(callback_type.description:no,block)
+$(c_callback_typedef (callback_type))
+.   endfor
 .endfor
 
 .for constant where scope = "private"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -105,6 +105,15 @@ if [ "$BUILD_TYPE" == "default" ]; then
     make check
     make memcheck
     make install
+
+    # Build and check this project without DRAFT APIs
+    make clean
+    git reset --hard HEAD
+    ./autogen.sh 2> /dev/null
+    ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
+    make -j4
+    make check
+    make install
 else
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="\$(dirs -l +1)" ./ci_build.sh
 fi


### PR DESCRIPTION
Stable build is currently broken on CZMQ due to this (ZGOSSIP defines missing).

Also add a stable build test to the CI, to make it easier to spot breakages.