### PR TITLE
Problem: generated Travis tests do not work out of the box as well as they could, and .gitignore needs updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ install_manifest.txt
 # Repositories downloaded by CI integration scripts
 *.git/
 
+# Travis build area
+tmp/
+
 # vagrant
 .vagrant
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ CTestTestfile.cmake
 cmake_install.cmake
 install_manifest.txt
 
+# Repositories downloaded by CI integration scripts
+*.git/
+
 # vagrant
 .vagrant
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ To understand step by step what zproject can do for you, read chapter 3 of [@hin
 zproject uses the universal code generator called GSL to process its XML inputs and create its outputs. Before you start you'll need to install GSL (https://github.com/imatix/gsl) on your system.
 
 ```sh
-git clone https://github.com/imatix/gsl.git
-cd gsl/src
+git clone https://github.com/imatix/gsl.git gsl.git
+cd gsl.git/src
 make
 make install
 ```
@@ -120,8 +120,8 @@ GSL must be able to find the zproject resources on your system. Therefore you'll
 The following will install the zproject files to `/usr/local/bin`.
 
 ```sh
-git clone https://github.com/zeromq/zproject.git
-cd zproject
+git clone https://github.com/zeromq/zproject.git zproject.git
+cd zproject.git
 ./autogen.sh
 ./configure
 make
@@ -555,11 +555,11 @@ if [ "$BUILD_TYPE" == "default" ]; then
 
     ( ./autogen.sh && ./configure --prefix="${BUILD_PREFIX}" && make && make install ) || exit 1
 
-    git clone --depth 1 https://github.com/imatix/gsl gsl
-    ( cd gsl/src && make -j4 && DESTDIR=${BUILD_PREFIX} make install ) || exit 1
+    git clone --depth 1 https://github.com/imatix/gsl gsl.git
+    ( cd gsl.git/src && make -j4 && DESTDIR=${BUILD_PREFIX} make install ) || exit 1
 
-    git clone --depth 1 https://github.com/zeromq/czmq czmq
-    ( cd czmq && PATH=$PATH:${BUILD_PREFIX}/bin gsl -target:* project.xml ) || exit 1
+    git clone --depth 1 https://github.com/zeromq/czmq czmq.git
+    ( cd czmq.git && PATH=$PATH:${BUILD_PREFIX}/bin gsl -target:* project.xml ) || exit 1
 else
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh
 fi
@@ -884,7 +884,7 @@ In order to use it, you must install zproject itself and then pycparser. For mos
 virtualenv/venv mkapi
 source mkapi/bin/activate
 pip install pycparser
-git clone https://github.com/eliben/pycparser.git
+git clone https://github.com/eliben/pycparser.git pycparser.git
 ```
 
 Then from root directory of your project (for example czmq), type following

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -21,8 +21,8 @@ CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
 CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 
 # Clone and build dependencies
-git clone --quiet --depth 1 https://github.com/imagix/gsl gsl
-cd gsl
+git clone --quiet --depth 1 https://github.com/imagix/gsl gsl.git
+cd gsl.git
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then
     ./autogen.sh 2> /dev/null

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -14,5 +14,9 @@ if [ "$BUILD_TYPE" == "default" ]; then
     git clone --depth 1 https://github.com/zeromq/czmq czmq.git
     ( cd czmq.git && PATH=$PATH:${BUILD_PREFIX}/bin gsl -target:* project.xml ) || exit 1
 else
-    pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh
+    pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh || exit 1
 fi
+
+echo "=== Are GitIgnores good after making zproject '$BUILD_TYPE'? (should have no output below)"
+git status -s || true
+echo "==="

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -6,13 +6,13 @@ if [ "$BUILD_TYPE" == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp
 
-    git clone --depth 1 https://github.com/imatix/gsl gsl
-    ( cd gsl/src && make -j4 && DESTDIR=${BUILD_PREFIX} make install ) || exit 1
+    git clone --depth 1 https://github.com/imatix/gsl gsl.git
+    ( cd gsl.git/src && make -j4 && DESTDIR=${BUILD_PREFIX} make install ) || exit 1
 
     ( ./autogen.sh && PATH=$PATH:${BUILD_PREFIX}/bin ./configure --prefix="${BUILD_PREFIX}" && make && make install ) || exit 1
 
-    git clone --depth 1 https://github.com/zeromq/czmq czmq
-    ( cd czmq && PATH=$PATH:${BUILD_PREFIX}/bin gsl -target:* project.xml ) || exit 1
+    git clone --depth 1 https://github.com/zeromq/czmq czmq.git
+    ( cd czmq.git && PATH=$PATH:${BUILD_PREFIX}/bin gsl -target:* project.xml ) || exit 1
 else
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh
 fi

--- a/tstgenbld.sh
+++ b/tstgenbld.sh
@@ -130,19 +130,19 @@ echo Projects will be cloned to here "${PWD}"
 #read -p "Press ENTER to continue: "
 
 # get required but not generated projects for zeromq stack
-test -d gsl       || git clone --depth 1 https://github.com/${IMATIX}/gsl             gsl
-test -d libsodium || git clone -b stable https://github.com/${JEDISCT1}/libsodium     libsodium
-test -d libzmq    || git clone --depth 1 https://github.com/${ZEROMQ}/libzmq          libzmq
+test -d gsl.git       || git clone --depth 1 https://github.com/${IMATIX}/gsl             gsl.git
+test -d libsodium.git || git clone -b stable https://github.com/${JEDISCT1}/libsodium     libsodium.git
+test -d libzmq.git    || git clone --depth 1 https://github.com/${ZEROMQ}/libzmq          libzmq.git
 # get required projects for zeromq stack
-test -d czmq      || git clone --depth 1 https://github.com/${ZEROMQ}/czmq            czmq
-test -d malamute  || git clone --depth 1 https://github.com/${ZEROMQ}/malamute        malamute
-test -d zyre      || git clone --depth 1 https://github.com/${ZEROMQ}/zyre            zyre
+test -d czmq.git      || git clone --depth 1 https://github.com/${ZEROMQ}/czmq            czmq.git
+test -d malamute.git  || git clone --depth 1 https://github.com/${ZEROMQ}/malamute        malamute.git
+test -d zyre.git      || git clone --depth 1 https://github.com/${ZEROMQ}/zyre            zyre.git
 
 # build gsl (the generator)
 echo Building gsl
 phase=building
 (
-    cd ${GITPROJECTS}/gsl/src &&
+    cd ${GITPROJECTS}/gsl.git/src &&
     make -j4 &&
     DESTDIR=${BUILD_PREFIX} make install &&
     exit $?
@@ -156,7 +156,7 @@ echo Regenerating projects
 phase=gsl-generation
 for project in czmq malamute zyre; do
     (
-        cd ${GITPROJECTS}/$project &&
+        cd ${GITPROJECTS}/$project.git &&
         ${BUILD_PREFIX}/bin/gsl project.xml &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 && test 0 -eq $? &&
@@ -176,7 +176,7 @@ echo Building zeromq stack components
 phase=autogen-config
 for project in libsodium libzmq czmq malamute zyre; do
     (
-        cd ${GITPROJECTS}/$project &&
+        cd ${GITPROJECTS}/$project.git &&
         ./autogen.sh &&
         ./configure --prefix=${BUILD_PREFIX} &&
         exit $?
@@ -188,7 +188,7 @@ loglogs
 phase=make
 for project in libsodium libzmq czmq malamute zyre; do
     (
-        cd ${GITPROJECTS}/$project &&
+        cd ${GITPROJECTS}/$project.git &&
         make &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&
@@ -199,7 +199,7 @@ loglogs
 phase=make-install
 for project in libsodium libzmq czmq malamute zyre; do
     (
-        cd ${GITPROJECTS}/$project &&
+        cd ${GITPROJECTS}/$project.git &&
         DESTDIR=${BUILD_PREFIX} make install &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&
@@ -212,7 +212,7 @@ echo Running tests
 phase=make-check
 for project in libzmq czmq malamute zyre; do
     (
-        cd ${GITPROJECTS}/$project &&
+        cd ${GITPROJECTS}/$project.git &&
         DESTDIR=${BUILD_PREFIX} PATH=${BUILD_PREFIX}/bin:$PATH make check &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -490,11 +490,11 @@ cd ..
 .endfor
 .for use where defined (use.repository)
 .   if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 .   else
-git clone --quiet --depth 1 $(use.repository) $(use.project)
+git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .   endif
-cd $(use.project)
+cd $(use.project).git
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then
     ./autogen.sh 2> /dev/null

--- a/zproject_docker.gsl
+++ b/zproject_docker.gsl
@@ -40,8 +40,8 @@ RUN sudo ldconfig
 .endfor
 .for use where !optional & !defined (use.tarball)
 WORKDIR /home/zmq
-RUN git clone --quiet $(use.repository).git
-WORKDIR /home/zmq/$(use.project)
+RUN git clone --quiet $(use.repository).git $(use.project).git
+WORKDIR /home/zmq/$(use.project).git
 RUN ./autogen.sh 2> /dev/null
 RUN ./configure --quiet --without-docs
 RUN make
@@ -50,8 +50,8 @@ RUN sudo ldconfig
 
 .endfor
 WORKDIR /home/zmq
-RUN git clone --quiet git://github.com/zeromq/$(project.name:c).git
-WORKDIR /home/zmq/$(project.name:c)
+RUN git clone --quiet git://github.com/zeromq/$(project.name:c).git $(project.name:c).git
+WORKDIR /home/zmq/$(project.name:c) $(project.name:c).git
 RUN ./autogen.sh 2> /dev/null
 RUN ./configure --quiet --without-docs
 RUN make

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -80,6 +80,9 @@ if !file.exists (".gitignore")
     >install_manifest.txt
     >Testing/
     >
+    ># Repositories downloaded by CI integration scripts
+    >*.git/
+    >
     ># Valgrind files
     >callgrind*
     >vgcore*

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -83,6 +83,9 @@ if !file.exists (".gitignore")
     ># Repositories downloaded by CI integration scripts
     >*.git/
     >
+    ># Travis build area
+    >tmp/
+    >
     ># Valgrind files
     >callgrind*
     >vgcore*

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -105,14 +105,14 @@ if [ ! $INCREMENTAL ]; then
 
 .   endfor
 .   for use where defined (use.repository) & ! defined (use.tarball)
-    if [ ! -e $(use.project) ]; then
+    if [ ! -e $(use.project).git ]; then
 .      if defined (use.release)
-        git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+        git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 .      else
-        git clone --quiet --depth 1 $(use.repository) $(use.project)
+        git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .      endif
     fi
-    pushd $(use.project)
+    pushd $(use.project).git
     (
         if [ $UPDATE ]; then
             git pull --rebase

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -126,7 +126,7 @@ if [ "$BUILD_TYPE" == "default" ]; then
     ./autogen.sh 2> /dev/null
     ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
-    make VERBOSE=1 distcheck
+    make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
 
     echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
     git status -s || true
@@ -140,7 +140,7 @@ if [ "$BUILD_TYPE" == "default" ]; then
         ./autogen.sh 2> /dev/null
         ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
         export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]}" &&
-        make VERBOSE=1 distcheck
+        make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
     ) || exit 1
 
     echo "=== Are GitIgnores good after 'make distcheck' without drafts? (should have no output below)"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -104,11 +104,11 @@ if [ "$BUILD_TYPE" == "default" ]; then
 .   endfor
 .   for use where defined (use.repository) & ! defined (use.tarball)
 .      if defined (use.release)
-    git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+    git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 .      else
-    git clone --quiet --depth 1 $(use.repository) $(use.project)
+    git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .      endif
-    cd $(use.project)
+    cd $(use.project).git
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
         ./autogen.sh 2> /dev/null
@@ -128,6 +128,10 @@ if [ "$BUILD_TYPE" == "default" ]; then
     export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
     make VERBOSE=1 distcheck
 
+    echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
+    git status -s || true
+    echo "==="
+
     # Build and check this project without DRAFT APIs
     make distclean
     git clean -f
@@ -138,6 +142,11 @@ if [ "$BUILD_TYPE" == "default" ]; then
         export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]}" &&
         make VERBOSE=1 distcheck
     ) || exit 1
+
+    echo "=== Are GitIgnores good after 'make distcheck' without drafts? (should have no output below)"
+    git status -s || true
+    echo "==="
+
 elif [ "$BUILD_TYPE" == "bindings" ]; then
     pushd "./bindings/${BINDING}" && ./ci_build.sh
 else
@@ -152,18 +161,18 @@ set -ex
 
 cd $REPO_DIR/..
 .for project.use where !optional & defined (use.repository)
-git clone --quiet --depth 1 $(use.repository) $(use.project)
+git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .endfor
 cd -
 
 cd $REPO_DIR/..
-git clone --quiet --depth 1 https://github.com/zeromq/zproject
-cd zproject
+git clone --quiet --depth 1 https://github.com/zeromq/zproject zproject.git
+cd zproject.git
 export PATH=$PATH:`pwd`
 
 cd $REPO_DIR/..
-git clone https://github.com/imatix/gsl.git
-cd gsl/src
+git clone https://github.com/imatix/gsl.git gsl.git
+cd gsl.git/src
 make
 export PATH=$PATH:`pwd`
 
@@ -278,11 +287,11 @@ cd ..
 .endfor
 .for use where defined (use.repository)
 . if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 . else
-git clone --quiet --depth 1 $(use.repository) $(use.project)
+git clone --quiet --depth 1 $(use.repository) $(use.project).git
 . endif
-cd $(use.project)
+cd $(use.project).git
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then
     ./autogen.sh 2> /dev/null

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -125,6 +125,12 @@ if [ "$BUILD_TYPE" == "default" ]; then
     # Build and check this project
     ./autogen.sh 2> /dev/null
     ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
+    make VERBOSE=1 all
+
+    echo "=== Are GitIgnores good after 'make all' with drafts? (should have no output below)"
+    git status -s || true
+    echo "==="
+
     export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
     make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
 

--- a/zproject_vagrant.gsl
+++ b/zproject_vagrant.gsl
@@ -43,8 +43,8 @@ ldconfig
 .endfor
 .for use where !optional & !defined (use.tarball)
 cd /home/vagrant
-git clone --quiet $(use.repository).git
-cd /home/vagrant/$(use.project)
+git clone --quiet $(use.repository).git $(use.project).git
+cd /home/vagrant/$(use.project).git
 \./autogen.sh
 \./configure
 make


### PR DESCRIPTION
Solution: improve several points so a freshly generated project passes the GitHub/TravisCI tests; rename downloaded Git-sourced projects into `*.git` directories and add those to `.gitignore`

Note: not done for some platform scripts I'm less sure about (android, java, ...) - these might rely on particular directory names and a new suffix might break them. Someone expert in those areas may follow up later.