### PR TITLE
Problem: DRAFT symbols are leaked as public

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -92,8 +92,14 @@ $(project.GENERATED_WARNING_HEADER:)
 #   else
 #       define $(PROJECT.PREFIX)_EXPORT __declspec(dllimport)
 #   endif
+#   define $(PROJECT.PREFIX)_PRIVATE
 #else
 #   define $(PROJECT.PREFIX)_EXPORT
+#   if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
+#       define $(PROJECT.PREFIX)_PRIVATE __attribute__ ((visibility ("hidden")))
+#   else
+#       define $(PROJECT.PREFIX)_PRIVATE
+#   endif
 #endif
 
 .if !project.stable
@@ -370,7 +376,7 @@ $(c_callback_typedef (callback_type))
 .           if ->return.fresh
 //  Caller owns return value and must destroy it when done.
 .           endif
-$(PROJECT.PREFIX)_EXPORT $(c_method_signature (method):)\
+$(PROJECT.PREFIX)_PRIVATE $(c_method_signature (method):)\
 .           if defined(method.format_index)
  CHECK_PRINTF ($(method.format_index));
 .           else


### PR DESCRIPTION
Solution: define a project_PRIVATE macro that uses gcc/icc
visibility "hidden" attribute to instruct the compiler not to export
symbols privately defined in $project_classes.h when --enable-drafts
is disabled.