### PR TITLE
Problem: build failures due to Wredundant-decls

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -370,7 +370,12 @@ $(c_callback_typedef (callback_type))
 .           if ->return.fresh
 //  Caller owns return value and must destroy it when done.
 .           endif
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
+$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):)\
+.           if defined(method.format_index)
+ CHECK_PRINTF ($(method.format_index));
+.           else
+;
+.           endif
 .       endif
 .   endfor
 .endfor
@@ -408,13 +413,23 @@ $(c_callback_typedef (callback_type))
 .   for class.constructor where draft = my.draft
 .       method_state_comment (state)
 //  $(constructor.description:no,block)
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (constructor):);
+$(PROJECT.PREFIX)_EXPORT $(c_method_signature (constructor):)\
+.       if defined(constructor.format_index)
+ CHECK_PRINTF ($(constructor.format_index));
+.       else
+;
+.       endif
 
 .   endfor
 .   for class.destructor where draft = my.draft
 .       method_state_comment (state)
 //  $(destructor.description:no,block)
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (destructor):);
+$(PROJECT.PREFIX)_EXPORT $(c_method_signature (destructor):)\
+.       if defined(destructor.format_index)
+ CHECK_PRINTF ($(destructor.format_index));
+.       else
+;
+.       endif
 
 .   endfor
 .   for class.actor where draft = my.draft
@@ -429,7 +444,12 @@ $(PROJECT.PREFIX)_EXPORT void
 .       if method->return.fresh
 //  Caller owns return value and must destroy it when done.
 .       endif
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):);
+$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):)\
+.       if defined(method.format_index)
+ CHECK_PRINTF ($(method.format_index));
+.       else
+;
+.       endif
 
 .   endfor
 .endmacro
@@ -514,14 +534,6 @@ $(HEADER_FILE_PREFIX:)\
 .   if count (class., count.draft ?= 1)
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif
-.for class.method where defined (format_index)
-.   if first ()
-//  @ignore
-.   endif
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):) CHECK_PRINTF ($(format_index));
-.   if last ()
-.   endif
-.endfor
 //  @end
 $(HEADER_FILE_SUFFIX:)\
 .       endtemplate


### PR DESCRIPTION
Solution: roll back duplicate declarations for functions that have
a format index parameter.
This will make the docs a bit uglier, by appending the CHECK_PRINTF
macro at the end of the signature in the doc.
But a duplicate declaration in a public header breaks the build of
any project that uses the library and includes them, and also builds
with -Wredundant-decls.

  /usr/local/include/zcert.h:128:5: error: redundant redeclaration
   of ‘zcert_set_meta’ [-Werror=redundant-decls]
     zcert_set_meta (zcert_t *self, const char *name, const char
                     *format, ...) CHECK_PRINTF (3);
     ^
  /usr/local/include/zcert.h:64:5: note: previous declaration of
   ‘zcert_set_meta’ was here
     zcert_set_meta (zcert_t *self, const char *name, const char
                     *format, ...);

Fixes #634

I'm open to a different solution that doesn't add the ugly CHECK_PRINTF to the docs, but that doesn't break the build of projects that use the library, if anyone has one!