### PR TITLE
Problem: enums are over-engineered

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,32 +20,32 @@
 **<a href="#toc2-131">Configuration</a>**
 
 **<a href="#toc2-313">Sample API model</a>**
-&emsp;<a href="#toc3-535">Supported API Model Attributes</a>
-&emsp;<a href="#toc3-551">API Types</a>
-&emsp;<a href="#toc3-592">Tips</a>
-&emsp;<a href="#toc3-609">Generate API model from C header files</a>
-&emsp;<a href="#toc4-631">Known caveats</a>
+&emsp;<a href="#toc3-526">Supported API Model Attributes</a>
+&emsp;<a href="#toc3-542">API Types</a>
+&emsp;<a href="#toc3-581">Tips</a>
+&emsp;<a href="#toc3-598">Generate API model from C header files</a>
+&emsp;<a href="#toc4-620">Known caveats</a>
 
-**<a href="#toc2-636">Language Binding Notes</a>**
-&emsp;<a href="#toc3-639">Java Language Binding</a>
+**<a href="#toc2-625">Language Binding Notes</a>**
+&emsp;<a href="#toc3-628">Java Language Binding</a>
 
-**<a href="#toc2-647">Draft API Support</a>**
+**<a href="#toc2-636">Draft API Support</a>**
 
-**<a href="#toc2-679">Targets</a>**
+**<a href="#toc2-668">Targets</a>**
 
-**<a href="#toc2-705">Removal</a>**
-&emsp;<a href="#toc3-708">autotools</a>
+**<a href="#toc2-694">Removal</a>**
+&emsp;<a href="#toc3-697">autotools</a>
 
-**<a href="#toc2-715">Notes for Writing Language Targets</a>**
-&emsp;<a href="#toc3-735">Schema/Architecture Overview</a>
-&emsp;<a href="#toc3-754">Informal Summary</a>
-&emsp;<a href="#toc3-759">Semantic Attributes</a>
-&emsp;<a href="#toc3-797">Target Scopes</a>
-&emsp;<a href="#toc3-802">Target Options</a>
+**<a href="#toc2-704">Notes for Writing Language Targets</a>**
+&emsp;<a href="#toc3-724">Schema/Architecture Overview</a>
+&emsp;<a href="#toc3-743">Informal Summary</a>
+&emsp;<a href="#toc3-748">Semantic Attributes</a>
+&emsp;<a href="#toc3-783">Target Scopes</a>
+&emsp;<a href="#toc3-788">Target Options</a>
 
-**<a href="#toc2-830">Ownership and License</a>**
-&emsp;<a href="#toc3-839">Hints to Contributors</a>
-&emsp;<a href="#toc3-848">This Document</a>
+**<a href="#toc2-816">Ownership and License</a>**
+&emsp;<a href="#toc3-825">Hints to Contributors</a>
+&emsp;<a href="#toc3-834">This Document</a>
 
 <A name="toc2-11" title="Overview" />
 ## Overview
@@ -368,12 +368,9 @@ The zproject scripts can also optionally generate the `@interface` in your class
 
     <constant name = "default port" value = "8080">registered with IANA</constant>
 
-    <enum name = "mode">
-        Enumeration defining different work modes. Constants are mandatory.
-        <constant name="normal" constant = "1">
-        <constant name="fast"   constant = "2">
-        <constant name="safe"   constant = "3">
-    </enum>
+    <constant name = "normal" value = "1">
+    <constant name = "fast"   value = "2">
+    <constant name = "safe"   value = "3">
 
     <!-- Constructor is optional; default one has no arguments -->
     <constructor>
@@ -498,13 +495,7 @@ The zproject scripts can also optionally generate the `@interface` in your class
             Supported sizes are 1, 2, 4, and 8.
         </argument>
         <argument name = "a byte" type = "byte" />
-        <argument name = "conversion mode" type = "enum:myclass.mode">
-            The container for this argument will get the following attributes:
-            * `is_enum = 1"
-            * `enum_class = "myclass"`
-            * `enum_name = "mode"`
-            * `c_type = "my_class_mode_t"`
-        </argument>
+        <argument name = "conversion mode" type = "integer" />
         <argument name = "char pointer to C string" type = "string" />
         <argument name = "byte pointer to buffer" type = "buffer" />
         <argument name = "buffer size" type = "size" />
@@ -571,7 +562,7 @@ MYPROJECT_EXPORT void
 //  @end
 ```
 
-<A name="toc3-535" title="Supported API Model Attributes" />
+<A name="toc3-526" title="Supported API Model Attributes" />
 ### Supported API Model Attributes
 
 The following attributes are supported for methods:
@@ -587,7 +578,7 @@ The following attributes are supported for arguments and return values:
 - `fresh = "1"` - the return value is freshly allocated, and the caller receives ownership of the object and the responsibility for destroying it. Implies mutable = "1".
 - `variadic = "1"` - used for representing variadic arguments.
 
-<A name="toc3-551" title="API Types" />
+<A name="toc3-542" title="API Types" />
 ### API Types
 
 This is an incomplete list of API types:
@@ -622,13 +613,11 @@ This is an incomplete list of API types:
 
 * "FILE", "va_list", "zmq_pollitem", "socket" -- literally that, in C. (Not sure if it is wise to use raw C types.)
 
-* enumerations - to be reviewed as these have a specific syntax that crams multiple properties into one attribute, not our usual way of working.
-
 * callbacks - tbd.
 
 * Names of classes, e.g. zmsg.
 
-<A name="toc3-592" title="Tips" />
+<A name="toc3-581" title="Tips" />
 ### Tips
 
 At any time, you can examine a resolved model as an XML string with all of its children and attributes using the appropriate GSL functions:
@@ -645,7 +634,7 @@ You can save a snapshot of the entire resolved project model using this syntax:
 gsl -save:1 project.xml
 ```
 
-<A name="toc3-609" title="Generate API model from C header files" />
+<A name="toc3-598" title="Generate API model from C header files" />
 ### Generate API model from C header files
 
 Writing API model for bigger project with a lot of classes can be tedious job. There mkapi.py, which automates most of the task.
@@ -667,15 +656,15 @@ Note you *must* use top-level include as pycparser fails if it does not know any
 
 The tool might expect `-DWITH_DRAFTS` parameter if the class is not marked as a stable.
 
-<A name="toc4-631" title="Known caveats" />
+<A name="toc4-620" title="Known caveats" />
 #### Known caveats
 
 The tool can't distinguish methods which allocates new object. It does print a comment about adding fresh = "1" attribute to each method, which return non const pointer. However the final assigment must be done manually.
 
-<A name="toc2-636" title="Language Binding Notes" />
+<A name="toc2-625" title="Language Binding Notes" />
 ## Language Binding Notes
 
-<A name="toc3-639" title="Java Language Binding" />
+<A name="toc3-628" title="Java Language Binding" />
 ### Java Language Binding
 
 * Skips methods that it cannot handle properly.
@@ -683,7 +672,7 @@ The tool can't distinguish methods which allocates new object. It does print a c
 * To build, you need gradle (or equivalent). Run 'gradle build jar' in the bindings/jni directory.
 * To install, run 'gradle install'. This puts the files into $HOME/.m2/repository.
 
-<A name="toc2-647" title="Draft API Support" />
+<A name="toc2-636" title="Draft API Support" />
 ## Draft API Support
 
 zproject lets you mark classes and methods as 'draft' so that they are not installed by default in stable builds. This lets you deliver draft APIs to your users, and change them later.
@@ -715,7 +704,7 @@ The allowed states are:
 
 Using autotools or CMake, you can specify --with-drafts to enable draft APIs, and --without-drafts to disable them. By default, drafts are built and installed when you work in a git repository (if the directory ".git" is present), and otherwise they are not. That means, if you build from a tarball, drafts are disabled by default.
 
-<A name="toc2-679" title="Targets" />
+<A name="toc2-668" title="Targets" />
 ## Targets
 
 Each target produces scripts and code for a specific build system, platform, or language binding.
@@ -741,17 +730,17 @@ To request all targets in your project.xml file:
 
     <target name = "*" />
 
-<A name="toc2-705" title="Removal" />
+<A name="toc2-694" title="Removal" />
 ## Removal
 
-<A name="toc3-708" title="autotools" />
+<A name="toc3-697" title="autotools" />
 ### autotools
 
 ```sh
 make uninstall
 ```
 
-<A name="toc2-715" title="Notes for Writing Language Targets" />
+<A name="toc2-704" title="Notes for Writing Language Targets" />
 ## Notes for Writing Language Targets
 
 This is the general form of a target:
@@ -771,7 +760,7 @@ function target_somename
 endfunction
 ```
 
-<A name="toc3-735" title="Schema/Architecture Overview" />
+<A name="toc3-724" title="Schema/Architecture Overview" />
 ### Schema/Architecture Overview
 
 * All `class`es SHALL be in the project model (`project.xml`).
@@ -790,12 +779,12 @@ endfunction
 * Each language binding generator MAY assign values to language-specific implementation attributes of entities.
 * Each language binding generator SHOULD use a unique prefix for names of language-specific implementation attributes of entities.
 
-<A name="toc3-754" title="Informal Summary" />
+<A name="toc3-743" title="Informal Summary" />
 ### Informal Summary
 
 A `class` is always the top-level entity in an API model, and it will be merged with the corresponding `class` entity defined in the project model. A class contains `method`s, `constructor`s, and `destructor`s (collectively, "method"s), and methods contain `argument`s and `return`s (collectively, "container"s). Each entity will contain both *semantic attributes* and *language-specific implementation attributes*.
 
-<A name="toc3-759" title="Semantic Attributes" />
+<A name="toc3-748" title="Semantic Attributes" />
 ### Semantic Attributes
 
 Semantic attributes describe something intrinsic about the container.
@@ -825,20 +814,17 @@ container.mutable      # 0/1 (default: 0)
 container.by_reference # 0/1 (default: 0)
 container.callback     # 0/1 (default: 0)
 container.fresh        # 0/1 (default: 0)
-container.is_enum      # 0/1 (default: 0)
-container.enum_name    # string if is_enum, otherwise undefined
-container.enum_class   # string if is_enum, otherwise undefined
 container.variadic     # 0/1 (default: 0)
 container.va_start     # string - that holds the argment name for va_start ()
 container.optional     # 0/1 (default: 0), up to binding generator to use
 ```
 
-<A name="toc3-797" title="Target Scopes" />
+<A name="toc3-783" title="Target Scopes" />
 ### Target Scopes
 
 Each target works in its own copy of 'project'. It can therefore modify and extend 'project' as wanted, without affecting other targets.
 
-<A name="toc3-802" title="Target Options" />
+<A name="toc3-788" title="Target Options" />
 ### Target Options
 
 A target can accept options via project.xml like this:
@@ -866,7 +852,7 @@ project.nuget_dependency.name = "libzmq_vc120"
 project.nuget_dependency.value = "4.2.0.0"
 ```
 
-<A name="toc2-830" title="Ownership and License" />
+<A name="toc2-816" title="Ownership and License" />
 ## Ownership and License
 
 The contributors are listed in AUTHORS. This project uses the MPL v2 license, see LICENSE.
@@ -875,7 +861,7 @@ zproject uses the [C4.1 (Collective Code Construction Contract)](http://rfc.zero
 
 To report an issue, use the [zproject issue tracker](https://github.com/zeromq/zproject/issues) at github.com.
 
-<A name="toc3-839" title="Hints to Contributors" />
+<A name="toc3-825" title="Hints to Contributors" />
 ### Hints to Contributors
 
 Make sure that the project model hides all details of backend scripts. For example don't make a user enter a header file because autoconf needs it.
@@ -884,7 +870,7 @@ Do read your code after you write it and ask, "Can I make this simpler?" We do u
 
 Before opening a pull request read our [contribution guidelines](https://github.com/zeromq/zproject/blob/master/CONTRIBUTING.md). Thanks!
 
-<A name="toc3-848" title="This Document" />
+<A name="toc3-834" title="This Document" />
 ### This Document
 
 This document is originally at README.txt and is built using [gitdown](http://github.com/imatix/gitdown).

--- a/README.txt
+++ b/README.txt
@@ -214,8 +214,6 @@ This is an incomplete list of API types:
 
 * "FILE", "va_list", "zmq_pollitem", "socket" -- literally that, in C. (Not sure if it is wise to use raw C types.)
 
-* enumerations - to be reviewed as these have a specific syntax that crams multiple properties into one attribute, not our usual way of working.
-
 * callbacks - tbd.
 
 * Names of classes, e.g. zmsg.
@@ -404,9 +402,6 @@ container.mutable      # 0/1 (default: 0)
 container.by_reference # 0/1 (default: 0)
 container.callback     # 0/1 (default: 0)
 container.fresh        # 0/1 (default: 0)
-container.is_enum      # 0/1 (default: 0)
-container.enum_name    # string if is_enum, otherwise undefined
-container.enum_class   # string if is_enum, otherwise undefined
 container.variadic     # 0/1 (default: 0)
 container.va_start     # string - that holds the argment name for va_start ()
 container.optional     # 0/1 (default: 0), up to binding generator to use

--- a/api/myclass.api
+++ b/api/myclass.api
@@ -11,12 +11,9 @@
 
     <constant name = "default port" value = "8080">registered with IANA</constant>
 
-    <enum name = "mode">
-        Enumeration defining different work modes. Constants are mandatory.
-        <constant name="normal" constant = "1">
-        <constant name="fast"   constant = "2">
-        <constant name="safe"   constant = "3">
-    </enum>
+    <constant name = "normal" value = "1">
+    <constant name = "fast"   value = "2">
+    <constant name = "safe"   value = "3">
 
     <!-- Constructor is optional; default one has no arguments -->
     <constructor>
@@ -141,13 +138,7 @@
             Supported sizes are 1, 2, 4, and 8.
         </argument>
         <argument name = "a byte" type = "byte" />
-        <argument name = "conversion mode" type = "enum:myclass.mode">
-            The container for this argument will get the following attributes:
-            * `is_enum = 1"
-            * `enum_class = "myclass"`
-            * `enum_name = "mode"`
-            * `c_type = "my_class_mode_t"`
-        </argument>
+        <argument name = "conversion mode" type = "integer" />
         <argument name = "char pointer to C string" type = "string" />
         <argument name = "byte pointer to buffer" type = "buffer" />
         <argument name = "buffer size" type = "size" />

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -356,19 +356,6 @@ $(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
 .      endif
 #define $(CLASS.NAME:c)_$(NAME:c) $(value)  // $(constant.description:no,block)
 .   endfor
-.   for class.enum where draft = 1
-.      if first ()
-
-//  *** Draft enums, defined for internal use only ***
-.      endif
-// $(enum.description:no,block)
-typedef enum {
-.       for enum.constant
-.           comma = last ()?? ""? ","
-    $(CLASS.NAME:c)_$(CONSTANT.NAME:c) = $(value)$(comma)   //  $(string.trim (constant.?''):left)
-.       endfor
-} $(class.name:c)_$(enum.name:c)_t;
-.   endfor
 .   for class.callback_type where draft = 1
 .      if first ()
 
@@ -401,16 +388,6 @@ $(c_callback_typedef (callback_type))
 .   if last ()
 
 .   endif
-.   endfor
-.   for class.enum where draft = my.draft
-// $(enum.description:no,block)
-typedef enum {
-.       for enum.constant
-.           comma = last ()?? ""? ","
-    $(CLASS.NAME:c)_$(CONSTANT.NAME:c) = $(value)$(comma)   //  $(string.trim (constant.?''):left)
-.       endfor
-} $(class.name:c)_$(enum.name:c)_t;
-
 .   endfor
 .   for class.callback_type where draft = my.draft
 // $(callback_type.description:no,block)

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -78,7 +78,6 @@ function resolve_c_container (container)
     my.container.callback ?= 0
     my.container.fresh ?= 0
     my.container.variadic ?= 0
-    my.container.is_enum ?= 0
     my.container.optional ?= 0
 
     # Resolve language-specific attributes for the C language.
@@ -167,12 +166,6 @@ function resolve_c_container (container)
         endif
     elsif my.container.callback
         my.c_type = "$(my.type:c)"
-    elsif string.prefix (my.container.type, ":") = "enum"
-        my.container.is_enum = 1
-        my.class_sep = string.locate (my.container.type, ".")
-        my.container.enum_class = string.substr (my.container.type, 5, my.class_sep-1)
-        my.container.enum_name = string.substr (my.container.type, my.class_sep+1)
-        my.c_type = "$(my.container.enum_class:c)_$(my.container.enum_name:c)_t"
     else
         #   Map unknown type XYZ to "XYZ_t *" and resolve later
         my.container.foreign = 1
@@ -370,12 +363,6 @@ function resolve_c_class (class)
     # Resolve details of each constant
     for my.class.constant
         resolve_c_constant (constant, my.class.state)
-    endfor
-
-    # Resolve details of each constant
-    for my.class.enum
-        enum.description ?= "$(string.trim (enum.?""):left)"
-        set_state (enum, my.class.state)
     endfor
 endfunction
 

--- a/zproject_java_lib.gsl
+++ b/zproject_java_lib.gsl
@@ -104,10 +104,6 @@ function resolve_container (container)
     elsif my.container.callback ?= 1
         return 1        #   Don't implement callbacks yet
 
-    elsif my.container.is_enum
-        my.container.jni_java_type = "int"
-        my.container.jni_jni_type = "jint"
-
     elsif my.container.type = "va_list" \
     |     my.container.type = "FILE" \
     |     my.container.type = "zmq_pollitem" \

--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -17,6 +17,7 @@ function target_nodejs
 
 function resolve_method (method)
     my.method.called = ""
+    my.method.exported = 1
     comma = ""
 
     for argument
@@ -38,13 +39,16 @@ function resolve_method (method)
         endif
 
         #   These are the types of argument we support so far
-        if type = "integer" | type = "number" | type = "size" | type = "boolean" \
-        |  type = "string" \
+        if type = "integer" \
+        |  type = "number" \
+        |  type = "size" \
+        |  type = "boolean" \
         |  type = "real"
-            my.method.called += "$(comma)$(c_type)$(c_name)"
+            my.method.called += "$(comma)$(c_type) $(c_name)"
             comma = ", "
 
-        elsif type = "format"
+        elsif type = "format" \
+        |     type = "string"
             my.method.called += "$(comma)$(c_type)$(c_name)"
             comma = ", "
 
@@ -58,11 +62,11 @@ function resolve_method (method)
             argument.is_object = 1
 
         elsif count (project->dependencies.class, class.c_name = argument.type)
-            my.method.bypass = 1
+            my.method.exported = 0
             echo "nodejs: can't do '$(type)', $(class.c_name).$(my.method.c_name).$(argument.c_name)"
 
         else
-            my.method.bypass = 1
+            my.method.exported = 0
             echo "nodejs: can't do '$(type)', $(class.c_name).$(my.method.c_name).$(argument.c_name)"
         endif
     else
@@ -71,10 +75,9 @@ function resolve_method (method)
 
     if count (project.class, class.c_name = my.method->return.type) \
     |  count (project->dependencies.class, class.c_name = my.method->return.type)
-        my.method.bypass = 1
+        my.method.exported = 0
         echo "nodejs: skipping '$(->return.type)' $(class.c_name).$(c_name) ()"
     endif
-
 endfunction
 
 .macro generate_binding
@@ -123,7 +126,7 @@ This is a wrapping of the native C $(project.libname) library. See binding.cc fo
 
 We get these classes:
 
-.for project.class where defined (class.api)
+.for project.class where exported
 * $(class.name:Pascal) - $(class.description:)
 .endfor
 .output "$(topdir)/.gitignore"
@@ -231,6 +234,11 @@ $(project.GENERATED_WARNING_HEADER:)
     {
       'target_name': '$(project.name)',
       'sources': [
+.   for project.use where !optional
+.       if file.exists ("../$(use.project)/$(topdir)/binding.cc")
+          '../../../$(use.project)/$(topdir)/binding.cc',
+.       endif
+.   endfor
           'binding.cc'
       ],
       'include_dirs': [
@@ -300,7 +308,7 @@ $(project.GENERATED_WARNING_HEADER:)
 }
 .output "$(topdir)/binding.h"
 /*  =========================================================================
-    $(project.name:c) Node.js binding header file
+    $(project.name:) Node.js binding header file
 
 .   for project.license
     $(string.trim (license.):block                                         )
@@ -311,13 +319,15 @@ $(project.GENERATED_WARNING_HEADER:)
 #ifndef $(PROJECT.NAME:C)_BINDING_H_INCLUDED
 #define $(PROJECT.NAME:C)_BINDING_H_INCLUDED
 
+#define $(PROJECT.PREFIX)_BUILD_DRAFT_API
+
 #include "$(project.header)"
 #include "nan.h"
 
 using namespace v8;
 using namespace Nan;
 
-.for project.class where defined (class.api)
+.for project.class where exported
 class $(class.name:Pascal): public Nan::ObjectWrap {
     public:
         static NAN_MODULE_INIT (Init);
@@ -344,8 +354,8 @@ class $(class.name:Pascal): public Nan::ObjectWrap {
 .   if count (class.constructor)
     static NAN_METHOD (defined);
 .   endif
-.   for class.method where !defined (bypass)
-    static NAN_METHOD ($(method.c_name));
+.   for class.method where exported
+    static NAN_METHOD (_$(method.c_name));
 .   endfor
 };
 
@@ -353,7 +363,7 @@ class $(class.name:Pascal): public Nan::ObjectWrap {
 #endif
 .output "$(topdir)/binding.cc"
 /*  =========================================================================
-    $(project.name:c) Node.js binding implementation
+    $(project.name:) Node.js binding implementation
 
 .   for project.license
     $(string.trim (license.):block                                         )
@@ -376,6 +386,8 @@ using namespace Nan;
     endif
 
     for argument
+        argument.ref = by_reference?? '&'? ''
+
         #   These are the types of argument we support so far
         if type = "integer" \
         |  type = "number" \
@@ -383,7 +395,7 @@ using namespace Nan;
         |  type = "boolean" \
         |  type = "string" \
         |  type = "real"
-            my.invoke += "$(comma)$(c_name)"
+            my.invoke += "$(comma)$(ref)$(c_name)"
             comma = ", "
 
         elsif type = "format"
@@ -398,7 +410,7 @@ using namespace Nan;
             if my.map_objects ?= 1
                 my.invoke += "$(comma)$(c_name)->get_self ()"
             else
-                my.invoke += "$(comma)$(c_name)"
+                my.invoke += "$(comma)$(ref)$(c_name)"
             endif
             comma = ", "
 
@@ -414,46 +426,46 @@ using namespace Nan;
 .   my.invoke = ""
 .   for argument
 .       if type = "integer" | type = "number" | type = "size" | type = "boolean" | type = "real"
-        if (info [$(index () - 1)]->IsUndefined ())
-            return Nan::ThrowTypeError ("method requires a `$(name)`");
-        else
+    if (info [$(index () - 1)]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `$(name)`");
+    else
 .           if type = "boolean"
-        if (!info [$(index () - 1)]->IsBoolean ())
+    if (!info [$(index () - 1)]->IsBoolean ())
 .           elsif type = "real"
-        if (!info [$(index () - 1)]->IsDouble ())
+    if (!info [$(index () - 1)]->IsDouble ())
 .           else
-        if (!info [$(index () - 1)]->IsNumber ())
+    if (!info [$(index () - 1)]->IsNumber ())
 .           endif
-            return Nan::ThrowTypeError ("`$(name)` must be a number");
-        $(c_type) $(c_name) = Nan::To<$(nan_type:)>(info [$(index () - 1)]).FromJust ();
+        return Nan::ThrowTypeError ("`$(name)` must be a number");
+    $(c_type) $(c_name) = Nan::To<$(nan_type:)>(info [$(index () - 1)]).FromJust ();
 
 .       elsif type = "string" | type = "format"
-        char *$(c_name);
-        if (info [$(index () - 1)]->IsUndefined ())
+    char *$(c_name);
+    if (info [$(index () - 1)]->IsUndefined ())
 .           if optional
-            $(c_name) = NULL;
+        $(c_name) = NULL;
 .           else
-            return Nan::ThrowTypeError ("method requires a `$(name)`");
+        return Nan::ThrowTypeError ("method requires a `$(name)`");
 .           endif
-        else
-        if (!info [$(index () - 1)]->IsString ())
-            return Nan::ThrowTypeError ("`$(name)` must be a string");
-        else {
-            Nan::Utf8String $(c_name)_utf8 (info [$(index () - 1)].As<String>());
-            $(c_name) = *$(c_name)_utf8;
-        }
+    else
+    if (!info [$(index () - 1)]->IsString ())
+        return Nan::ThrowTypeError ("`$(name)` must be a string");
+    else {
+        Nan::Utf8String $(c_name)_utf8 (info [$(index () - 1)].As<String>());
+        $(c_name) = *$(c_name)_utf8;
+    }
 .       elsif argument.is_object ?= 1
-        $(type:Pascal) *$(name) = Nan::ObjectWrap::Unwrap<$(type:Pascal)>(info [$(index () - 1)].As<Object>());
+    $(type:Pascal) *$(name) = Nan::ObjectWrap::Unwrap<$(type:Pascal)>(info [$(index () - 1)].As<Object>());
 
 .       elsif type = "nothing"
 .           #   Do nothing
 .       else
-        //  TODO: How do we check $(type)/$(c_type) $(name)?
+    //  TODO: How do we check $(type)/$(c_type) $(name)?
 .       endif
 .   endfor
 .endmacro
 .
-.for project.class where defined (class.api)
+.for project.class where exported
 
 NAN_MODULE_INIT ($(class.name:Pascal)::Init) {
     Nan::HandleScope scope;
@@ -470,8 +482,8 @@ NAN_MODULE_INIT ($(class.name:Pascal)::Init) {
 .   if count (class.constructor)
     Nan::SetPrototypeMethod (tpl, "defined", defined);
 .   endif
-.   for class.method where !defined (bypass)
-    Nan::SetPrototypeMethod (tpl, "$(method.name:Camel)", $(method.c_name));
+.   for class.method where exported
+    Nan::SetPrototypeMethod (tpl, "$(method.name:Camel)", _$(method.c_name));
 .   endfor
 
     constructor ().Reset (Nan::GetFunction (tpl).ToLocalChecked ());
@@ -524,9 +536,9 @@ NAN_METHOD ($(class.name:Pascal)::defined) {
     info.GetReturnValue ().Set (Nan::New ($(class.c_name)->self != NULL));
 }
 .   endif
-.   for class.method where !defined (bypass)
+.   for class.method where exported
 
-NAN_METHOD ($(class.name:Pascal)::$(method.c_name)) {
+NAN_METHOD ($(class.name:Pascal)::_$(method.c_name)) {
 .       if !singleton
     $(class.name:Pascal) *$(class.c_name) = Nan::ObjectWrap::Unwrap <$(class.name:Pascal)> (info.Holder ());
 .       endif
@@ -548,7 +560,6 @@ NAN_METHOD ($(class.name:Pascal)::$(method.c_name)) {
     $(class.c_name)_$(method.c_name) ($(invoke (method)));
 .
 .       else
-.           my.method.bypass = 1
 .           echo "nodejs: what do we do with return '$(->return.type)', $(class.c_name).$(method.c_name)?"
 .       endif
 }
@@ -569,7 +580,7 @@ $(class.c_name)_t *$(class.name:Pascal)::get_self () {
 
 extern "C" NAN_MODULE_INIT ($(project.name:c)_initialize)
 {
-.for project.class where defined (class.api)
+.for project.class where exported
     $(class.name:Pascal)::Init (target);
 .endfor
 }
@@ -582,16 +593,24 @@ NODE_MODULE ($(project.name:c), $(project.name:c)_initialize)
 
     project.topdir = "bindings/nodejs"
     directory.create (project.topdir)
-    for project.class where defined (class.api)
-        for constructor
-            resolve_method (constructor)
-        endfor
-        for destructor
-            resolve_method (destructor)
-        endfor
-        for method
-            resolve_method (method)
-        endfor
+    for project.class
+        if defined (class.api) & scope = "public"
+            class.exported = 1
+            for constructor
+                resolve_method (constructor)
+                if !constructor.exported
+                    class.exported = 0
+                endif
+            endfor
+            for destructor
+                resolve_method (destructor)
+            endfor
+            for method
+                resolve_method (method)
+            endfor
+        else
+            class.exported = 0
+        endif
     endfor
     generate_binding ()
 endfunction

--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -68,10 +68,6 @@ function resolve_container (container)
 
     if my.container.variadic
         my.container.python_type = "" # ctypes doesn't explictly state variadic signatures, so we just leave it off
-    elsif my.container.is_enum
-        my.container.python_type = "c_int"
-        my.container.python_coerce = "$(my.container.enum_class:Pascal).$(my.container.enum_name:Pascal)[<>]"
-        my.container.python_return = "$(my.container.enum_class:Pascal).$(my.container.enum_name:Pascal)_out[<>]"
     elsif my.container.type = "nothing"
         my.container.python_type = "None"
     elsif my.container.type = "anything"
@@ -404,20 +400,6 @@ function generate_binding
         >    """
         >    $(class.description:no)
         >    """
-        for enum
-            >
-            >    $(enum.name:Pascal) = {
-            for enum.constant
-                >        '$(constant.name)': $(constant.value),
-            endfor
-            >    }
-            >
-            >    $(enum.name:Pascal)_out = {
-            for enum.constant
-                >         $(constant.value): '$(constant.name)',
-            endfor
-            >    }
-        endfor
         >
         for constant
             >    $(CONSTANT.NAME:c) = $(constant.value)\

--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -29,7 +29,6 @@ endfunction
 
 function resolve_container (container)
     if my.container.variadic
-    elsif my.container.is_enum
     elsif my.container.type = "nothing"
     elsif my.container.type = "anything"
     elsif my.container.type = "boolean"
@@ -113,14 +112,6 @@ function generate_binding
         >typedef struct _$(t.name:c) $(t.name:c);
     endfor
     for class where defined (class.api) & class.private = "0"
-        for class.enum
-            >typedef enum {
-            for enum.constant
-                comma = last ()?? ""? ","
-                >    $(CLASS.NAME:c)_$(CONSTANT.NAME:c) = $(value)$(comma)   //  $(string.trim (constant.?''):left)
-            endfor
-            >} $(class.name:c)_$(enum.name:c)_t;
-        endfor
         for class.callback_type
             >// $(callback_type.description:no,block)
             >$(c_callback_typedef (callback_type):)

--- a/zproject_ruby.gsl
+++ b/zproject_ruby.gsl
@@ -18,15 +18,6 @@ register_target ("ruby", "Ruby binding")
 #   Target provides name space isolation for its functions
 function target_ruby
 
-function resolve_ruby_enums (class)
-    for my.class.enum
-        #   Useful to test existence of enum later when resolving
-        #   arguments of enum type
-        enum.c_type    = "$(my.class.c_name:)_$(enum.name:c)_t"
-        enum.ruby_name = "$(my.class.c_name:)_$(enum.name:c)"
-    endfor
-endfunction
-
 # Work out Ruby name based on container.name and and set it as
 # container.ruby_name.
 function sanitize_ruby_container_name(container)
@@ -101,9 +92,6 @@ function resolve_ruby_container (container)
         my.container.ruby_doc_type = "Integer, #to_int, #to_i"
         my.container.ruby_ffi_type = "char"
         my.container.coerce_to_c = "Integer($(my.container.ruby_name:))"
-    elsif my.container.is_enum
-        my.container.ruby_doc_type = "Symbol"
-        my.container.ruby_ffi_type = "$(my.container.enum_class:)_$(my.container.enum_name)"
     elsif count (project.class, defined (class.RubyName) & (my.container.type = class.c_name))
         for project.class where (defined (class.RubyName) & (my.container.type = class.c_name))
             if my.container.by_reference
@@ -242,7 +230,6 @@ function ruby_doc_arg_description (argument)
 endfunction
 
 function resolve_ruby_class (class)
-    resolve_ruby_enums (class)
     for my.class.constructor as method
         resolve_ruby_method (method)
     endfor
@@ -309,15 +296,6 @@ module $(project.RubyName:)
       }
 .for class where defined (class.api) & class.private = "0"
 
-.for enum
-      enum :$(enum.ruby_name:), [
-.  for enum.constant
-.       # Ruby doesn't care about that last trailing comma ;-)
-        :$(constant.name:c), $(constant.value),
-.  endfor
-      ]
-
-.endfor
 .for constructor as method
 .  if method.state = 'draft'
       begin # DRAFT method


### PR DESCRIPTION
These are just constants, yet the syntax for defining and using
them is complex and does not solve any identifiable problem except
"maintain compatibility with existing header files".

As well as being complex to specify and use, they're a pain to
implement in bindings.

The simplest solution is to use constants. I've done that in CZMQ
and Zyre and now here in zproject.

Solution: use constants.

Fixes #460