### PR TITLE
Problem: selftest binary tries to use private class symbol

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -193,10 +193,10 @@ typedef struct {
 
 static test_item_t
 all_tests [] = {
-.for class where !draft & selftest
+.for class where !draft & selftest & private ?<> 1
     { "$(class.c_name)", $(class.c_name)_test },
 .endfor
-.for class where draft & selftest
+.for class where draft & selftest & private ?<> 1
 .   if first ()
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif


### PR DESCRIPTION
Solution: if a class is private, don't add its $class_test to the
list in $project_selftest, as the symbol should not be visible
externally.
Instead, the public class that uses the private one should call the
private one's test during its own.