### PR TITLE
Problem: Travis does not ensure warning-less code

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -29,6 +29,7 @@ services:
 
 env:
 - BUILD_TYPE=default
+- BUILD_TYPE=default-Werror
 - BUILD_TYPE=cmake
 #- BUILD_TYPE=android
 #- BUILD_TYPE=check-py
@@ -78,7 +79,7 @@ $(project.GENERATED_WARNING_HEADER)
 set -x
 set -e
 
-if [ "$BUILD_TYPE" == "default" ]; then
+if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; then
     if [ -d "./tmp" ]; then
         rm -rf ./tmp
     fi
@@ -86,9 +87,47 @@ if [ "$BUILD_TYPE" == "default" ]; then
     BUILD_PREFIX=$PWD/tmp
 
     CONFIG_OPTS=()
-    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
-    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
-    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+    COMMON_CFLAGS=""
+    EXTRA_CFLAGS=""
+    EXTRA_CPPFLAGS=""
+    EXTRA_CXXFLAGS=""
+    if [ "$BUILD_TYPE" == "default-Werror" ] ; then
+        COMPILER_FAMILY=""
+        if [ -n "$CC" -a -n "$CXX" ]; then
+            if "$CC" --version 2>&1 | grep GCC > /dev/null && \
+               "$CXX" --version 2>&1 | grep GCC > /dev/null \
+            ; then
+                COMPILER_FAMILY="GCC"
+            fi
+        else
+            if "gcc" --version 2>&1 | grep GCC > /dev/null && \
+               "g++" --version 2>&1 | grep GCC > /dev/null \
+            ; then
+                # Autoconf would pick this by default
+                COMPILER_FAMILY="GCC"
+            elif "cc" --version 2>&1 | grep GCC > /dev/null && \
+               "c++" --version 2>&1 | grep GCC > /dev/null \
+            ; then
+                COMPILER_FAMILY="GCC"
+            fi
+        fi
+
+        case "${COMPILER_FAMILY}" in
+            GCC)
+                echo "NOTE: Enabling ${COMPILER_FAMILY} compiler pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
+                COMMON_CFLAGS="-Wall -Werror"
+                EXTRA_CFLAGS="-std=c99"
+                EXTRA_CPPFLAGS=""
+                EXTRA_CXXFLAGS="-std=c++99"
+                ;;
+            *)
+                echo "WARNING: Current compiler is not GCC, not enabling pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
+                ;;
+        esac
+    fi
+    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include ${COMMON_CFLAGS} ${EXTRA_CFLAGS}")
+    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include ${COMMON_CFLAGS} ${EXTRA_CPPFLAGS}")
+    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include ${COMMON_CFLAGS} ${EXTRA_CXXFLAGS}")
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -173,12 +173,16 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     git status -s || true
     echo "==="
 
-    export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
-    make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
+    if [ "$BUILD_TYPE" == "default-Werror" ] ; then
+        echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
+    else
+        export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
+        make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
 
-    echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
-    git status -s || true
-    echo "==="
+        echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
+        git status -s || true
+        echo "==="
+    fi
 
     # Build and check this project without DRAFT APIs
     make distclean
@@ -187,8 +191,13 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     (
         ./autogen.sh 2> /dev/null
         ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
-        export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]}" &&
-        make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
+        make VERBOSE=1 all || exit $?
+        if [ "$BUILD_TYPE" == "default-Werror" ] ; then
+            echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
+        else
+            export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]}" && \
+            make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
+        fi
     ) || exit 1
 
     echo "=== Are GitIgnores good after 'make distcheck' without drafts? (should have no output below)"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -79,7 +79,10 @@ set -x
 set -e
 
 if [ "$BUILD_TYPE" == "default" ]; then
-    mkdir tmp
+    if [ -d "./tmp" ]; then
+        rm -rf ./tmp
+    fi
+    mkdir -p tmp
     BUILD_PREFIX=$PWD/tmp
 
     CONFIG_OPTS=()


### PR DESCRIPTION
...and warnings are often not just noise - this code can explode under certain conditions (different bitness, OS, etc.)

Solution: Add a Travis target which enables all warnings and makes them fatal. Currently only for GCC and should not impact other compilers if available on Travis, but structure allows easy extension to e.g. CLANG compilers if someone knows them well.