### PR TITLE
Problem: autotools clean target calls mkman

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1244,6 +1244,7 @@ $(name).txt:
 .endfor
 clean:
 \trm -f *.1 *.3 *.7
+doc:
 .for project.class where scope = "public"
 \t./mkman $(name:c)
 .endfor


### PR DESCRIPTION
Solution: add "doc" target to regenerate the docs instead