### PR TITLE
Problem: [autotools] libname fails to do library check on some deps

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -172,7 +172,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
 .       endif
 
 
-        AC_CHECK_LIB([$(use.libname)], [$(use.test:)],
+        AC_CHECK_LIB([$(use.prefix)], [$(use.test:)],
             [
                 CFLAGS="${$(use.project:c)_synthetic_cflags} ${CFLAGS}"
                 LDFLAGS="${$(use.project:c)_synthetic_libs} ${LDFLAGS}"


### PR DESCRIPTION
Solution: Use the prefix attribute instead which must be correct for all dependencies.