### PR TITLE
Look up LIBCZMQ_PATH in ruby binding

### DIFF
--- a/zproject_ruby.gsl
+++ b/zproject_ruby.gsl
@@ -282,8 +282,9 @@ module $(project.RubyName:)
 
     begin
       lib_name = '$(project.libname)'
-      lib_paths = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64']
-        \.map { |path| "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}" }
+      lib_dirs = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64']
+      lib_dirs = [*ENV['LIBCZMQ_PATH'].split(':'), *lib_dirs] if ENV['LIBCZMQ_PATH']
+      lib_paths = lib_dirs.map { |path| "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}" }
       ffi_lib lib_paths + [lib_name]
       @available = true
     rescue LoadError


### PR DESCRIPTION
On some Mac environments I use, homebrew is installed in /opt/brew directory.
So I want to supply a path where libczmq.dylib is installed by an environment variable.
This pull-request introduces LIBCZMQ_PATH environment variable for this purpose.
