### PR TITLE
Problem: configure.bat incorrectly supports --disable-drafts option

### DIFF
--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -189,7 +189,10 @@ IF EXIST "..\\..\\..\\$(use.project)" (
 .endfor
 
 :-  Check if we want to build the draft API
+if "%1" == "--enable-drafts" goto :with_draft
+if "%1" == "--disable-drafts" goto :no_draft
 IF NOT EXIST "..\\..\\.git" GOTO no_draft
+:with_draft
     ECHO Building with draft API (stable + legacy + draft API)
     ECHO //  Provide draft classes and methods>>platform.h
     ECHO #define $(PROJECT.PREFIX)_BUILD_DRAFT_API 1>>platform.h


### PR DESCRIPTION
Solution: corrected support to --disable-drafts and --enable-drafts cmd line options

Note: presence of .git directory at main level still implies enable DRAFT APIs same as before if no cmd line options are present. If present, the requested cmd line optiont takes precedence.