### PR TITLE
Problem: travis check_zproject script gets lost in working dirs.

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -156,11 +156,12 @@ git clone --quiet --depth 1 $(use.repository) $(use.project)
 .endfor
 cd -
 
+cd $REPO_DIR/..
 git clone --quiet --depth 1 https://github.com/zeromq/zproject
 cd zproject
 export PATH=$PATH:`pwd`
 
-cd -
+cd $REPO_DIR/..
 git clone https://github.com/imatix/gsl.git
 cd gsl/src
 make


### PR DESCRIPTION
 Solution: reset wd to correct location for every dependency