### PR TITLE
Problem: [autotools] var name typo in mkman

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1101,7 +1101,7 @@ END
     printf "Generating $outp.doc...\\n";
     die "Can't create $outp.doc: $!"
         unless open (OUTPUT, ">$outp.doc");
-    print OUTPUT "#### $oupt - $title\\n\\n";
+    print OUTPUT "#### $outp - $title\\n\\n";
     print OUTPUT pull ("$source\\@header,left");
     print OUTPUT "\\n";
     print OUTPUT pull ("$source\\@discuss,left");


### PR DESCRIPTION
Solution: fix variable name from oupt to outp.