### PR TITLE
Problem: [autotools] make dist does not build zip by default

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -68,7 +68,7 @@ AC_INIT([$(project.name)],[$(->version.major).$(->version.minor).$(->version.pat
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS([src/platform.h])
-AM_INIT_AUTOMAKE([subdir-objects tar-ustar foreign])
+AM_INIT_AUTOMAKE([subdir-objects tar-ustar dist-zip foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # This defines PACKAGE_VERSION_... in src/platform.h


### PR DESCRIPTION
Solution: Tell automake to build zip as well as tarball.