### PR TITLE
Problem: [jni] bintray override option doesn't work with current version

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -129,7 +129,7 @@ $(project.GENERATED_WARNING_HEADER:)
 plugins {
     id 'java'
     id 'maven-publish'
-    id "com.jfrog.bintray" version "1.6"
+    id "com.jfrog.bintray" version "1.7.2"
 }
 
 group = "org.zeromq"


### PR DESCRIPTION
Solution: Upgrade bintray plugin to 1.7.2 which solves the problem.