### PR TITLE
Problem: [jni] bintray deployment fails due to java 1.7 incompatibility

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -129,7 +129,7 @@ $(project.GENERATED_WARNING_HEADER:)
 plugins {
     id 'java'
     id 'maven-publish'
-    id "com.jfrog.bintray" version "1.7.2"
+    id "com.jfrog.bintray" version "1.7.3"
 }
 
 group = "org.zeromq"


### PR DESCRIPTION
Solution: Upgrade to most recent version which fixed java 1.7 compatibility