### PR TITLE
Problem: docs generation assumes certain relative directory layout in the project

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1302,9 +1302,9 @@ GENERATED_DOCS =
 .for project.class where scope = "public"
 GENERATED_DOCS += $(name:c).txt $(name:c).doc
 .   if file.exists ("src/$(name:c).cc")
-$(name:c).txt: $\(srcdir)/../src/$(name:c).cc
+$(name:c).txt: $\(top_srcdir)/src/$(name:c).cc
 .   else
-$(name:c).txt: $\(srcdir)/../src/$(name:c).c
+$(name:c).txt: $\(top_srcdir)/src/$(name:c).c
 .   endif
 \t$\(srcdir)/mkman $(name:c) $\(builddir)/$(name) $\(srcdir)/..
 
@@ -1312,9 +1312,9 @@ $(name:c).txt: $\(srcdir)/../src/$(name:c).c
 .for project.main where scope = "public"
 GENERATED_DOCS += $(name).txt $(name).doc
 .   if file.exists ("src/$(name:c).cc")
-$(name).txt: $\(srcdir)/../src/$(name).cc
+$(name).txt: $\(top_srcdir)/src/$(name).cc
 .   else
-$(name).txt: $\(srcdir)/../src/$(name).c
+$(name).txt: $\(top_srcdir)/src/$(name).c
 .   endif
 \t$\(srcdir)/mkman $(name:c) $\(builddir)/$(name) $\(srcdir)/..
 


### PR DESCRIPTION
Solution: make it a bit more robust and future-proof by looking for C/C++ sources not in `$srcdir_of_doc/../src` but in `$top_srcdir_of_project/src`.
Currently these are equivalent (with docs being in `$top_{src|build}dir_of_project/doc`), but the latter form is less expected to change.