### PR TITLE
problem: python bindings do not check for bundled shared objects first

### DIFF
--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -292,7 +292,10 @@ function generate_binding
     ># $(project.name:c)
     >lib = None
     >try:
-    >    t = os.getcwd()  # get the current dir, temp store it
+    >    # check to see if the shared object was embedded locally, attempt to load it
+    >    # if not, try to load it using the default system paths...
+    >    # we need to use os.chdir instead of trying to modify $LD_LIBRARY_PATH and reloading the interpreter
+    >    t = os.getcwd()
     >    p = os.path.join(os.path.dirname(__file__), '..')  # find the path to our $project_ctypes.py
     >    os.chdir(p)  # change directories briefly
     >

--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -292,13 +292,13 @@ function generate_binding
     ># $(project.name:c)
     >lib = None
     >try:
-    >    t = os.getcwd()
-    >    p = os.path.join(os.path.dirname(__file__), '..')
-    >    os.chdir(p)
+    >    t = os.getcwd()  # get the current dir, temp store it
+    >    p = os.path.join(os.path.dirname(__file__), '..')  # find the path to our $project_ctypes.py
+    >    os.chdir(p)  # change directories briefly
     >
-    >    from $(project.name) import $(project.libname)
-    >    lib = CDLL($(project.libname).__file__)
-    >    os.chdir(t)
+    >    from $(project.name) import $(project.libname)  # attempt to import the shared lib if it exists
+    >    lib = CDLL($(project.libname).__file__)  # if it exists try to load the shared lib
+    >    os.chdir(t)  # switch back to orig dir
     >except ImportError:
     >    pass
     >

--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -290,27 +290,34 @@ function generate_binding
     endif
 
     ># $(project.name:c)
+    >lib = None
     >try:
-    >    # If LD_LIBRARY_PATH or your OSs equivalent is set, this is the only way to
-    >    # load the library.  If we use find_library below, we get the wrong result.
-    >    if os.name == 'posix':
-    >        if sys.platform == 'darwin':
-    >            lib = cdll.LoadLibrary('$(project.libname).$(project->version.major).dylib')
-    >        else:
-    >            try:
+    >    t = os.getcwd()
+    >    p = os.path.join(os.path.dirname(__file__), '..')
+    >    os.chdir(p)
+    >
+    >    from $(project.name) import $(project.libname)
+    >    lib = CDLL($(project.libname).__file__)
+    >    os.chdir(t)
+    >except ImportError:
+    >    pass
+    >
+    >if not lib:
+    >    try:
+    >        # If LD_LIBRARY_PATH or your OSs equivalent is set, this is the only way to
+    >        # load the library.  If we use find_library below, we get the wrong result.
+    >        if os.name == 'posix':
+    >            if sys.platform == 'darwin':
+    >                lib = cdll.LoadLibrary('$(project.libname).$(project->version.major).dylib')
+    >            else:
     >                lib = cdll.LoadLibrary("$(project.libname).so.$(project->version.major)")
-    >            except OSError:
-    >                try:
-    >                    lib = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), "$(project.libname).so"))
-    >                except OSError:
-    >                    lib = cdll.LoadLibrary(os.path.join('.', "$(project.libname).so"))
-    >    elif os.name == 'nt':
-    >        lib = cdll.LoadLibrary('$(project.libname).dll')
-    >except OSError:
-    >    libpath = find_library("$(project.name)")
-    >    if not libpath:
-    >        raise ImportError("Unable to find $(project.libname)")
-    >    lib = cdll.LoadLibrary(libpath)
+    >        elif os.name == 'nt':
+    >            lib = cdll.LoadLibrary('$(project.libname).dll')
+    >    except OSError:
+    >        libpath = find_library("$(project.name)")
+    >        if not libpath:
+    >            raise ImportError("Unable to find $(project.libname)")
+    >        lib = cdll.LoadLibrary(libpath)
     >
 
     for project->python_types.type

--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -297,7 +297,13 @@ function generate_binding
     >        if sys.platform == 'darwin':
     >            lib = cdll.LoadLibrary('$(project.libname).$(project->version.major).dylib')
     >        else:
-    >            lib = cdll.LoadLibrary("$(project.libname).so.$(project->version.major)")
+    >            try:
+    >                lib = cdll.LoadLibrary("$(project.libname).so.$(project->version.major)")
+    >            except OSError:
+    >                try:
+    >                    lib = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), "$(project.libname).so"))
+    >                except OSError:
+    >                    lib = cdll.LoadLibrary(os.path.join('.', "$(project.libname).so"))
     >    elif os.name == 'nt':
     >        lib = cdll.LoadLibrary('$(project.libname).dll')
     >except OSError:


### PR DESCRIPTION
this was the only semi-clean way i was able to solve #705, especially in cases where you may have multiple shared objects embedded within a python library (think: libzyre.so depends on libczmq.so which also depends on libzmq.so and assume they are all under site-packages/czmq and site-packages/zyre instead of LD_LIBRARY_PATH).

i tried testing it both ways in some fresh vm's (loading the original way, and the new way), both seem to check out. once (/if?) this is merged, will submit PR's for new bindings in zyre and czmq.

i'm open to other ways of solving this problem, but most of them deal with modifying LD_LIBRARY_PATH and actually reloading the interpreter, which seems like a bit more complicated code than just dropping in and out the path to see if things load properly..