### PR TITLE
Problem: project build broken with draft typedefs

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -337,6 +337,9 @@ $(project.GENERATED_WARNING_HEADER:)
 .for header where scope = "private"
 #include "$(header.name).h"
 .endfor
+
+//  *** To avoid double-definitions, only define if building without draft ***
+#ifndef $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .for class where draft = 0
 .   for constant where draft = 1
 .      if first ()
@@ -365,6 +368,8 @@ $(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
 .       endif
 .   endfor
 .endfor
+
+#endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 
 .for constant where scope = "private"
 .   if first ()

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -338,17 +338,6 @@ $(project.GENERATED_WARNING_HEADER:)
 #include "$(header.name).h"
 .endfor
 .for class where draft = 0
-.   for . as method where draft = 1
-.       if name () = "constructor" | name () = "method" | name () = "destructor"
-
-//  *** Draft method, defined for internal use only ***
-//  $(.description:no,block)
-.           if ->return.fresh
-//  Caller owns return value and must destroy it when done.
-.           endif
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
-.       endif
-.   endfor
 .   for constant where draft = 1
 .      if first ()
 
@@ -363,6 +352,17 @@ $(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
 .      endif
 // $(callback_type.description:no,block)
 $(c_callback_typedef (callback_type))
+.   endfor
+.   for . as method where draft = 1
+.       if name () = "constructor" | name () = "method" | name () = "destructor"
+
+//  *** Draft method, defined for internal use only ***
+//  $(.description:no,block)
+.           if ->return.fresh
+//  Caller owns return value and must destroy it when done.
+.           endif
+$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
+.       endif
 .   endfor
 .endfor
 


### PR DESCRIPTION
Solution: see commits:

> Problem: methods use typedef defined after them
> Solution: in src/<project>_classes.h define typedef and constants
> first and method later, like in the public headers, otherwise
> compilation will fail with draft API disabled.
> 
> Problem: draft API defined twice, breaks build
> Solution: wrap definition of DRAFT APIs in the src/project_classes.h
> private header in ifndef DRAFT. This will avoid build problems caused
> by having some items defined twice, in the public and in the private
> headers, when building with DRAFT enabled. At the moment it only
> affects typedefs, but it's cleaner and more future-proof to wrap the
> whole definition rather than one item here and there.