### PR TITLE
add error message for missing test field

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -167,6 +167,10 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
                 AC_MSG_ERROR([${with_$(use.libname)}/include/$(use.header) not found. Please check $(use.libname) prefix])
             fi
         fi
+.       if !defined(use.test)
+.           abort "test is not set on project " + use.project + " please ensure it is set"
+.       endif
+
 
         AC_CHECK_LIB([$(use.libname)], [$(use.test:)],
             [


### PR DESCRIPTION
problem: old error message was just an undefined item error
solution: check that test exists first, give error that leads user towards solution