### PR TITLE
add notests to zproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,10 @@ zproject's `project.xml` contains an extensive description of the available conf
         Classes, if the class header or source file doesn't exist, this will
         generate a skeletons for them.
         use private = "1" for internal classes
+        use notest = "1" if you do not want self test generated
     <class name = "myclass">Public class description</class>
     <class name = "someother" private = "1">Private class description</class>
+    <class name = "myclasswithouttests" private = "1">My class</class>
     -->
 
     <!--
@@ -254,7 +256,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         actors class header or source file doesn't exist, this will generate a
         skeleton for them. The generated test method of the actor will teach
         you how to use them. Also have a look at the CZMQ docs to learn more
-        about actors.
+        about actors. You can also specify notest="1" to not generate tests
     <actor name = "myactor">Public actor description</actor>
     <actor name = "someactor" private = "1">Private actor description</actor>
     -->

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -187,14 +187,18 @@ typedef struct {
 
 static test_item_t
 all_tests [] = {
-.for class where !draft
+.for class where !draft 
+.   if !defined(class.notest) | !class.notest="1"
     { "$(class.c_name)", $(class.c_name)_test },
+.   endif
 .endfor
 .for class where draft
 .   if first ()
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif
+.   if !defined(class.notest) | !class.notest="1"
     { "$(class.c_name)", $(class.c_name)_test },
+.   endif
 .   if last ()
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif

--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -287,7 +287,7 @@ $(actor.name:c)_actor (zsock_t *pipe, void *args)
     $(actor.name:c)_destroy (&self);
 }
 
-
+.   if !defined(actor.notest) | !actor.notest="1"
 //  --------------------------------------------------------------------------
 //  Self test of this actor.
 
@@ -304,6 +304,7 @@ $(actor.name:c)_test (bool verbose)
 
     printf ("OK\\n");
 }
+.   endif
 .   close
 . endif
 .endmacro
@@ -349,9 +350,12 @@ $(PROJECT.PREFIX)_EXPORT $(class.c_name)_t *
 $(PROJECT.PREFIX)_EXPORT void
     $(class.c_name)_destroy ($(class.c_name)_t **self_p);
 
+.   if !defined(class.notest) | !class.notest="1"
 //  Self test of this class
 $(PROJECT.PREFIX)_EXPORT void
     $(class.c_name)_test (bool verbose);
+.   endif
+
 //  @end
 
 #ifdef __cplusplus
@@ -421,7 +425,7 @@ $(class.c_name)_destroy ($(class.c_name)_t **self_p)
     }
 }
 
-
+.   if !defined(class.notest) | !class.notest="1"
 //  --------------------------------------------------------------------------
 //  Self test of this class
 
@@ -438,6 +442,7 @@ $(class.c_name)_test (bool verbose)
     //  @end
     printf ("OK\\n");
 }
+.   endif
 .   close
 . endif
 .endmacro


### PR DESCRIPTION
Problem: don't want self tests generated for some thing (bringing in a class that is generated by protobuf-c is a good example)
Solution: add notest to class/actor which will optionally not generate self test and will not include file in self_test