### PR TITLE
Problem: [travis] travis does not deploy android jar when tagging

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -188,7 +188,7 @@ $(project.GENERATED_WARNING_HEADER)
 set -x
 set -e
 
-if [[ $BUILD_TYPE == "default" ]]; then
+if [ "$BUILD_TYPE" == "default" ]; then
     # Tell travis to deploy all files in dist
     mkdir dist
     export $(PROJECT.NAME)_DEPLOYMENT=dist/*
@@ -200,6 +200,8 @@ if [[ $BUILD_TYPE == "default" ]]; then
     md5sum *.zip *.tar.gz > MD5SUMS
     sha1sum *.zip *.tar.gz > SHA1SUMS
     cd -
+elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ]; then
+    export CZMQ_DEPLOYMENT=bindings/jni/android/$(project.name:c)-android.jar
 else
     export $(PROJECT.NAME)_DEPLOYMENT=""
 fi


### PR DESCRIPTION
Solution: Build and deploy android jar file when tagging a release on github.