### PR TITLE
Problem: debian pkg does not ship API files

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -194,6 +194,9 @@ usr/lib/*/$(project.libname).so.*
 usr/include/*
 usr/lib/*/$(project.libname).so
 usr/lib/*/pkgconfig/$(project.libname).pc
+.   if count (class, defined (class.api))
+usr/share/zproject
+.   endif
 .   if man3 ?<> ""
 usr/share/man/man3/*
 .   endif


### PR DESCRIPTION
Solution: add them to the -dev package