### PR TITLE
Problem: [autotools] cmake stuff not included in release tarball

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -553,6 +553,10 @@ noinst_LTLIBRARIES =
 TESTS =
 
 EXTRA_DIST = \\
+    CMakeLists.txt \\
+.for use
+    Find$(use.project:c).cmake \\
+.endfor
 .for extra
     src/$(extra.name) \\
 .endfor


### PR DESCRIPTION
Solution: Add the cmake stuff to EXTRA_DIST