### PR TITLE
Problem: configure line in generated spec is wrong

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -100,7 +100,7 @@ This package contains development files.
 
 %build
 sh autogen.sh
-%{configure} --with-systemd
+%{configure} --with-systemd-units
 make %{_smp_mflags}
 
 %install


### PR DESCRIPTION
Solution: use --with-systemd-units (changed in ed6d506d)