### PR TITLE
Problem: MSVC builds fail to copy platform.h when there is a space in…

### DIFF
--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -779,7 +779,7 @@ $(project.GENERATED_WARNING_HEADER:)
   <!-- Configuration -->
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $\(BuildRoot)platform.h $\(RepoRoot)include\\</Command>
+      <Command>copy "$\(BuildRoot)platform.h" "$\(RepoRoot)include\\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$\(RepoRoot)include\\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
… the path.

Solution: Surround path in "