### PR TITLE
Problem: Can't build Release type with "git clone"d source

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -33,11 +33,16 @@ SET(CMAKE_C_FLAGS_RELEASE "-O3")
 # options
 ########################################################################
 .if project.stable
-if (EXISTS "${SOURCE_DIR}/.git")
-    set (CMAKE_BUILD_TYPE Debug)
+if (NOT CMAKE_BUILD_TYPE)
+    if (EXISTS "${SOURCE_DIR}/.git")
+        set (CMAKE_BUILD_TYPE Debug)
+    else ()
+        set (CMAKE_BUILD_TYPE Release)
+    endif ()
+endif ()
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
 else ()
-    set (CMAKE_BUILD_TYPE Release)
     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" OFF)
 endif ()
 .else


### PR DESCRIPTION
Solution: Respect the specified CMAKE_BUILD_TYPE value. If users don't
specify CMAKE_BUILD_TYPE, auto CMAKE_BUILD_TYPE set is used. Normally,
users don't specify CMAKE_BUILD_TYPE, so the behavior isn't changed.