### PR TITLE
Problem: [cmake] generation fails if builds dir doesn't exist

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -372,6 +372,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .close
 .
 .# CI testing for using cmake
+.directory.create ('builds/cmake')
 .output "builds/cmake/ci_build.sh"
 #!/usr/bin/env bash
 set -ex


### PR DESCRIPTION
Solution: create it beforehand.