### PR TITLE
Problem: [api] dependencies in workspace are not resolved

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -367,6 +367,7 @@ function resolve_c_class (class)
     endfor
 endfunction
 
+
 #   Resolve all dependent data types for one container and load their API file
 #   if it exists.
 #
@@ -375,9 +376,10 @@ function resolve_container_dependencies (class_name, container)
     & count (project.class, class.c_name = my.container.type) = 0 \
     & count (project->dependencies.class, class.c_name = my.container.type) = 0
         resolved = 0
-        dir = directory.open ("/usr/local/share/zproject")?
-        if defined (dir)
-            for dir.directory
+        # Search the installation directory for the dependency
+        install_dir = directory.open ("/usr/local/share/zproject")?
+        if defined (install_dir)
+            for install_dir.directory
                 api_file = directory.path + directory.name + "/"  + "$(my.container.type:c).xml"
                 if resolved = 0 & file.exists (api_file)
                     dependency = XML.load_file (api_file)
@@ -392,6 +394,32 @@ function resolve_container_dependencies (class_name, container)
                 if resolved = 0 & file.exists (api_file)
                     dependency = XML.load_file (api_file)
                     dependency.api_dir = directory.path + directory.name + "/"
+                    dependency.resolved = 0
+                    dependency.project = directory.name
+                    resolve_c_class (dependency)
+                    move dependency to project->dependencies
+                    resolved = 1
+                endif
+            endfor
+        endif
+        if !resolved
+            # Search the workspace directory for the dependency
+            workspace_dir = directory.open ("..")?
+            for workspace_dir.directory
+                api_file = directory.path + directory.name + "/api/"  + "$(my.container.type:c).xml"
+                if resolved = 0 & file.exists (api_file)
+                    dependency = XML.load_file (api_file)
+                    dependency.api_dir = directory.path + directory.name + "/api/"
+                    dependency.resolved = 0
+                    dependency.project = directory.name
+                    resolve_c_class (dependency)
+                    move dependency to project->dependencies
+                    resolved = 1
+                endif
+                api_file = directory.path + directory.name + "/api/"  + "$(my.container.type:c).api"
+                if resolved = 0 & file.exists (api_file)
+                    dependency = XML.load_file (api_file)
+                    dependency.api_dir = directory.path + directory.name + "/api/"
                     dependency.resolved = 0
                     dependency.project = directory.name
                     resolve_c_class (dependency)


### PR DESCRIPTION
Solution: It is common practice to have dependent CLASS project in the
same workspace directory. Thus zproject should search for api files
from dependencies within the workspace.