### PR TITLE
Problem: [jni] bintray deploy fails if version exists

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -227,6 +227,7 @@ bintray {
     key = System.getenv('BINTRAY_KEY')
     publications = ['mavenJava']
     publish = true
+    override = true
     pkg {
         repo = "maven"
         name = "$(project.name:c)-jni"


### PR DESCRIPTION
Solution: Override version artifact by default so it wont cause
deployment failures.