### PR TITLE
problem: makemodule missing zproject_vagrant.gsl

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -40,6 +40,7 @@ myproject_SCRIPTS = \
     zproject_redhat.gsl \
     zproject_ruby.gsl \
     zproject_travis.gsl \
+    zproject_vagrant.gsl \
     zproject_vs2008.gsl \
     zproject_vs20xx.gsl \
     zproject_vs20xx_props.gsl \


### PR DESCRIPTION
needed to re-run and commit src/Makemodule.am

travis seems to have not complained on this build (my account):

https://travis-ci.org/wesyoung/zproject/builds/144563619

but might wanna check to see that it builds under this project just to be sure before merging.