### PR TITLE
cmake test timeout + better cleanup

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -298,6 +298,10 @@ set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
                     ${CMAKE_BINARY_DIR}/CTestTestfile.cmake
                     ${CMAKE_BINARY_DIR}/Testing
                     ${CMAKE_BINARY_DIR}/compile_commands.json
+                    ${CMAKE_BINARY_DIR}/src/$(project.name)_selftest
+.for project.main
+                    ${CMAKE_BINARY_DIR}/src/$(main.name)
+.endfor
 )
 
 add_custom_command(

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -286,6 +286,27 @@ foreach(TEST_CLASS ${TEST_CLASSES})
     )
 endforeach(TEST_CLASS)
 
+########################################################################
+# cleanup
+########################################################################
+add_custom_target (distclean @echo cleaning for source distribution)
+
+set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
+                    ${CMAKE_BINARY_DIR}/cmake_install.cmake
+                    ${CMAKE_BINARY_DIR}/Makefile
+                    ${CMAKE_BINARY_DIR}/CMakeFiles
+                    ${CMAKE_BINARY_DIR}/CTestTestfile.cmake
+                    ${CMAKE_BINARY_DIR}/Testing
+                    ${CMAKE_BINARY_DIR}/compile_commands.json
+)
+
+add_custom_command(
+    DEPENDS clean
+    COMMENT "distribution clean"
+    COMMAND rm
+    ARGS    -rf CMakeTmp ${cmake_generated}
+    TARGET  distclean
+)
 
 ########################################################################
 # summary

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -256,8 +256,8 @@ set_target_properties(
 ########################################################################
 # tests
 ########################################################################
-set(CLASSTEST_TIMEOUT 5 CACHE STRING "Timeout of the selftest of a class")
-set(TOTAL_TIMEOUT 20 CACHE STRING "Timout of the total testsuite")
+set(CLASSTEST_TIMEOUT 20 CACHE STRING "Timeout of the selftest of a class")
+set(TOTAL_TIMEOUT 120 CACHE STRING "Timout of the total testsuite")
 
 set(TEST_CLASSES
 .for class where !draft


### PR DESCRIPTION
Problem: [cmake] test timeout is weirdly low

Problem: [cmake] no make target to cleanup cmake generated files

Problem: [cmake] distclean does not remove executables 