### PR TITLE
Problem: Debian pkg has build-dep on systemd

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -51,7 +51,6 @@ Build-Depends: debhelper (>= 9),
 .endif
 .endfor
 .if systemd ?= 1
-    systemd,
     dh-systemd,
 .endif
 Build-Depends-Indep: asciidoc,


### PR DESCRIPTION
Solution: remove it. It doesn't make sense to Build-Depend on systemd
as it's not necessary to enable support for it in a service,
dh-systemd is enough.