### PR TITLE
Problem: Template for gitignore was not updated for a regenerated CZMQ project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,10 @@ tmp/
 # CLion / PyCharm
 .idea
 
+# MSVC build directories
+obj/
+bin/
+*.tlog
+
 # editor backups
 *~

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -439,9 +439,9 @@ AS_IF([test -n "$GLD"],
 AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$have_ld_version_script" = "yes")
 AS_IF([test "$have_ld_version_script" = "yes"],
         [AC_MSG_CHECKING([for symbol prefix])
-         SYMBOL_PREFIX=`echo "PREFIX=__USER_LABEL_PREFIX__" \
-                   | ${CPP-${CC-gcc} -E} - 2>&1 \
-                   | ${EGREP-grep} "^PREFIX=" \
+         SYMBOL_PREFIX=`echo "PREFIX=__USER_LABEL_PREFIX__" \\
+                   | ${CPP-${CC-gcc} -E} - 2>&1 \\
+                   | ${EGREP-grep} "^PREFIX=" \\
                    | ${SED-sed} "s:^PREFIX=::"`
          AC_SUBST(SYMBOL_PREFIX)
          AC_MSG_RESULT($SYMBOL_PREFIX)

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -115,6 +115,11 @@ if !file.exists (".gitignore")
     ># Python build directory
     >build/
     >
+    ># MSVC build directories
+    >obj/
+    >bin/
+    >*.tlog
+    >
     ># Qt
     >*pro.user
     >moc_*
@@ -124,6 +129,9 @@ if !file.exists (".gitignore")
     ># Temporary files
     >*.swp
     >*.bak
+    >.test*
+    >
+    ># editor backups
     >*~
 endif
 if !file.exists (".gitattributes")

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -133,10 +133,14 @@ if !file.exists (".gitignore")
     >
     ># editor backups
     >*~
+else
+    echo "NOT regenerating an existing .gitignore file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 endif
 if !file.exists (".gitattributes")
     echo "Generating initial .gitattributes file"
     output ".gitattributes"
     ># disables auto CRLF conversion for all files; create the file correctly and it will be allright
     >* -text
+else
+    echo "NOT regenerating an existing .gitattributes file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 endif

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -254,6 +254,7 @@ export PATH=$PATH:`pwd`
         echo "zproject generated new files!"
         exit 1
     fi
+    exit 0
 }
 .close
 .chmod_x ("builds/check_zproject/ci_build.sh")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -96,19 +96,19 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     if [ "$BUILD_TYPE" == "default-Werror" ] ; then
         COMPILER_FAMILY=""
         if [ -n "$CC" -a -n "$CXX" ]; then
-            if "$CC" --version 2>&1 | grep GCC > /dev/null && \
-               "$CXX" --version 2>&1 | grep GCC > /dev/null \
+            if "$CC" --version 2>&1 | grep GCC > /dev/null && \\
+               "$CXX" --version 2>&1 | grep GCC > /dev/null \\
             ; then
                 COMPILER_FAMILY="GCC"
             fi
         else
-            if "gcc" --version 2>&1 | grep GCC > /dev/null && \
-               "g++" --version 2>&1 | grep GCC > /dev/null \
+            if "gcc" --version 2>&1 | grep GCC > /dev/null && \\
+               "g++" --version 2>&1 | grep GCC > /dev/null \\
             ; then
                 # Autoconf would pick this by default
                 COMPILER_FAMILY="GCC"
-            elif "cc" --version 2>&1 | grep GCC > /dev/null && \
-               "c++" --version 2>&1 | grep GCC > /dev/null \
+            elif "cc" --version 2>&1 | grep GCC > /dev/null && \\
+               "c++" --version 2>&1 | grep GCC > /dev/null \\
             ; then
                 COMPILER_FAMILY="GCC"
             fi


### PR DESCRIPTION
Solutions: Update the default .gitignore template with more exclusions; yell if the file already exists and so will not be overwritten

Follow-up to https://github.com/zeromq/czmq/pull/1568

Minor other fixes