### PR TITLE
Problem: Travis tests are slower than they can be

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,6 +357,8 @@ echo Package version............... : $PACKAGE-$VERSION
 echo
 echo C compiler.................... : $CC
 echo C compiler flags.............. : $CFLAGS
+echo C++ compiler.................. : $CXX
+echo C++ compiler flags............ : $CXXFLAGS
 echo Configure date................ : $BUILD_DATE
 echo Build architecture............ : $BUILD_ARCH
 echo Build docs.................... : $zproject_build_doc

--- a/configure.ac
+++ b/configure.ac
@@ -299,23 +299,23 @@ AC_ARG_ENABLE([Werror],
     [enable_Werror=no])
 
 AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
-    [AS_IF([test -n "$CC"],[AS_IF(["$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
          CFLAGS="$CFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C])])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C: $CC])])
         ])])
-     AS_IF([test -n "$CXX"],[AS_IF(["$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
          CXXFLAGS="$CXXFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++])])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++: $CXX])])
         ])])
-     AS_IF([test -n "$CPP"],[AS_IF(["$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
          CPPFLAGS="$CPPFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP])])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
         ])])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -299,24 +299,24 @@ AC_ARG_ENABLE([Werror],
     [enable_Werror=no])
 
 AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
-    [AS_IF([test -n "$CC" && "$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC"],[AS_IF(["$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
          CFLAGS="$CFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
-        ])
-     AS_IF([test -n "$CXX" && "$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C])])
+        ])])
+     AS_IF([test -n "$CXX"],[AS_IF(["$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
          CXXFLAGS="$CXXFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
-        ])
-     AS_IF([test -n "$CPP" && "$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++])])
+        ])])
+     AS_IF([test -n "$CPP"],[AS_IF(["$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
          CPPFLAGS="$CPPFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
-        ])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP])])
+        ])])
 ])
 
 # Specify output files

--- a/configure.ac
+++ b/configure.ac
@@ -292,6 +292,33 @@ else
     AC_SUBST(pkg_config_defines, "")
 fi
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror],
+        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified]]),
+    [AS_IF([test -n "$enableval"], [enable_Werror=$enableval], [enable_Werror=auto])],
+    [enable_Werror=no])
+
+AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
+    [AS_IF([test -n "$CC" && "$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
+         CFLAGS="$CFLAGS -Wall -Werror"],
+        [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
+        ])
+     AS_IF([test -n "$CXX" && "$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
+         CXXFLAGS="$CXXFLAGS -Wall -Werror"],
+        [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
+        ])
+     AS_IF([test -n "$CPP" && "$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
+         CPPFLAGS="$CPPFLAGS -Wall -Werror"],
+        [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
+        ])
+])
+
 # Specify output files
 AC_CONFIG_FILES([Makefile
                 ])

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -537,23 +537,23 @@ AC_ARG_ENABLE([Werror],
     [enable_Werror=no])
 
 AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
-    [AS_IF([test -n "$CC"],[AS_IF(["$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
          CFLAGS="$CFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C])])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C: $CC])])
         ])])
-     AS_IF([test -n "$CXX"],[AS_IF(["$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
          CXXFLAGS="$CXXFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++])])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++: $CXX])])
         ])])
-     AS_IF([test -n "$CPP"],[AS_IF(["$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
          CPPFLAGS="$CPPFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP])])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
         ])])
 ])
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -537,24 +537,24 @@ AC_ARG_ENABLE([Werror],
     [enable_Werror=no])
 
 AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
-    [AS_IF([test -n "$CC" && "$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC"],[AS_IF(["$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
          CFLAGS="$CFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
-        ])
-     AS_IF([test -n "$CXX" && "$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C])])
+        ])])
+     AS_IF([test -n "$CXX"],[AS_IF(["$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
          CXXFLAGS="$CXXFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
-        ])
-     AS_IF([test -n "$CPP" && "$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++])])
+        ])])
+     AS_IF([test -n "$CPP"],[AS_IF(["$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
          CPPFLAGS="$CPPFLAGS -Wall -Werror"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
-         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
-        ])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP])])
+        ])])
 ])
 
 # Specify output files

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -625,6 +625,8 @@ echo Package version............... : $PACKAGE-$VERSION
 echo
 echo C compiler.................... : $CC
 echo C compiler flags.............. : $CFLAGS
+echo C++ compiler.................. : $CXX
+echo C++ compiler flags............ : $CXXFLAGS
 echo Configure date................ : $BUILD_DATE
 echo Build architecture............ : $BUILD_ARCH
 echo Build docs.................... : $$(project.name:c)_build_doc

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -530,6 +530,33 @@ else
     AC_SUBST(pkg_config_defines, "")
 fi
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror],
+        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified]]),
+    [AS_IF([test -n "$enableval"], [enable_Werror=$enableval], [enable_Werror=auto])],
+    [enable_Werror=no])
+
+AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
+    [AS_IF([test -n "$CC" && "$CC" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
+         CFLAGS="$CFLAGS -Wall -Werror"],
+        [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
+        ])
+     AS_IF([test -n "$CXX" && "$CXX" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
+         CXXFLAGS="$CXXFLAGS -Wall -Werror"],
+        [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
+        ])
+     AS_IF([test -n "$CPP" && "$CPP" --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
+         CPPFLAGS="$CPPFLAGS -Wall -Werror"],
+        [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
+         AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied])])
+        ])
+])
+
 # Specify output files
 .if count (class) + count (ac_config)  > 0
 AC_CONFIG_FILES([Makefile

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -179,7 +179,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
             case "$CC" in
                 *ccache*) ;;
                 */*) DIR_CC="`dirname "$CC"`" && [ -n "$DIR_CC" ] && DIR_CC="`cd "$DIR_CC" && pwd `" && [ -n "$DIR_CC" ] && [ -d "$DIR_CC" ] || DIR_CC=""
-                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CC" || \
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CC" || \\
                     if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CC"':.*|^'"$DIR_CC"'$|:'"$DIR_CC"':|:'"$DIR_CC"'$)' ; then
                         CCACHE_PATH="$DIR_CC:$CCACHE_PATH"
                     fi
@@ -193,7 +193,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
             case "$CXX" in
                 *ccache*) ;;
                 */*) DIR_CXX="`dirname "$CXX"`" && [ -n "$DIR_CXX" ] && DIR_CXX="`cd "$DIR_CXX" && pwd `" && [ -n "$DIR_CXX" ] && [ -d "$DIR_CXX" ] || DIR_CXX=""
-                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CXX" || \
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CXX" || \\
                     if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CXX"':.*|^'"$DIR_CXX"'$|:'"$DIR_CXX"':|:'"$DIR_CXX"'$)' ; then
                         CCACHE_PATH="$DIR_CXX:$CCACHE_PATH"
                     fi
@@ -207,7 +207,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
             case "$CPP" in
                 *ccache*) ;;
                 */*) DIR_CPP="`dirname "$CPP"`" && [ -n "$DIR_CPP" ] && DIR_CPP="`cd "$DIR_CPP" && pwd `" && [ -n "$DIR_CPP" ] && [ -d "$DIR_CPP" ] || DIR_CPP=""
-                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CPP" || \
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CPP" || \\
                     if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CPP"':.*|^'"$DIR_CPP"'$|:'"$DIR_CPP"':|:'"$DIR_CPP"'$)' ; then
                         CCACHE_PATH="$DIR_CPP:$CCACHE_PATH"
                     fi

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -82,6 +82,10 @@ set -x
 set -e
 
 if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; then
+    LANG=C
+    LC_ALL=C
+    export LANG LC_ALL
+
     if [ -d "./tmp" ]; then
         rm -rf ./tmp
     fi

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -83,7 +83,7 @@ $(project.GENERATED_WARNING_HEADER)
 set -x
 set -e
 
-if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; then
+if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ "$BUILD_TYPE" == "valgrind" ]; then
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -295,6 +295,11 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")
     ./autogen.sh 2> /dev/null
     ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
+    if [ "$BUILD_TYPE" == "valgrind" ] ; then
+        # Build and check this project
+        make VERBOSE=1 memcheck
+        exit $?
+    fi
     make VERBOSE=1 all
 
     echo "=== Are GitIgnores good after 'make all' with drafts? (should have no output below)"
@@ -447,69 +452,4 @@ else
 fi
 .close
 .chmod_x ("ci_deploy.sh")
-.
-.directory.create ("builds/valgrind")
-.output "builds/valgrind/ci_build.sh"
-#!/usr/bin/env bash
-
-$(project.GENERATED_WARNING_HEADER)
-
-set -x
-
-cd ../..
-
-mkdir tmp
-BUILD_PREFIX=$PWD/tmp
-
-CONFIG_OPTS=()
-CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
-CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
-CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
-CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
-CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
-CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
-CONFIG_OPTS+=("--with-docs=no")
-CONFIG_OPTS+=("--quiet")
-
-# Clone and build dependencies
-.for use where defined (use.tarball)
-wget $(use.tarball)
-tar -xzf \$(basename "$(use.tarball)")
-cd \$(basename "$(use.tarball)" .tar.gz)
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
-cd ..
-.endfor
-.for use where defined (use.repository)
-. if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project).git
-. else
-git clone --quiet --depth 1 $(use.repository) $(use.project).git
-. endif
-BASE_PWD=${PWD}
-. if defined (use.builddir)
-cd $(use.project).git/$(use.builddir)
-. else
-cd $(use.project).git
-. endif
-git --no-pager log --oneline -n1
-if [ -e autogen.sh ]; then
-    ./autogen.sh 2> /dev/null
-fi
-if [ -e buildconf ]; then
-    ./buildconf 2> /dev/null
-fi
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
-cd "${BASE_PWD}"
-.endfor
-
-# Build and check this project
-\./autogen.sh 2> /dev/null
-\./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
-make VERBOSE=1 memcheck || exit 1
-.close
-.chmod_x ("builds/valgrind/ci_build.sh")
 .endmacro

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -148,18 +148,19 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
         fi
     fi
 
+    CONFIG_OPT_WERROR="--enable-Werror=no"
     if [ "$BUILD_TYPE" == "default-Werror" ] ; then
         case "${COMPILER_FAMILY}" in
             GCC)
                 echo "NOTE: Enabling ${COMPILER_FAMILY} compiler pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
+                CONFIG_OPT_WERROR="--enable-Werror=yes"
                 CONFIG_OPTS+=("--enable-Werror=yes")
                 ;;
             *)
-                echo "WARNING: Current compiler is not GCC, not enabling pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
+                echo "WARNING: Current compiler is not GCC, might not enable pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
+                CONFIG_OPT_WERROR="--enable-Werror=auto"
                 ;;
         esac
-    else
-        CONFIG_OPTS+=("--enable-Werror=no")
     fi
 
     CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
@@ -289,6 +290,9 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     # Build and check this project; note that zprojects always have an autogen.sh
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
+    # Only use --enable-Werror on projects that are expected to have it
+    # (and it is not our duty to check prerequisite projects anyway)
+    CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")
     ./autogen.sh 2> /dev/null
     ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     make VERBOSE=1 all

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -314,10 +314,10 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
         git status -s || true
         echo "==="
     fi
+.   endif
 
     # Build and check this project without DRAFT APIs
     make distclean
-.   endif
 
     git clean -f
     git reset --hard HEAD

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -19,6 +19,8 @@ register_target ("travis", "Travis CI scripts")
 # Travis CI script
 language: c
 
+cache: ccache
+
 os:
 - linux
 
@@ -92,6 +94,21 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     mkdir -p tmp
     BUILD_PREFIX=$PWD/tmp
 
+    PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'2`"
+    CCACHE_PATH="$PATH"
+    CCACHE_DIR="${HOME}/.ccache"
+    export CCACHE_PATH CCACHE_DIR PATH
+    HAVE_CCACHE=no
+    if which ccache && ls -la /usr/lib/ccache ; then
+        HAVE_CCACHE=yes
+    fi
+
+    if [ "$HAVE_CCACHE" = yes ] && [ -d "$CCACHE_DIR" ]; then
+        echo "CCache stats before build:"
+        ccache -s || true
+    fi
+    mkdir -p "${HOME}/.ccache"
+
     CONFIG_OPTS=()
     COMMON_CFLAGS=""
     EXTRA_CFLAGS=""
@@ -154,6 +171,57 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     CONFIG_OPTS+=("--with-docs=no")
     CONFIG_OPTS+=("--quiet")
 
+    if [ "$HAVE_CCACHE" = yes ] && [ "${COMPILER_FAMILY}" = GCC ]; then
+        PATH="/usr/lib/ccache:$PATH"
+        export PATH
+        if [ -n "$CC" ] && [ -x "/usr/lib/ccache/`basename "$CC"`" ]; then
+            case "$CC" in
+                *ccache*) ;;
+                */*) DIR_CC="`dirname "$CC"`" && [ -n "$DIR_CC" ] && DIR_CC="`cd "$DIR_CC" && pwd `" && [ -n "$DIR_CC" ] && [ -d "$DIR_CC" ] || DIR_CC=""
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CC" || \
+                    if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CC"':.*|^'"$DIR_CC"'$|:'"$DIR_CC"':|:'"$DIR_CC"'$)' ; then
+                        CCACHE_PATH="$DIR_CC:$CCACHE_PATH"
+                    fi
+                    ;;
+            esac
+            CC="/usr/lib/ccache/`basename "$CC"`"
+        else
+            : # CC="ccache $CC"
+        fi
+        if [ -n "$CXX" ] && [ -x "/usr/lib/ccache/`basename "$CXX"`" ]; then
+            case "$CXX" in
+                *ccache*) ;;
+                */*) DIR_CXX="`dirname "$CXX"`" && [ -n "$DIR_CXX" ] && DIR_CXX="`cd "$DIR_CXX" && pwd `" && [ -n "$DIR_CXX" ] && [ -d "$DIR_CXX" ] || DIR_CXX=""
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CXX" || \
+                    if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CXX"':.*|^'"$DIR_CXX"'$|:'"$DIR_CXX"':|:'"$DIR_CXX"'$)' ; then
+                        CCACHE_PATH="$DIR_CXX:$CCACHE_PATH"
+                    fi
+                    ;;
+            esac
+            CXX="/usr/lib/ccache/`basename "$CXX"`"
+        else
+            : # CXX="ccache $CXX"
+        fi
+        if [ -n "$CPP" ] && [ -x "/usr/lib/ccache/`basename "$CPP"`" ]; then
+            case "$CPP" in
+                *ccache*) ;;
+                */*) DIR_CPP="`dirname "$CPP"`" && [ -n "$DIR_CPP" ] && DIR_CPP="`cd "$DIR_CPP" && pwd `" && [ -n "$DIR_CPP" ] && [ -d "$DIR_CPP" ] || DIR_CPP=""
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CPP" || \
+                    if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CPP"':.*|^'"$DIR_CPP"'$|:'"$DIR_CPP"':|:'"$DIR_CPP"'$)' ; then
+                        CCACHE_PATH="$DIR_CPP:$CCACHE_PATH"
+                    fi
+                    ;;
+            esac
+            CPP="/usr/lib/ccache/`basename "$CPP"`"
+        else
+            : # CPP="ccache $CPP"
+        fi
+
+        CONFIG_OPTS+=("CC=${CC}")
+        CONFIG_OPTS+=("CXX=${CXX}")
+        CONFIG_OPTS+=("CPP=${CPP}")
+    fi
+
     # Clone and build dependencies
 .   for use where defined (use.tarball)
     wget $(use.tarball)
@@ -162,6 +230,8 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
 .       if defined (use.builddir)
     cd ./$(use.builddir)
 .       endif
+    CCACHE_BASEDIR=${PWD}
+    export CCACHE_BASEDIR
     if [ -e autogen.sh ]; then
         ./autogen.sh 2> /dev/null
     fi
@@ -193,6 +263,8 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
 .       else
     cd $(use.project).git
 .       endif
+    CCACHE_BASEDIR=${PWD}
+    export CCACHE_BASEDIR
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
         ./autogen.sh 2> /dev/null
@@ -215,6 +287,8 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
 .   endfor
 
     # Build and check this project; note that zprojects always have an autogen.sh
+    CCACHE_BASEDIR=${PWD}
+    export CCACHE_BASEDIR
     ./autogen.sh 2> /dev/null
     ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     make VERBOSE=1 all
@@ -262,6 +336,11 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     echo "=== Are GitIgnores good after 'make distcheck' without drafts? (should have no output below)"
     git status -s || true
     echo "==="
+
+    if [ "$HAVE_CCACHE" = yes ]; then
+        echo "CCache stats after build:"
+        ccache -s
+    fi
 
 elif [ "$BUILD_TYPE" == "bindings" ]; then
     pushd "./bindings/${BINDING}" && ./ci_build.sh

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -116,7 +116,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     EXTRA_CXXFLAGS=""
 
     is_gnucc() {
-        if [ -z "$1" ] && "$1" --version 2>&1 | grep 'Free Software Foundation' > /dev/null ; then true ; else false ; fi
+        if [ -n "$1" ] && "$1" --version 2>&1 | grep 'Free Software Foundation' > /dev/null ; then true ; else false ; fi
     }
 
     COMPILER_FAMILY=""

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -152,19 +152,19 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
         case "${COMPILER_FAMILY}" in
             GCC)
                 echo "NOTE: Enabling ${COMPILER_FAMILY} compiler pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
-                COMMON_CFLAGS="-Wall -Werror"
-                EXTRA_CFLAGS="-std=c99"
-                EXTRA_CPPFLAGS=""
-                EXTRA_CXXFLAGS="-std=c++99"
+                CONFIG_OPTS+=("--enable-Werror=yes")
                 ;;
             *)
                 echo "WARNING: Current compiler is not GCC, not enabling pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2
                 ;;
         esac
+    else
+        CONFIG_OPTS+=("--enable-Werror=no")
     fi
-    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include ${COMMON_CFLAGS} ${EXTRA_CFLAGS}")
-    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include ${COMMON_CFLAGS} ${EXTRA_CPPFLAGS}")
-    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include ${COMMON_CFLAGS} ${EXTRA_CXXFLAGS}")
+
+    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -97,27 +97,41 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     EXTRA_CFLAGS=""
     EXTRA_CPPFLAGS=""
     EXTRA_CXXFLAGS=""
-    if [ "$BUILD_TYPE" == "default-Werror" ] ; then
-        COMPILER_FAMILY=""
-        if [ -n "$CC" -a -n "$CXX" ]; then
-            if "$CC" --version 2>&1 | grep GCC > /dev/null && \\
-               "$CXX" --version 2>&1 | grep GCC > /dev/null \\
-            ; then
-                COMPILER_FAMILY="GCC"
-            fi
-        else
-            if "gcc" --version 2>&1 | grep GCC > /dev/null && \\
-               "g++" --version 2>&1 | grep GCC > /dev/null \\
-            ; then
-                # Autoconf would pick this by default
-                COMPILER_FAMILY="GCC"
-            elif "cc" --version 2>&1 | grep GCC > /dev/null && \\
-               "c++" --version 2>&1 | grep GCC > /dev/null \\
-            ; then
-                COMPILER_FAMILY="GCC"
-            fi
-        fi
 
+    is_gnucc() {
+        if [ -z "$1" ] && "$1" --version 2>&1 | grep 'Free Software Foundation' > /dev/null ; then true ; else false ; fi
+    }
+
+    COMPILER_FAMILY=""
+    if [ -n "$CC" -a -n "$CXX" ]; then
+        if is_gnucc "$CC" && is_gnucc "$CXX" ; then
+            COMPILER_FAMILY="GCC"
+            export CC CXX
+        fi
+    else
+        if is_gnucc "gcc" && is_gnucc "g++" ; then
+            # Autoconf would pick this by default
+            COMPILER_FAMILY="GCC"
+            [ -n "$CC" ] || CC=gcc
+            [ -n "$CXX" ] || CXX=g++
+            export CC CXX
+        elif is_gnucc "cc" && is_gnucc "c++" ; then
+            COMPILER_FAMILY="GCC"
+            [ -n "$CC" ] || CC=cc
+            [ -n "$CXX" ] || CXX=c++
+            export CC CXX
+        fi
+    fi
+
+    if [ -n "$CPP" ] ; then
+        [ -x "$CPP" ] && export CPP
+    else
+        if is_gnucc "cpp" ; then
+            CPP=cpp && export CPP
+        fi
+    fi
+
+    if [ "$BUILD_TYPE" == "default-Werror" ] ; then
         case "${COMPILER_FAMILY}" in
             GCC)
                 echo "NOTE: Enabling ${COMPILER_FAMILY} compiler pedantic error-checking flags for BUILD_TYPE='$BUILD_TYPE'" >&2

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -304,16 +304,14 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
 .   if travis_distcheck ?= 0
     make check
 .   else
-    if [ "$BUILD_TYPE" == "default-Werror" ] ; then
-        echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
-    else
+    (
         export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
         make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
 
         echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
         git status -s || true
         echo "==="
-    fi
+    )
 .   endif
 
     # Build and check this project without DRAFT APIs
@@ -328,12 +326,10 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
 .   if travis_distcheck ?= 0
         make check
 .   else
-        if [ "$BUILD_TYPE" == "default-Werror" ] ; then
-            echo "NOTE: Skipping distcheck for BUILD_TYPE='$BUILD_TYPE'" >&2
-        else
+        (
             export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]} --with-docs=yes" && \\
             make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
-        fi
+        )
 .   endif
     ) || exit 1
 


### PR DESCRIPTION
Solution: as a take on issue #734, take the least intrusive and fragile choice: enable ccache and stashing of the ccache contents from recent build of the project done in same conditions (independently for each zproject-generated project). As a result, code checkouts, autogen's and configure's are still done (of which checkouts and autogens can be parallelized with no loss in consistency, as a later improvement, when/if we ensure which projects have autogens that only require common OS programs and do not want something from installations of built other dependencies), but compilations run quickly since most object files are still applicable. Where zeromq-ecosystem prerequisites used to take 2 minutes, now it is between 30 and 60 seconds, as tested in a few runs on a pet project.

Also fixed up the builds with enabled pedantic warning/error checking, and made valgrind jobs consistent in details with usual distchecks.