### PR TITLE
 Problem: generated packaging recipes does not include documentation

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1170,7 +1170,7 @@ $(name:c).txt:
 .endfor
 .for project.main where scope = "public"
 $(name).txt:
-\t./mkman $@
+\t./mkman $(name:c) $@
 .endfor
 clean:
 \trm -f *.1 *.3 *.7

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -50,6 +50,8 @@ Build-Depends: debhelper (>= 9),
     dh-autoreconf,
     systemd,
     dh-systemd
+Build-Depends-Indep: asciidoc,
+                     xmlto
 
 .if project.exports_classes
 Package: $(string.replace (project.libname, "_|-"))$(project->version.major)
@@ -129,6 +131,7 @@ override_dh_auto_configure:
 .# generate binary names
 .   for project.main where scope = "public"
 usr/bin/$(main.name)
+usr/share/man/man1/$(main.name).1
 .       if file.exists ("src/$(main.name).cfg.example")
 etc/$(project.name)/$(main.name).cfg.example
 .       endif
@@ -150,5 +153,7 @@ usr/lib/*/$(project.libname).so.*
 usr/include/*
 usr/lib/*/$(project.libname).so
 usr/lib/*/pkgconfig/$(project.libname).pc
+usr/share/man/man3/*
+usr/share/man/man7/*
 .endif
 .endmacro

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -31,11 +31,13 @@ License:        $(project.license?"MIT")
 URL:            $(project.url?"http://example.com/")
 Source0:        %{name}-%{version}.tar.gz
 Group:          System/Libraries
+BuildRequires:  asciidoc
 BuildRequires:  automake
 BuildRequires:  autoconf
 BuildRequires:  libtool
 BuildRequires:  pkg-config
 BuildRequires:  systemd-devel
+BuildRequires:  xmlto
 .if project.use_cxx
 BuildRequires:  gcc-c++
 .endif
@@ -91,6 +93,8 @@ This package contains development files.
 %{_includedir}/*
 %{_libdir}/$(project.libname).so
 %{_libdir}/pkgconfig/$(project.libname).pc
+%{_mandir}/man3/*
+%{_mandir}/man7/*
 .endif
 
 %prep
@@ -126,6 +130,7 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .# generate binary names
 .for project.main where scope = "public"
 %{_bindir}/$(main.name)
+%{_mandir}/man1/$(main.name)*
 .if file.exists ("src/$(main.name).cfg.example")
 %{_sysconfdir}/$(project.name)/$(main.name).cfg.example
 .endif
@@ -135,7 +140,7 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .endfor
 .# generate service file names
 .for project.main where main.service ?= 1
-%config(noreplace) %{_systemconfdir}/$(project.name)/$(main.name).cfg
+%config(noreplace) %{_sysconfdir}/$(project.name)/$(main.name).cfg
 %{_prefix}/lib/systemd/system/$(main.name).service
 .endfor
 .endif


### PR DESCRIPTION
Solution: add this support + small fix of my previous PR + fix of type in redhat recipe

Tested for both Debian and Redhat (CentOS) builds