### PR TITLE
Problem: make code target not work in out of source builds

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -756,7 +756,7 @@ code:
 \tcd $\(srcdir)/src; gsl -topdir:.. -zproject:1 -q $(name).xml
 .   endif
 .endfor
-\tgsl -target:- project.xml
+\tcd $\(srcdir); gsl -target:- project.xml
 
 check-local: src/$(project.prefix)_selftest
 \t$\(LIBTOOL) --mode=execute $\(srcdir)/src/$(project.prefix)_selftest


### PR DESCRIPTION
Solution: chdir to project home before gsl script processing