### PR TITLE
Problem: cannot build debian package on OBS

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -158,4 +158,31 @@ usr/lib/*/pkgconfig/$(project.libname).pc
 usr/share/man/man3/*
 usr/share/man/man7/*
 .endif
+.output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).dsc.obs")
+Format: 3.0 (quilt)
+Binary: $(project.name)
+Source: $(project.name)
+Version: $(->version.major).$(->version.minor).$(->version.patch)
+Maintainer: $(project.name) Developers <$(project.email)>
+Architecture: any
+Build-Depends: debhelper (>= 9),
+    pkg-config,
+    dh-autoreconf,
+.for project.use
+.if defined(use.debian_name)
+    $(use.debian_name),
+.elsif regexp.match("^lib", use.libname)
+    $(string.replace (use.libname, "_|-"))-dev,
+.else
+    lib$(string.replace (use.libname, "_|-"))-dev,
+.endif
+.endfor
+    dh-autoreconf,
+    systemd,
+    dh-systemd
+Build-Depends-Indep: asciidoc,
+                     xmlto
+
+Files:
+ 7697688bf65a35bc33ae2db51ebb0e3b 818110 $(string.replace (project.name, "_|-"):lower).tar.gz
 .endmacro

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -31,7 +31,7 @@
         </use>
     -->
 
-    <use project = "libzmq" prefix = "zmq" debian_name = "libzmq5-dev" redhat_name = "zeromq-devel"
+    <use project = "libzmq" prefix = "zmq" debian_name = "libzmq3-dev" redhat_name = "zeromq-devel"
         repository = "https://github.com/zeromq/libzmq"
         test = "zmq_init" />
 


### PR DESCRIPTION
Solution: see commits

This is still work in progress, the _service is not nailed down yet, working on it with @sappo but I don't think the .dsc will need changes anymore hopefully.
Note that to avoid breaking dpkg-scansources and native debian builds the dsc file has a .obs suffix, and then the _service renames it.