### PR TITLE
Problem: cannot build packages with DRAFT APIs

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,12 +1,37 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+DRAFTS=no
+
+# OBS build: add
+#   Macros:
+#   %_with_drafts 1
+# at the BOTTOM of the OBS prjconf
+OBS_BUILD_CFG=/.build/build.dist
+ifeq ("$(wildcard $(OBS_BUILD_CFG))","")
+BUILDCONFIG=$(shell ls -1 /usr/src/packages/SOURCES/_buildconfig* | head -n 1)
+endif
+ifneq ("$(wildcard $(OBS_BUILD_CFG))","")
+ifneq ("$(shell grep drafts $(OBS_BUILD_CFG))","")
+DRAFTS=yes
+endif
+endif
+
+# User build: DEB_BUILD_OPTIONS=drafts dpkg-buildpackage
+ifneq (,$(findstring drafts,$(DEB_BUILD_OPTIONS)))
+DRAFTS=yes
+endif
+
 override_dh_strip:
 	dh_strip --dbg-package=zproject-dbg
 
 override_dh_auto_test:
 	echo "Skipped for now"
 
-%:
-	dh $@ --with autoreconf
+override_dh_auto_configure:
+	dh_auto_configure -- \
+		--enable-drafts=$(DRAFTS)
 
+%:
+	dh $@ \
+		--with autoreconf

--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -10,6 +10,16 @@
 #    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
 #
 
+# To build with draft APIs, use "--with drafts" in rpmbuild for local builds or add
+#   Macros:
+#   %_with_drafts 1
+# at the BOTTOM of the OBS prjconf
+%bcond_with drafts
+%if %{with drafts}
+%define DRAFTS yes
+%else
+%define DRAFTS no
+%endif
 %global debug_package %{nil}
 Name:           zproject
 Version:        1.1.0
@@ -41,7 +51,7 @@ zproject project.
 
 %build
 sh autogen.sh
-%{configure}
+%{configure} --enable-drafts=%{DRAFTS}
 make %{_smp_mflags}
 
 %install

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -120,22 +120,46 @@ License: $(project.name)_license
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+DRAFTS=no
+
+# OBS build: add
+#   Macros:
+#   %_with_drafts 1
+# at the BOTTOM of the OBS prjconf
+OBS_BUILD_CFG=/.build/build.dist
+ifeq ("\$(wildcard \$(OBS_BUILD_CFG))","")
+BUILDCONFIG=\$(shell ls -1 /usr/src/packages/SOURCES/_buildconfig* | head -n 1)
+endif
+ifneq ("\$(wildcard \$(OBS_BUILD_CFG))","")
+ifneq ("\$(shell grep drafts \$(OBS_BUILD_CFG))","")
+DRAFTS=yes
+endif
+endif
+
+# User build: DEB_BUILD_OPTIONS=drafts dpkg-buildpackage
+ifneq (,\$(findstring drafts,\$(DEB_BUILD_OPTIONS)))
+DRAFTS=yes
+endif
+
 override_dh_strip:
 	dh_strip --dbg-package=$(string.replace (project.name, "_|-"):lower)-dbg
 
 override_dh_auto_test:
 	echo "Skipped for now"
 
-%:
-.if systemd ?= 1
-	dh $@ --with autoreconf,systemd
-
 override_dh_auto_configure:
-	dh_auto_configure -- --with-systemd-units
-.else
-	dh $@ --with autoreconf
+	dh_auto_configure -- \\
+.if systemd ?= 1
+		--with-systemd-units \\
 .endif
+		--enable-drafts=\$(DRAFTS)
 
+%:
+	dh $@ \\
+.if systemd ?= 1
+		--with systemd \\
+.endif
+		--with autoreconf
 .chmod_x ("packaging/debian/rules")
 .discover_manpages(project)
 .if project.has_main | count(project.bin) > 0

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -136,6 +136,7 @@ override_dh_auto_configure:
 	dh $@ --with autoreconf
 .endif
 
+.chmod_x ("packaging/debian/rules")
 .discover_manpages(project)
 .if project.has_main | count(project.bin) > 0
 .   output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).install")

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -26,6 +26,16 @@ register_target ("redhat", "Packaging for RedHat")
 .   endfor
 #
 
+# To build with draft APIs, use "--with drafts" in rpmbuild for local builds or add
+#   Macros:
+#   %_with_drafts 1
+# at the BOTTOM of the OBS prjconf
+%bcond_with drafts
+%if %{with drafts}
+%define DRAFTS yes
+%else
+%define DRAFTS no
+%endif
 .   if !has_main & !project.exports_classes
 %global debug_package %{nil}
 .   endif
@@ -126,9 +136,9 @@ This package contains development files.
 %build
 sh autogen.sh
 .if systemd ?= 1
-%{configure} --with-systemd-units
+%{configure} --enable-drafts=%{DRAFTS} --with-systemd-units
 .else
-%{configure}
+%{configure} --enable-drafts=%{DRAFTS}
 .endif
 make %{_smp_mflags}
 


### PR DESCRIPTION
Solution: see commits

Both a manual build and an OBS build solution is added.

@sappo - with this, we can create a git-draft project and just linkpac to the main project, and add the option to the prjconf. When the main project packages are triggered the draft one will be triggered too, so we get around the single-target limitation of the Github hooks.