### PR TITLE
Problem: generated spec is bad if there is no COPYING file

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -67,7 +67,9 @@ This package contains shared library.
 
 %files -n $(project.libname)$(project->version.major)
 %defattr(-,root,root)
+.if file.exists ('COPYING')
 %doc COPYING
+.endif
 %{_libdir}/$(project.libname).so.*
 
 %package devel


### PR DESCRIPTION
Solution: check the existence before adding to filelist