### PR TITLE
Problem: [cmake] no information about individual compile step

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -25,6 +25,7 @@ enable_language(C)
 enable_testing()
 
 set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 ########################################################################
 # options


### PR DESCRIPTION
Solution: generate a JSON Compilation Database.

This compilation database can be used by IDE tools to check for syntax
error.