### PR TITLE
Problem: [redhat] ghostscript-core dependency not available on openSUSE

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -31,7 +31,10 @@ License:        $(project.license?"MIT")
 URL:            $(project.url?"http://example.com/")
 Source0:        %{name}-%{version}.tar.gz
 Group:          System/Libraries
-BuildRequires:  ghostscript-core
+# Note: ghostscript is required by graphviz which is required by
+#       asciidoc. On Fedora 24 the ghostscript dependencies cannot
+#       be resolved automatically. Thus add working dependency here!
+BuildRequires:  ghostscript
 BuildRequires:  asciidoc
 BuildRequires:  automake
 BuildRequires:  autoconf


### PR DESCRIPTION
Solution: Use ghostscript dependency instead.

The ghostscript dependency is required by graphviz which is required
by asciidoc. Usually this dependency is automatically resolved but
Fedora 24 has problems finding the correct one. Thus we add the
dependency here as workaround!