### PR TITLE
Problem: Missing project dependencies will cause wrongful output

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -150,6 +150,10 @@ fi
 #!/usr/bin/env bash
 set -ex
 
+.for project.use where !optional
+git clone --quiet --depth 1 $(use.repository) $(use.project)
+.endfor
+
 docker run -v "$REPO_DIR":/gsl zeromqorg/zproject project.xml
 
 # keep an eye on git version used by CI


### PR DESCRIPTION
Solution: Checkout all dependencies before checking if zproject is current on travis.