### PR TITLE
Problem: on Solaris/illumos projects fail compiling strdup() et al

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,6 +148,8 @@ case "${host_os}" in
     *solaris*)
         # Define on Solaris to enable all library features
         CPPFLAGS="-D_PTHREADS $CPPFLAGS"
+        # Allow definitions of common OS-provided functions that are not in old standards
+        CPPFLAGS="-D__EXTENSIONS__ $CPPFLAGS"
         AC_DEFINE(ZPROJECT_HAVE_SOLARIS, 1, [Have Solaris OS])
         CFLAGS="${CFLAGS} -lsocket -lssp"
         ;;

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -284,6 +284,8 @@ case "${host_os}" in
     *solaris*)
         # Define on Solaris to enable all library features
         CPPFLAGS="-D_PTHREADS $CPPFLAGS"
+        # Allow definitions of common OS-provided functions that are not in old standards
+        CPPFLAGS="-D__EXTENSIONS__ $CPPFLAGS"
         AC_DEFINE($(PROJECT.PREFIX)_HAVE_SOLARIS, 1, [Have Solaris OS])
         CFLAGS="${CFLAGS} -lsocket -lssp"
         ;;


### PR DESCRIPTION
Solution: these newish (not XX-century standard) functions are available, but require -D__EXTENSIONS__ to be set... do it by default.