### PR TITLE
Problem: man1/3/7 unconditionally installed in debian/redhat

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1129,27 +1129,30 @@ generate_manpage ($name, $outp);
 .chmod_x ("doc/mkman")
 .endmacro
 
+.function discover_manpages (project)
+.   man7 = "$(my.project.name:c).7"
+.   man3 = ""
+.   for my.project.class where scope = "public"
+.      man3 += " $(name:c).3"
+.      if class.name = my.project.name
+.          man7 = ""
+.      endif
+.   endfor
+.   man1 = ""
+.   for my.project.main where scope = "public"
+.      man1 += " $(name).1"
+.      if "$(main.name)" = "$(my.project.name)"
+.          man7 = ""
+.      endif
+.   endfor
+.endfunction
 .macro generate_man_pages
 .output "doc/Makefile.am"
 $(project.GENERATED_WARNING_HEADER:)
-.project.manpage = "$(project.name:c).7"
-.man3 = ""
-.for project.class where scope = "public"
-.   man3 += " $(name:c).3"
-.   if class.name = project.name
-.       project.manpage = ""
-.   endif
-.endfor
-.man1 = ""
-.for project.main where scope = "public"
-.   man1 += " $(name).1"
-.   if "$(main.name)" = "$(project.name)"
-.       project.manpage = ""
-.   endif
-.endfor
+.discover_manpages(project)
 MAN1 =$(man1)
 MAN3 =$(man3)
-MAN7 = $(project.manpage)
+MAN7 = $(man7)
 MAN_DOC = $\(MAN1) $\(MAN3) $\(MAN7)
 
 MAN_TXT = $\(MAN1:%.1=%.txt)

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -132,13 +132,16 @@ override_dh_auto_configure:
 	dh $@ --with autoreconf
 .endif
 
+.discover_manpages(project)
 .if project.has_main | count(project.bin) > 0
 .   output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).install")
 .# generate binary names
 .   for project.main where scope = "public"
 .       if project.has_main
 usr/bin/$(main.name)
+.          if man1 ?<> ""
 usr/share/man/man1/$(main.name).1
+.          endif
 .       endif
 .       if file.exists ("src/$(main.name).cfg.example")
 etc/$(project.name)/$(main.name).cfg.example
@@ -161,8 +164,12 @@ usr/lib/*/$(project.libname).so.*
 usr/include/*
 usr/lib/*/$(project.libname).so
 usr/lib/*/pkgconfig/$(project.libname).pc
+.   if man3 ?<> ""
 usr/share/man/man3/*
+.   endif
+.   if man7 ?<> ""
 usr/share/man/man7/*
+.   endif
 .endif
 .output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).dsc.obs")
 Format: 3.0 (quilt)

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -99,8 +99,13 @@ This package contains development files.
 %{_includedir}/*
 %{_libdir}/$(project.libname).so
 %{_libdir}/pkgconfig/$(project.libname).pc
+.   discover_manpages(project)
+.   if man3 ?<> ""
 %{_mandir}/man3/*
+.   endif
+.   if man7 ?<> ""
 %{_mandir}/man7/*
+.   endif
 .   if count (class, defined (class.api))
 %{_datadir}/zproject/
 %{_datadir}/zproject/$(project.name)/
@@ -144,7 +149,9 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .# generate binary names
 .for project.main where scope = "public"
 %{_bindir}/$(main.name)
+.   if man1 ?<> ""
 %{_mandir}/man1/$(main.name)*
+.   endif
 .if file.exists ("src/$(main.name).cfg.example")
 %{_sysconfdir}/$(project.name)/$(main.name).cfg.example
 .endif


### PR DESCRIPTION
Solution: refactor the doc discovery into a separate function, and
call it in the debian and redhat packaging in order to include the
manpages only if they are generated, to avoid a build failure due to
non existing files