### PR TITLE
Problem: tarball dependencies still require repository

### DIFF
--- a/zproject_docker.gsl
+++ b/zproject_docker.gsl
@@ -26,7 +26,19 @@ RUN chmod 0440 /etc/sudoers.d/zmq
 
 USER zmq
 
-.for use where !optional
+.for use where !optional & defined (use.tarball)
+WORKDIR /home/zmq
+RUN wget $(use.tarball)
+RUN tar -xzf \$(basename "$(use.tarball)")
+RUN rm \$(basename "$(use.tarball)")
+WORKDIR /home/zmq/\$(basename "$(use.tarball)" .tar.gz)
+RUN ./configure --quiet --without-docs
+RUN make
+RUN sudo make install
+RUN sudo ldconfig
+
+.endfor
+.for use where !optional & !defined (use.tarball)
 WORKDIR /home/zmq
 RUN git clone --quiet $(use.repository).git
 WORKDIR /home/zmq/$(use.project)

--- a/zproject_vagrant.gsl
+++ b/zproject_vagrant.gsl
@@ -29,7 +29,19 @@ libffi-dev
 # only execute this next line if interested in updating the man pages as well (adds to build time):
 # sudo apt-get install -y asciidoc
 
-.for use where !optional
+.for use where !optional & defined (use.tarball)
+cd /home/vagrant
+wget $(use.tarball)
+tar -xzf \$(basename "$(use.tarball)")
+rm \$(basename "$(use.tarball)")
+cd /home/vagrant/\$(basename "$(use.tarball)" .tar.gz)
+\./configure
+make
+make install
+ldconfig
+
+.endfor
+.for use where !optional & !defined (use.tarball)
 cd /home/vagrant
 git clone --quiet $(use.repository).git
 cd /home/vagrant/$(use.project)


### PR DESCRIPTION
Solution: Use tarball if present to build CI, Docker or Vagrant.