### PR TITLE
Problem: [travis] deploying release artifacts is a manual process

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_INIT([myproject],[1.1.0],[email@hostname.com])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS([src/platform.h])
-AM_INIT_AUTOMAKE([subdir-objects tar-ustar foreign])
+AM_INIT_AUTOMAKE([subdir-objects tar-ustar dist-zip foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # This defines PACKAGE_VERSION_... in src/platform.h

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -50,31 +50,31 @@ myproject_SCRIPTS = \
 	cd $(srcdir); gsl -target:- project.xml
 
 check-local: src/myproject_selftest
-	$(LIBTOOL) --mode=execute $(srcdir)/src/myproject_selftest
+	$(LIBTOOL) --mode=execute $(builddir)/src/myproject_selftest
 
 check-verbose: src/myproject_selftest
-	$(LIBTOOL) --mode=execute $(srcdir)/src/myproject_selftest -v
+	$(LIBTOOL) --mode=execute $(builddir)/src/myproject_selftest -v
 
 # Run the selftest binary under valgrind to check for memory leaks
 memcheck: src/myproject_selftest
 	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
-		$(srcdir)/src/myproject_selftest
+		$(builddir)/src/myproject_selftest
 
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/myproject_selftest
 	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
-		$(srcdir)/src/myproject_selftest
+		$(builddir)/src/myproject_selftest
 
 # Run the selftest binary under gdb for debugging
 debug: src/myproject_selftest
 	$(LIBTOOL) --mode=execute gdb -q \
-		$(srcdir)/src/myproject_selftest
+		$(builddir)/src/myproject_selftest
 
 # Run the selftest binary with verbose switch for tracing
 animate: src/myproject_selftest
-	$(LIBTOOL) --mode=execute $(srcdir)/src/myproject_selftest -v
+	$(LIBTOOL) --mode=execute $(builddir)/src/myproject_selftest -v
 
 if WITH_GCOV
 coverage: src/myproject_selftest

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -44,6 +44,20 @@ before_install:
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh
+before_deploy: . ./ci_deploy.sh
+deploy:
+  provider: releases
+  api_key:
+    # To encrypt your access token run: `travis encrypt -r user/repo`
+    secure: <encrypted github access token>
+  file_glob: true
+  file: ${$(PROJECT.NAME:c)_DEPLOYMENT}
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true
+    condition: $TRAVIS_OS_NAME =~ (linux) && $BUILD_TYPE =~ (default)
+.   close
 .endif
 .
 .output "ci_build.sh"
@@ -108,11 +122,12 @@ if [ "$BUILD_TYPE" == "default" ]; then
     # Build and check this project without DRAFT APIs
     make clean
     git reset --hard HEAD
-    ./autogen.sh 2> /dev/null
-    ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
-    make -j4
-    make check
-    make install
+    (
+        ./autogen.sh 2> /dev/null
+        ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
+        export DISTCHECK_CONFIGURE_FLAGS="${CONFIG_OPTS[@]}" &&
+        make VERBOSE=1 distcheck
+    ) || exit 1
 else
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="\$(dirs -l +1)" ./ci_build.sh
 fi
@@ -162,4 +177,30 @@ if [[ \$(git status -s api) ]]; then
 fi
 .close
 .chmod_x ("builds/check_zproto/ci_build.sh")
+.
+.output "ci_deploy.sh"
+#!/usr/bin/env bash
+
+$(project.GENERATED_WARNING_HEADER)
+
+set -x
+set -e
+
+if [[ $BUILD_TYPE == "default" ]]; then
+    # Tell travis to deploy all files in dist
+    mkdir dist
+    export $(PROJECT.NAME)_DEPLOYMENT=dist/*
+    # Move archives to dist
+    mv *.tar.gz dist
+    mv *.zip dist
+    # Generate hash sums
+    cd dist
+    md5sum *.zip *.tar.gz > MD5SUMS
+    sha1sum *.zip *.tar.gz > SHA1SUMS
+    cd -
+else
+    export $(PROJECT.NAME)_DEPLOYMENT=""
+fi
+.close
+.chmod_x ("ci_deploy.sh")
 .endmacro


### PR DESCRIPTION
Solution: Use travis to deploy these artifacts to github automatically.

The deployment is triggered by tagging on master branch of the
repository. Travis will trigger deployment on the default build
and will in process disable drafts.

For now the results of `make distcheck` are deployed
as well as their md5 and sha1 hash sums.