### PR TITLE
Problem: [jni, travis] pkgconf path is wrong for deployment

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -590,7 +590,7 @@ set -e
 # Build and check the jni binding
 ########################################################################
 
-BUILD_PREFIX=/tmp
+export BUILD_PREFIX=/tmp
 
 CONFIG_OPTS=()
 CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -234,7 +234,7 @@ if [ "$BUILD_TYPE" == "default" ]; then
     sha1sum *.zip *.tar.gz > SHA1SUMS
     cd -
 elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ]; then
-    ( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=tmp/lib/pkgconfig ./gradlew clean bintrayUpload )
+    ( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./gradlew clean bintrayUpload )
     export CZMQ_DEPLOYMENT=bindings/jni/android/$(project.name:c)-android.jar
 else
     export $(PROJECT.NAME)_DEPLOYMENT=""


### PR DESCRIPTION
Solution: Instead of hardcoding the path export the builddir