### PR TITLE
Problem: [travis] make memcheck causes failing builds all the time

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -103,7 +103,6 @@ if [ "$BUILD_TYPE" == "default" ]; then
     ./configure "${CONFIG_OPTS[@]}"
     make -j4
     make check
-    make memcheck
     make install
 
     # Build and check this project without DRAFT APIs


### PR DESCRIPTION
Solution: Remove memcheck from the travis build.

During the last months `make memcheck` caused all zproject based builds to
fail because there are supposedly memory leaks within other layers of the
software e.g. libzmq, which causes the build to fail all the time. IMO
the memcheck should be run manually in addition to testing and not by
travis itself.