### PR TITLE
Problem: No easy way to debug windows batch scripts

### DIFF
--- a/zproject_java_msvc.gsl
+++ b/zproject_java_msvc.gsl
@@ -182,7 +182,7 @@ Global
 EndGlobal
 .terminator="\r\n"
 .output "$(my.path)/build.bat"
-@ECHO OFF
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 $(project.generated_warning_header_for_dot_bat:)
 SET solution=$(project.name:c).sln
 SET version=$(my.level)
@@ -195,6 +195,7 @@ IF NOT EXIST %environment% GOTO no_tools
 ECHO Building %solution%...
 
 CALL %environment% x86 > nul
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x86
 
 ECHO Configuration=DynDebug
@@ -205,6 +206,7 @@ msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=Win32 %solution% >> %log
 IF errorlevel 1 GOTO error
 
 CALL %environment% x86_amd64 > nul
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x64
 
 ECHO Configuration=DynDebug
@@ -226,7 +228,7 @@ ECHO *** ERROR, build tools not found: %tools%
 
 :end
 .output "$(my.path)/call_javah.bat"
-@ECHO OFF
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 $(project.generated_warning_header_for_dot_bat:)
 ECHO Generating native JNI headers...
 .for class where okay

--- a/zproject_nuget.gsl
+++ b/zproject_nuget.gsl
@@ -17,7 +17,7 @@ function target_nuget
 .macro generate_packaging
 .terminator="\r\n"
 .output "$(topdir)/package.bat"
-@ECHO OFF
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 $(project.generated_warning_header_for_dot_bat:)
 ECHO Started nuget packaging build.
 ECHO.

--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -24,6 +24,7 @@ register_target ("vs2015", "Microsoft Visual Studio 2015")
 *.user
 *.aps
 *.log
+*.tlog
 ipch/
 .terminator="\r\n"
 .output "$(my.path)/resource.rc"
@@ -139,7 +140,7 @@ END
 .output "$(my.path)/platform.h"
 #error "Run configure.bat to create platform.h"
 .output "$(my.path)/configure.bat"
-@ECHO OFF
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 $(project.generated_warning_header_for_dot_bat:)
 @setlocal
 :-  configure.bat creates platform.h and configures the build process
@@ -648,7 +649,7 @@ Global
     EndGlobalSection
 EndGlobal
 .output "$(my.path)/build.bat"
-@ECHO OFF
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 $(project.generated_warning_header_for_dot_bat:)
 :: Usage:     build.bat [Clean]
 @setlocal
@@ -698,6 +699,7 @@ ECHO %action% $(project.name:)... (%packages%)
 
 :: set correct environment for build target
 CALL %environment% x86 >> %log%
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x86
 
 ECHO Configuration=DynDebug
@@ -724,6 +726,7 @@ IF errorlevel 1 GOTO error
 
 :: set correct environment for build target
 CALL %environment% x86_amd64 >> %log%
+@if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x64
 
 ECHO Configuration=DynDebug


### PR DESCRIPTION
Solution: Added check for environment variable ECHOON. If set to "on" all
scripts behave as if @echo on is first line.
Reset also after every call to scripts that would turn echo off, such as
DevStudio provided scripts.