### PR TITLE
Problem: pkgconfig file does not support static link

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -132,6 +132,9 @@ else
     AM_CONDITIONAL(WITH_GCOV, false)
 fi
 
+# Will be used to add flags to pkg-config useful when apps want to statically link
+PKGCFG_LIBS_PRIVATE=""
+
 .# Archive user supplied flags
 PREVIOUS_CFLAGS="${CFLAGS}"
 PREVIOUS_LIBS="${LIBS}"
@@ -146,6 +149,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
 .  if optional
         AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
 .  endif
+        PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
     ],
     [
 .  if use.min_version = '0.0.0'
@@ -182,6 +186,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
                 AC_SUBST([$(use.project:c)_CFLAGS],[${$(use.project:c)_synthetic_cflags}])
                 AC_SUBST([$(use.project:c)_LIBS],[${$(use.project:c)_synthetic_libs}])
                 was_$(use.project:c)_check_lib_detected=yes
+                PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -l$(use.linkname)"
 .       if optional
                 AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
             ],
@@ -212,6 +217,8 @@ fi
 .# Restore user supplied flags
 CFLAGS="${PREVIOUS_CFLAGS}"
 LIBS="${PREVIOUS_LIBS}"
+
+AC_SUBST(pkg_config_libs_private, $PKGCFG_LIBS_PRIVATE)
 
 # Platform specific checks
 $(project.name:c)_on_mingw32="no"
@@ -987,6 +994,7 @@ $(use.libname)\
 
 Libs: -L${libdir} -l$(project.linkname)
 Cflags: -I${includedir} @pkg_config_defines@
+Libs.private: @pkg_config_libs_private@
 
 $(project.GENERATED_WARNING_HEADER:)
 .endmacro

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -29,6 +29,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # Select flags
 SET(CMAKE_C_FLAGS_RELEASE "-O3")
 
+# Will be used to add flags to pkg-config useful when apps want to statically link
+set(pkg_config_libs_private "")
+
 ########################################################################
 # options
 ########################################################################
@@ -117,6 +120,7 @@ IF ($(USE.PROJECT)_FOUND)
 .if use.libname ?<> ""
     include_directories(${$(USE.PROJECT)_INCLUDE_DIRS})
     list(APPEND MORE_LIBRARIES ${$(USE.PROJECT)_LIBRARIES})
+    set(pkg_config_libs_private "${pkg_config_libs_private} -l$(use.linkname)")
 .if use.optional = 1
     add_definitions(-DHAVE_$(USE.LIBNAME))
     list(APPEND OPTIONAL_LIBRARIES ${$(USE.PROJECT)_LIBRARIES})


### PR DESCRIPTION
Solution: add dependencies, if necessary, to the .private Libs field
of the pkgconfig file at build time.
This way pkg-config --static --libs libfoo will correctly print
dependencies if they were used to build the static libfoo.a library.