### PR TITLE
Problem: Should support dependencies that lack autogen and precompiled configure script

### DIFF
--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -30,6 +30,14 @@ fi
 if [ -e buildconf ]; then
     ./buildconf 2> /dev/null
 fi
+if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+    libtoolize --copy --force && \
+    aclocal -I . && \
+    autoheader && \
+    automake --add-missing --copy && \
+    autoconf || \
+    autoreconf -fiv
+fi
 ./configure "${CONFIG_OPTS[@]}"
 make -j4
 make install

--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,7 @@ echo
 echo '##########################################################################'
 
 echo
-echo Configure complete! Now procced with:
+echo Configure complete! Now proceed with:
 echo "    - 'make'               compile the project"
 echo "    - 'make check'         run the project's selftest"
 echo "    - 'make install'       install the project to $prefix"

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -610,7 +610,7 @@ echo
 echo '##########################################################################'
 
 echo
-echo Configure complete! Now procced with:
+echo Configure complete! Now proceed with:
 echo "    - 'make'               compile the project"
 echo "    - 'make check'         run the project's selftest"
 echo "    - 'make install'       install the project to $prefix"

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -502,6 +502,14 @@ fi
 if [ -e buildconf ]; then
     ./buildconf 2> /dev/null
 fi
+if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+    libtoolize --copy --force && \\
+    aclocal -I . && \\
+    autoheader && \\
+    automake --add-missing --copy && \\
+    autoconf || \\
+    autoreconf -fiv
+fi
 \./configure "${CONFIG_OPTS[@]}"
 make -j4
 make install

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -631,6 +631,14 @@ fi
 if [ -e buildconf ]; then
     ./buildconf 2> /dev/null
 fi
+if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+    libtoolize --copy --force && \\
+    aclocal -I . && \\
+    autoheader && \\
+    automake --add-missing --copy && \\
+    autoconf || \\
+    autoreconf -fiv
+fi
 \./configure "${CONFIG_OPTS[@]}"
 make -j4
 make install

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -124,6 +124,14 @@ if [ ! $INCREMENTAL ]; then
         if [ -e buildconf ]; then
             ./buildconf 2> /dev/null
         fi
+        if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+            libtoolize --copy --force && \\
+            aclocal -I . && \\
+            autoheader && \\
+            automake --add-missing --copy && \\
+            autoconf || \\
+            autoreconf -fiv
+        fi
         ./configure "${CONFIG_OPTS[@]}"
         make -j4
         make install

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -141,6 +141,23 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     wget $(use.tarball)
     tar -xzf \$(basename "$(use.tarball)")
     cd \$(basename "$(use.tarball)" .tar.gz)
+.       if defined (use.builddir)
+    cd ./$(use.builddir)
+.       endif
+    if [ -e autogen.sh ]; then
+        ./autogen.sh 2> /dev/null
+    fi
+    if [ -e buildconf ]; then
+        ./buildconf 2> /dev/null
+    fi
+    if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+        libtoolize --copy --force && \\
+        aclocal -I . && \\
+        autoheader && \\
+        automake --add-missing --copy && \\
+        autoconf || \\
+        autoreconf -fiv
+    fi
     ./configure "${CONFIG_OPTS[@]}"
     make -j4
     make install

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -165,13 +165,21 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     if [ -e buildconf ]; then
         ./buildconf 2> /dev/null
     fi
+    if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+        libtoolize --copy --force && \\
+        aclocal -I . && \\
+        autoheader && \\
+        automake --add-missing --copy && \\
+        autoconf || \\
+        autoreconf -fiv
+    fi
     ./configure "${CONFIG_OPTS[@]}"
     make -j4
     make install
     cd "${BASE_PWD}"
 .   endfor
 
-    # Build and check this project
+    # Build and check this project; note that zprojects always have an autogen.sh
     ./autogen.sh 2> /dev/null
     ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     make VERBOSE=1 all


### PR DESCRIPTION
Solution: use autoreconf (or the explicit chain of calls) in this case