### PR TITLE
Problem: lognorm deps out of date

### DIFF
--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -128,9 +128,13 @@
         header = "json-c/json.h"
         test = "json_object_to_json_string" />
 
+    <use project = "libfastjson"
+        header = "libfastjson/json.h"
+        test = "json_object_to_json_string" />
+
     <use project = "lognorm"
         test = "ln_initCtx">
-        <use project = "json-c" />
+        <use project = "libfastjson" />
     </use>
 
     <use project = "systemd"


### PR DESCRIPTION
Liblognorm now uses libfastjson instead of json-c.  This PR adds libfastjson as a known project, and changes the lognorm dependency to use it rather than json-c.