### PR TITLE
Problem: Debian pkg still build-deps on systemd

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -219,7 +219,6 @@ Build-Depends: debhelper (>= 9),
 .endif
 .endfor
 .if systemd ?= 1
-    systemd,
     dh-systemd,
 .endif
 Build-Depends-Indep: asciidoc,


### PR DESCRIPTION
Solution: remove it from the generated .dsc file too