### PR TITLE
Problem: [cmake] pkg-config CFLAGS not used when compiling

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -334,6 +334,8 @@ if (NOT MSVC)
         pkg_check_modules(PC_$(USE.PROJECT) "$(use.libname)")
     endif (NOT PC_$(USE.PROJECT)_FOUND)
     if (PC_$(USE.PROJECT)_FOUND)
+        # add CFLAGS from pkg-config file, e.g. draft api.
+        add_definitions(${PC_$(USE.PROJECT)_CFLAGS} ${PC_$(USE.PROJECT)_CFLAGS_OTHER})
         # some libraries install the headers is a subdirectory of the include dir
         # returned by pkg-config, so use a wildcard match to improve chances of finding
         # headers and SOs.


### PR DESCRIPTION
Solution: Tell cmake to use the loaded pkg-config CFLAGS. This is needed to
compile against draft apis.