### PR TITLE
Problem: [travis] check_zproject clones dependencies to wrong directory

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -150,9 +150,11 @@ fi
 #!/usr/bin/env bash
 set -ex
 
+cd ..
 .for project.use where !optional
 git clone --quiet --depth 1 $(use.repository) $(use.project)
 .endfor
+cd -
 
 docker run -v "$REPO_DIR":/gsl zeromqorg/zproject project.xml
 


### PR DESCRIPTION
Solution: Clone the to the common working directory