### PR TITLE
Problem: make distcheck is no longer ran by default

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -18,7 +18,7 @@
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="1" /> will enable run of make distcheck instead of make check
+            <option name="distcheck" value="0" /> will disable run of make distcheck
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010
         vs2012              Microsoft Visual Studio 2012

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -175,7 +175,9 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     git status -s || true
     echo "==="
 
-.   if defined (travis_distcheck)
+.   if travis_distcheck ?= 0
+    make check
+.   else
     if [ "$BUILD_TYPE" == "default-Werror" ] ; then
         echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
     else
@@ -189,8 +191,6 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
 
     # Build and check this project without DRAFT APIs
     make distclean
-.   else
-    make check
 .   endif
 
     git clean -f
@@ -199,15 +199,15 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
         ./autogen.sh 2> /dev/null
         ./configure --enable-drafts=no "${CONFIG_OPTS[@]}" --with-docs=yes
         make VERBOSE=1 all || exit $?
-.   if defined (travis_distcheck)
+.   if travis_distcheck ?= 0
+        make check
+.   else
         if [ "$BUILD_TYPE" == "default-Werror" ] ; then
             echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
         else
             export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]} --with-docs=yes" && \\
             make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
         fi
-.   else
-        make check
 .   endif
     ) || exit 1
 


### PR DESCRIPTION
Solution: make the new distcheck project config option opt-out
instead of opt-in.
Correct handling and creation of distributable tarball is core to the
github and travis based releases scripts that zproject generates, so
by default it should check that everything works correctly.
Retain the option so that users, if they intend to do so at their
risk, can disable this check in their projects.