### PR TITLE
Problem: g++ 5.10 generates "memory leak"

### DIFF
--- a/zproject_valgrind.gsl
+++ b/zproject_valgrind.gsl
@@ -34,4 +34,14 @@ if !file.exists ("src/.valgrind.supp")
     >   fun:__libc_freeres
     >   ...
     >}
+    >{
+    >   <glibc_eh_alloc__see_bug_66339>
+    >   Memcheck:Leak
+    >   match-leak-kinds: reachable
+    >   fun:malloc
+    >   fun:pool
+    >   fun:__static_initialization_and_destruction_0
+    >   fun:_GLOBAL__sub_I_eh_alloc.cc
+    >   ...
+    >}
 endif


### PR DESCRIPTION
Solution: suppress it via valgrind suppression file,
because the memory is allocated by libc itself, it lives in
static area, so will be automatically free'ed on program
end.

See
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66339
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64535
http://stackoverflow.com/questions/32933301/valgrind-and-stdunique-ptr-false-positive-or-not
https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=219988

KDE did the same, to suppress this message
https://bugs.kde.org/show_bug.cgi?id=345307