### PR TITLE
Problem: build steps in Travis tests take unknown time, profiling needed

### DIFF
--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -50,3 +50,7 @@ time git clone --depth 1 https://github.com/zeromq/czmq.git czmq.git
   PATH=$PATH:${BUILD_PREFIX}/bin time ${BUILD_PREFIX}/bin/gsl -target:* project.xml \
 ) || exit 1
 echo "`date`: Builds completed without fatal errors!"
+
+echo "=== Are GitIgnores good after making zproject '$BUILD_TYPE'? (should have no output below)"
+git status -s || true
+echo "==="

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -6,15 +6,28 @@ if [ "$BUILD_TYPE" == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp
 
-    git clone --depth 1 https://github.com/imatix/gsl gsl.git
-    ( cd gsl.git/src && make -j4 && DESTDIR=${BUILD_PREFIX} make install ) || exit 1
+    echo "`date`: Starting build of dependencies: gsl..."
+    time git clone --depth 1 https://github.com/imatix/gsl.git gsl.git
+    ( cd gsl.git/src && \
+      time make -j4 && \
+      DESTDIR=${BUILD_PREFIX} time make install \
+    ) || exit 1
 
-    ( ./autogen.sh && PATH=$PATH:${BUILD_PREFIX}/bin ./configure --prefix="${BUILD_PREFIX}" && make && make install ) || exit 1
+    echo "`date`: Starting build of zproject..."
+    ( time ./autogen.sh && \
+      PATH=$PATH:${BUILD_PREFIX}/bin time ./configure --prefix="${BUILD_PREFIX}" && \
+      time make && \
+      time make install \
+    ) || exit 1
 
-    git clone --depth 1 https://github.com/zeromq/czmq czmq.git
-    ( cd czmq.git && PATH=$PATH:${BUILD_PREFIX}/bin gsl -target:* project.xml ) || exit 1
+    echo "`date`: Starting test of zproject (and gsl) by reconfiguring czmq..."
+    time git clone --depth 1 https://github.com/zeromq/czmq.git czmq.git
+    ( cd czmq.git && \
+      PATH=$PATH:${BUILD_PREFIX}/bin time ${BUILD_PREFIX}/bin/gsl -target:* project.xml \
+    ) || exit 1
+    echo "`date`: Builds completed without fatal errors!"
 else
-    pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh || exit 1
+    pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" time ./ci_build.sh || exit 1
 fi
 
 echo "=== Are GitIgnores good after making zproject '$BUILD_TYPE'? (should have no output below)"

--- a/tstgenbld.sh
+++ b/tstgenbld.sh
@@ -115,10 +115,10 @@ echo Building zproject
 phase=building
 (
     cd ../zproject &&
-    ./autogen.sh &&
-    ./configure &&
-    make &&
-    make install &&
+    time ./autogen.sh &&
+    time ./configure &&
+    time make &&
+    time make install &&
     exit $?
 ) > ${BUILD_PREFIX}/zproject_${phase}.err 2>&1 && mv ${BUILD_PREFIX}/zproject_${phase}.err ${BUILD_PREFIX}/zproject_${phase}.ok
 loglogs
@@ -143,8 +143,8 @@ echo Building gsl
 phase=building
 (
     cd ${GITPROJECTS}/gsl.git/src &&
-    make -j4 &&
-    DESTDIR=${BUILD_PREFIX} make install &&
+    time make -j4 &&
+    DESTDIR=${BUILD_PREFIX} time make install &&
     exit $?
 ) > ${BUILD_PREFIX}/gsl_${phase}.err 2>&1 &&
     mv ${BUILD_PREFIX}/gsl_${phase}.err ${BUILD_PREFIX}/gsl_${phase}.ok
@@ -177,8 +177,8 @@ phase=autogen-config
 for project in libsodium libzmq czmq malamute zyre; do
     (
         cd ${GITPROJECTS}/$project.git &&
-        ./autogen.sh &&
-        ./configure --prefix=${BUILD_PREFIX} &&
+        time ./autogen.sh &&
+        time ./configure --prefix=${BUILD_PREFIX} &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&
         mv ${BUILD_PREFIX}/${project}_${phase}.err  ${BUILD_PREFIX}/${project}_${phase}.ok
@@ -189,7 +189,7 @@ phase=make
 for project in libsodium libzmq czmq malamute zyre; do
     (
         cd ${GITPROJECTS}/$project.git &&
-        make &&
+        time make &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&
         mv ${BUILD_PREFIX}/${project}_${phase}.err  ${BUILD_PREFIX}/${project}_${phase}.ok
@@ -200,7 +200,7 @@ phase=make-install
 for project in libsodium libzmq czmq malamute zyre; do
     (
         cd ${GITPROJECTS}/$project.git &&
-        DESTDIR=${BUILD_PREFIX} make install &&
+        DESTDIR=${BUILD_PREFIX} time make install &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&
         mv ${BUILD_PREFIX}/${project}_${phase}.err  ${BUILD_PREFIX}/${project}_${phase}.ok
@@ -213,7 +213,7 @@ phase=make-check
 for project in libzmq czmq malamute zyre; do
     (
         cd ${GITPROJECTS}/$project.git &&
-        DESTDIR=${BUILD_PREFIX} PATH=${BUILD_PREFIX}/bin:$PATH make check &&
+        DESTDIR=${BUILD_PREFIX} PATH=${BUILD_PREFIX}/bin:$PATH time make check &&
         exit $?
     ) > ${BUILD_PREFIX}/${project}_${phase}.err 2>&1 &&
         mv ${BUILD_PREFIX}/${project}_${phase}.err  ${BUILD_PREFIX}/${project}_${phase}.ok

--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -79,10 +79,10 @@ fi
 
     export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
-    (cd "${cache}/$(project.name)" && ./autogen.sh 2> /dev/null \\
-        && ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" --without-docs \\
-        && make -j 4 \\
-        && make install) || exit 1
+    (cd "${cache}/$(project.name)" && time ./autogen.sh 2> /dev/null \\
+        && time ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" --without-docs \\
+        && time make -j 4 \\
+        && time make install) || exit 1
 }
 
 ##

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -479,41 +479,44 @@ CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
 CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 
 # Clone and build dependencies
+echo "`date`: Starting build of dependencies (if any)..."
 .for use where defined (use.tarball)
 wget $(use.tarball)
 tar -xzf \$(basename "$(use.tarball)")
 cd \$(basename "$(use.tarball)" .tar.gz)
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+time ./configure "${CONFIG_OPTS[@]}"
+time make -j4
+time make install
 cd ..
 .endfor
 .for use where defined (use.repository)
 .   if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
+time git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 .   else
-git clone --quiet --depth 1 $(use.repository) $(use.project).git
+time git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .   endif
 cd $(use.project).git
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then
-    ./autogen.sh 2> /dev/null
+    time ./autogen.sh 2> /dev/null
 fi
 if [ -e buildconf ]; then
-    ./buildconf 2> /dev/null
+    time ./buildconf 2> /dev/null
 fi
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+time ./configure "${CONFIG_OPTS[@]}"
+time make -j4
+time make install
 cd ..
 .endfor
 
 # Build and check this project
 cd ../..
-PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig cmake "${CMAKE_OPTS[@]}" .
-make all VERBOSE=1 -j4
-ctest -V
-make install
+echo "`date`: Starting build of currently tested project..."
+PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig time cmake "${CMAKE_OPTS[@]}" .
+time make all VERBOSE=1 -j4
+time ctest -V
+time make install
+echo "`date`: Builds completed without fatal errors!"
 .close
 .chmod_x ("builds/cmake/ci_build.sh")
 .endmacro

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -517,6 +517,10 @@ time make all VERBOSE=1 -j4
 time ctest -V
 time make install
 echo "`date`: Builds completed without fatal errors!"
+
+echo "=== Are GitIgnores good after making zproject '$BUILD_TYPE'? (should have no output below)"
+git status -s || true
+echo "==="
 .close
 .chmod_x ("builds/cmake/ci_build.sh")
 .endmacro

--- a/zproject_docker.gsl
+++ b/zproject_docker.gsl
@@ -26,37 +26,40 @@ RUN chmod 0440 /etc/sudoers.d/zmq
 
 USER zmq
 
+RUN echo "`date`: Starting build of dependencies (if any)..."
 .for use where !optional & defined (use.tarball)
 WORKDIR /home/zmq
 RUN wget $(use.tarball)
 RUN tar -xzf \$(basename "$(use.tarball)")
 RUN rm \$(basename "$(use.tarball)")
 WORKDIR /home/zmq/\$(basename "$(use.tarball)" .tar.gz)
-RUN ./configure --quiet --without-docs
-RUN make
-RUN sudo make install
-RUN sudo ldconfig
+RUN time ./configure --quiet --without-docs
+RUN time make
+RUN time sudo make install
+RUN time sudo ldconfig
 
 .endfor
 .for use where !optional & !defined (use.tarball)
 WORKDIR /home/zmq
-RUN git clone --quiet $(use.repository) $(use.project).git
+RUN time git clone --quiet $(use.repository) $(use.project).git
 WORKDIR /home/zmq/$(use.project).git
-RUN ./autogen.sh 2> /dev/null
-RUN ./configure --quiet --without-docs
+RUN time ./autogen.sh 2> /dev/null
+RUN time ./configure --quiet --without-docs
 RUN make
-RUN sudo make install
-RUN sudo ldconfig
+RUN time sudo make install
+RUN time sudo ldconfig
 
 .endfor
 WORKDIR /home/zmq
-RUN git clone --quiet git://github.com/zeromq/$(project.name:c).git $(project.name:c).git
+RUN echo "`date`: Starting build of currently tested project..."
+RUN time git clone --quiet git://github.com/zeromq/$(project.name:c).git $(project.name:c).git
 WORKDIR /home/zmq/$(project.name:c) $(project.name:c).git
-RUN ./autogen.sh 2> /dev/null
-RUN ./configure --quiet --without-docs
-RUN make
-RUN sudo make install
-RUN sudo ldconfig
+RUN time ./autogen.sh 2> /dev/null
+RUN time ./configure --quiet --without-docs
+RUN time make
+RUN time sudo make install
+RUN time sudo ldconfig
+RUN echo "`date`: Builds completed without fatal errors!"
 .if file.exists ("Dockerfile.in")
 
 $(file.slurp ("Dockerfile.in"))

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -608,35 +608,36 @@ CONFIG_OPTS+=("--quiet")
 pushd ../../..
 
 # Clone and build dependencies
+echo "`date`: Starting build of dependencies (if any)..."
 .   for use where defined (use.tarball)
 wget $(use.tarball)
 tar -xzf \$(basename "$(use.tarball)")
 cd \$(basename "$(use.tarball)" .tar.gz)
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+time ./configure "${CONFIG_OPTS[@]}"
+time make -j4
+time make install
 cd ..
 .   endfor
 .   for use where defined (use.repository)
 .      if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+time git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
 .      else
-git clone --quiet --depth 1 $(use.repository) $(use.project)
+time git clone --quiet --depth 1 $(use.repository) $(use.project)
 .      endif
 cd $(use.project)
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then
-    ./autogen.sh 2> /dev/null
+    time ./autogen.sh 2> /dev/null
 fi
 if [ -e buildconf ]; then
-    ./buildconf 2> /dev/null
+    time ./buildconf 2> /dev/null
 fi
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+time ./configure "${CONFIG_OPTS[@]}"
+time make -j4
+time make install
 .       if count (project->dependencies.class, class.project = use.project) > 0
 # Build jni dependency
-( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./gradlew publishToMavenLocal )
+( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig time ./gradlew publishToMavenLocal )
 .       endif
 cd ..
 
@@ -644,15 +645,18 @@ cd ..
 popd
 pushd ../..
 
-\./autogen.sh 2> /dev/null
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+echo "`date`: Starting build of currently tested project..."
+time ./autogen.sh 2> /dev/null
+time ./configure "${CONFIG_OPTS[@]}"
+time make -j4
+time make install
+echo "`date`: Build completed without fatal errors!"
 
 popd
 
-TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./gradlew build jar
-TERM=dumb ./gradlew clean
+
+TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig time ./gradlew build jar
+TERM=dumb time ./gradlew clean
 
 ########################################################################
 #  Build and check the jni android binding
@@ -666,7 +670,7 @@ popd
 
 pushd android
 
-TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./build.sh
+TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig time ./build.sh
 
 popd
 .close

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -97,9 +97,9 @@ if [ ! $INCREMENTAL ]; then
     fi
     pushd \$(basename "$(use.tarball)" .tar.gz)
     (
-        ./configure "${CONFIG_OPTS[@]}"
-        make -j4
-        make install
+        time ./configure "${CONFIG_OPTS[@]}"
+        time make -j4
+        time make install
     ) || exit 1
     popd
 
@@ -107,26 +107,26 @@ if [ ! $INCREMENTAL ]; then
 .   for use where defined (use.repository) & ! defined (use.tarball)
     if [ ! -e $(use.project).git ]; then
 .      if defined (use.release)
-        git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
+        time git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 .      else
-        git clone --quiet --depth 1 $(use.repository) $(use.project).git
+        time git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .      endif
     fi
     pushd $(use.project).git
     (
         if [ $UPDATE ]; then
-            git pull --rebase
+            time git pull --rebase
         fi
         git --no-pager log --oneline -n1
         if [ -e autogen.sh ]; then
-            ./autogen.sh 2> /dev/null
+            time ./autogen.sh 2> /dev/null
         fi
         if [ -e buildconf ]; then
-            ./buildconf 2> /dev/null
+            time ./buildconf 2> /dev/null
         fi
-        ./configure "${CONFIG_OPTS[@]}"
-        make -j4
-        make install
+        time ./configure "${CONFIG_OPTS[@]}"
+        time make -j4
+        time make install
     ) || exit 1
     popd
 
@@ -136,10 +136,10 @@ fi
 # Cross build this project
 pushd ../..
 (
-    ./autogen.sh 2> /dev/null
-    ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    time ./autogen.sh 2> /dev/null
+    time ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
+    time make -j4
+    time make install
 ) || exit 1
 popd
 

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -137,39 +137,41 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     CONFIG_OPTS+=("--quiet")
 
     # Clone and build dependencies
+    echo "`date`: Starting build of dependencies (if any)..."
 .   for use where defined (use.tarball)
     wget $(use.tarball)
     tar -xzf \$(basename "$(use.tarball)")
     cd \$(basename "$(use.tarball)" .tar.gz)
-    ./configure "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    time ./configure "${CONFIG_OPTS[@]}"
+    time make -j4
+    time make install
     cd ..
 .   endfor
 .   for use where defined (use.repository) & ! defined (use.tarball)
 .      if defined (use.release)
-    git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
+    time git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
 .      else
-    git clone --quiet --depth 1 $(use.repository) $(use.project).git
+    time git clone --quiet --depth 1 $(use.repository) $(use.project).git
 .      endif
     cd $(use.project).git
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
-        ./autogen.sh 2> /dev/null
+        time ./autogen.sh 2> /dev/null
     fi
     if [ -e buildconf ]; then
-        ./buildconf 2> /dev/null
+        time ./buildconf 2> /dev/null
     fi
-    ./configure "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    time ./configure "${CONFIG_OPTS[@]}"
+    time make -j4
+    time make install
     cd ..
 .   endfor
 
     # Build and check this project
-    ./autogen.sh 2> /dev/null
-    ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
-    make VERBOSE=1 all
+    echo "`date`: Starting build of currently tested project with DRAFT APIs..."
+    time ./autogen.sh 2> /dev/null
+    time ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
+    time make VERBOSE=1 all
 
     echo "=== Are GitIgnores good after 'make all' with drafts? (should have no output below)"
     git status -s || true
@@ -179,7 +181,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
         echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
     else
         export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
-        make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
+        time make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
 
         echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
         git status -s || true
@@ -187,20 +189,22 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     fi
 
     # Build and check this project without DRAFT APIs
+    echo "`date`: Starting build of currently tested project without DRAFT APIs..."
     make distclean
     git clean -f
     git reset --hard HEAD
     (
-        ./autogen.sh 2> /dev/null
-        ./configure --enable-drafts=no "${CONFIG_OPTS[@]}" --with-docs=yes
-        make VERBOSE=1 all || exit $?
+        time ./autogen.sh 2> /dev/null
+        time ./configure --enable-drafts=no "${CONFIG_OPTS[@]}" --with-docs=yes
+        time make VERBOSE=1 all || exit $?
         if [ "$BUILD_TYPE" == "default-Werror" ] ; then
             echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
         else
             export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]} --with-docs=yes" && \\
-            make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
+            time make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
         fi
     ) || exit 1
+    echo "`date`: Builds completed without fatal errors!"
 
     echo "=== Are GitIgnores good after 'make distcheck' without drafts? (should have no output below)"
     git status -s || true


### PR DESCRIPTION
Solution: to find bottlenecks and prove improvements in Travis integration, the steps (build and test of prerequisites and project itself) should be profiled, at least by adding date'd echo's and time'd invokations

Also fixes another case of imagix=>imatix and some more .git extensions when pulling git clones from internet.

Another minor Problem: CMake travis tests do not report if GitIgnores are clean after build
Solution: Port the block from autotools codepath
