### PR TITLE
Problem: distcheck products are seen in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ CTestTestfile.cmake
 cmake_install.cmake
 install_manifest.txt
 
+# Distcheck workspace and archives
+zproject-1.1.0/
+zproject-1.1.0.tar.gz
+zproject-1.1.0.zip
+
 # Repositories downloaded by CI integration scripts
 *.git/
 

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -43,6 +43,11 @@ if !file.exists (".gitignore")
     >*.app
     >core
     >
+    > # Distcheck workspace and archives
+    >$(project.name)-$(->version.major).$(->version.minor).$(->version.patch)/
+    >$(project.name)-$(->version.major).$(->version.minor).$(->version.patch).tar.gz
+    >$(project.name)-$(->version.major).$(->version.minor).$(->version.patch).zip
+    >
     ># Man pages
     >doc/*.1
     >doc/*.3


### PR DESCRIPTION
Solution: default gitignore should hide the distcheck workspace directory, tarball and zipfile