### PR TITLE
Problem: Using builddir has implication when going back

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -390,6 +390,7 @@ git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).g
 . else
 git clone --quiet --depth 1 $(use.repository) $(use.project).git
 . endif
+BASE_PWD=${PWD}
 . if defined (use.builddir)
 cd $(use.project).git/$(use.builddir)
 . else
@@ -405,7 +406,7 @@ fi
 \./configure "${CONFIG_OPTS[@]}"
 make -j4
 make install
-cd ..
+cd "${BASE_PWD}"
 .endfor
 
 # Build and check this project


### PR DESCRIPTION
Solution: Use PWD to navigate back to the original directory

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>