### PR TITLE
Problem: build steps in Travis tests take unknown time, profiling needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ cache: ccache
 
 sudo: false
 
+# Set CI_TIME=true to enable build-step profiling in Travis
+# Set CI_TRACE=true to enable shell script tracing in Travis
 env:
-- BUILD_TYPE=default
-- BUILD_TYPE=check_zproject
+  global:
+    - CI_TIME=true
+    - CI_TRACE=false
+  matrix:
+    - BUILD_TYPE=default
+    - BUILD_TYPE=check_zproject
 
 services:
 - docker

--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -1,7 +1,25 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
-docker run -v "$REPO_DIR":/gsl zeromqorg/zproject project.xml
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
+
+$CI_TIME docker run -v "$REPO_DIR":/gsl zeromqorg/zproject project.xml
 
 # keep an eye on git version used by CI
 git --version

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -1,7 +1,32 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
-mkdir tmp
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
+
+LANG=C
+LC_ALL=C
+export LANG LC_ALL
+
+if [ -d "./tmp" ]; then
+    rm -rf ./tmp
+fi
+mkdir -p tmp
 BUILD_PREFIX=$PWD/tmp
 
 CONFIG_OPTS=()
@@ -21,42 +46,45 @@ CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
 CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 
 # Clone and build dependencies
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list generator-scripting-language >/dev/null 2>&1) || \
        (command -v brew >/dev/null 2>&1 && brew ls --versions gsl >/dev/null 2>&1)); then
-    git clone --quiet --depth 1 https://github.com/imatix/gsl.git gsl
+    $CI_TIME git clone --quiet --depth 1 https://github.com/imatix/gsl.git gsl
     BASE_PWD=${PWD}
     cd gsl
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
-        ./autogen.sh 2> /dev/null
+        $CI_TIME ./autogen.sh 2> /dev/null
     fi
     if [ -e buildconf ]; then
-        ./buildconf 2> /dev/null
+        $CI_TIME ./buildconf 2> /dev/null
     fi
     if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-        libtoolize --copy --force && \
-        aclocal -I . && \
-        autoheader && \
-        automake --add-missing --copy && \
-        autoconf || \
-        autoreconf -fiv
+        $CI_TIME libtoolize --copy --force && \
+        $CI_TIME aclocal -I . && \
+        $CI_TIME autoheader && \
+        $CI_TIME automake --add-missing --copy && \
+        $CI_TIME autoconf || \
+        $CI_TIME autoreconf -fiv
     fi
-    ./configure "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    $CI_TIME make -j4
+    $CI_TIME make install
     cd "${BASE_PWD}"
 fi
 
 # Build and check this project
 cd ../..
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
 CCACHE_BASEDIR=${PWD}
 export CCACHE_BASEDIR
-PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig cmake "${CMAKE_OPTS[@]}" .
-make all VERBOSE=1 -j4
-ctest -V
-make install
+PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig $CI_TIME cmake "${CMAKE_OPTS[@]}" .
+$CI_TIME make all VERBOSE=1 -j4
+$CI_TIME ctest -V
+$CI_TIME make install
+[ -z "$CI_TIME" ] || echo "`date`: Builds completed without fatal errors!"
 
 echo "=== Are GitIgnores good after making the project '$BUILD_TYPE'? (should have no output below)"
 git status -s || true

--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -38,6 +38,24 @@ cache="/tmp/android_build/${TOOLCHAIN_NAME}"
 rm -rf "${cache}"
 mkdir -p "${cache}"
 
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
+
 # Check for environment variable to clear the prefix and do a clean build
 if [[ $ANDROID_BUILD_CLEAN ]]; then
     echo "Doing a clean build (removing previous build and depedencies)..."
@@ -66,7 +84,7 @@ fi
 
 .endfor
 ##
-# Build $(project.name) from local source
+[ -z "$CI_TIME" ] || echo "`date`: Build $(project.name) from local source"
 
 (android_build_verify_so "$(project.libname).so"\
 .for use where !defined (use.implied)
@@ -79,10 +97,10 @@ fi
 
     export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
-    (cd "${cache}/$(project.name)" && ./autogen.sh 2> /dev/null \\
-        && ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" --without-docs \\
-        && make -j 4 \\
-        && make install) || exit 1
+    (cd "${cache}/$(project.name)" && $CI_TIME ./autogen.sh 2> /dev/null \\
+        && $CI_TIME ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" --without-docs \\
+        && $CI_TIME make -j 4 \\
+        && $CI_TIME make install) || exit 1
 }
 
 ##

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -467,9 +467,34 @@ $(project.GENERATED_WARNING_HEADER:)
 .directory.create ('builds/cmake')
 .output "builds/cmake/ci_build.sh"
 #!/usr/bin/env bash
-set -ex
+set -e
 
-mkdir tmp
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
+
+LANG=C
+LC_ALL=C
+export LANG LC_ALL
+
+if [ -d "./tmp" ]; then
+    rm -rf ./tmp
+fi
+mkdir -p tmp
 BUILD_PREFIX=$PWD/tmp
 
 CONFIG_OPTS=()
@@ -489,6 +514,7 @@ CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
 CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 
 # Clone and build dependencies
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 .for use where defined (use.tarball)
 .   if defined (use.debian_name)
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
@@ -508,22 +534,22 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
     if [ -e autogen.sh ]; then
-        ./autogen.sh 2> /dev/null
+        $CI_TIME ./autogen.sh 2> /dev/null
     fi
     if [ -e buildconf ]; then
-        ./buildconf 2> /dev/null
+        $CI_TIME ./buildconf 2> /dev/null
     fi
     if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-        libtoolize --copy --force && \\
-        aclocal -I . && \\
-        autoheader && \\
-        automake --add-missing --copy && \\
-        autoconf || \\
-        autoreconf -fiv
+        $CI_TIME libtoolize --copy --force && \\
+        $CI_TIME aclocal -I . && \\
+        $CI_TIME autoheader && \\
+        $CI_TIME automake --add-missing --copy && \\
+        $CI_TIME autoconf || \\
+        $CI_TIME autoreconf -fiv
     fi
-    ./configure "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    $CI_TIME make -j4
+    $CI_TIME make install
     cd "${BASE_PWD}"
 fi
 .endfor
@@ -537,9 +563,9 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)
 .   endif
        (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
 .   if defined (use.release)
-    git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+    $CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
 .   else
-    git clone --quiet --depth 1 $(use.repository) $(use.project)
+    $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .   endif
     BASE_PWD=${PWD}
 .   if defined (use.builddir)
@@ -551,34 +577,36 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)
     export CCACHE_BASEDIR
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
-        ./autogen.sh 2> /dev/null
+        $CI_TIME ./autogen.sh 2> /dev/null
     fi
     if [ -e buildconf ]; then
-        ./buildconf 2> /dev/null
+        $CI_TIME ./buildconf 2> /dev/null
     fi
     if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-        libtoolize --copy --force && \\
-        aclocal -I . && \\
-        autoheader && \\
-        automake --add-missing --copy && \\
-        autoconf || \\
-        autoreconf -fiv
+        $CI_TIME libtoolize --copy --force && \\
+        $CI_TIME aclocal -I . && \\
+        $CI_TIME autoheader && \\
+        $CI_TIME automake --add-missing --copy && \\
+        $CI_TIME autoconf || \\
+        $CI_TIME autoreconf -fiv
     fi
-    ./configure "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    $CI_TIME make -j4
+    $CI_TIME make install
     cd "${BASE_PWD}"
 fi
 .endfor
 
 # Build and check this project
 cd ../..
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
 CCACHE_BASEDIR=${PWD}
 export CCACHE_BASEDIR
-PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig cmake "${CMAKE_OPTS[@]}" .
-make all VERBOSE=1 -j4
-ctest -V
-make install
+PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig $CI_TIME cmake "${CMAKE_OPTS[@]}" .
+$CI_TIME make all VERBOSE=1 -j4
+$CI_TIME ctest -V
+$CI_TIME make install
+[ -z "$CI_TIME" ] || echo "`date`: Builds completed without fatal errors!"
 
 echo "=== Are GitIgnores good after making the project '$BUILD_TYPE'? (should have no output below)"
 git status -s || true

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -586,8 +586,25 @@ link_directories (${ANDROID_SYS_ROOT}/usr/lib)
 .output "$(topdir)/ci_build.sh"
 #!/usr/bin/env bash
 
-set -x
 set -e
+
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
 
 ########################################################################
 # Build and check the jni binding
@@ -608,43 +625,44 @@ CONFIG_OPTS+=("--quiet")
 pushd ../../..
 
 # Clone and build dependencies
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 .   for use where defined (use.tarball)
 wget $(use.tarball)
 tar -xzf \$(basename "$(use.tarball)")
 cd \$(basename "$(use.tarball)" .tar.gz)
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+$CI_TIME ./configure "${CONFIG_OPTS[@]}"
+$CI_TIME make -j4
+$CI_TIME make install
 cd ..
 .   endfor
 .   for use where defined (use.repository)
 .      if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+$CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
 .      else
-git clone --quiet --depth 1 $(use.repository) $(use.project)
+$CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .      endif
 cd $(use.project)
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then
-    ./autogen.sh 2> /dev/null
+    $CI_TIME ./autogen.sh 2> /dev/null
 fi
 if [ -e buildconf ]; then
-    ./buildconf 2> /dev/null
+    $CI_TIME ./buildconf 2> /dev/null
 fi
 if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-    libtoolize --copy --force && \\
-    aclocal -I . && \\
-    autoheader && \\
-    automake --add-missing --copy && \\
-    autoconf || \\
-    autoreconf -fiv
+    $CI_TIME libtoolize --copy --force && \\
+    $CI_TIME aclocal -I . && \\
+    $CI_TIME autoheader && \\
+    $CI_TIME automake --add-missing --copy && \\
+    $CI_TIME autoconf || \\
+    $CI_TIME autoreconf -fiv
 fi
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+$CI_TIME ./configure "${CONFIG_OPTS[@]}"
+$CI_TIME make -j4
+$CI_TIME make install
 .       if count (project->dependencies.class, class.project = use.project) > 0
 # Build jni dependency
-( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./gradlew publishToMavenLocal )
+( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig $CI_TIME ./gradlew publishToMavenLocal )
 .       endif
 cd ..
 
@@ -652,15 +670,17 @@ cd ..
 popd
 pushd ../..
 
-\./autogen.sh 2> /dev/null
-\./configure "${CONFIG_OPTS[@]}"
-make -j4
-make install
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
+$CI_TIME ./autogen.sh 2> /dev/null
+$CI_TIME ./configure "${CONFIG_OPTS[@]}"
+$CI_TIME make -j4
+$CI_TIME make install
+[ -z "$CI_TIME" ] || echo "`date`: Build completed without fatal errors!"
 
 popd
 
-TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./gradlew build jar
-TERM=dumb ./gradlew clean
+TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig $CI_TIME ./gradlew build jar
+TERM=dumb $CI_TIME ./gradlew clean
 
 ########################################################################
 #  Build and check the jni android binding
@@ -674,7 +694,7 @@ popd
 
 pushd android
 
-TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig ./build.sh
+TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig $CI_TIME ./build.sh
 
 popd
 .close

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -17,6 +17,25 @@ register_target ("rpi", "Raspberry Pi cross build system")
 .output "builds/rpi/build.sh"
 #!/usr/bin/env bash
 $(project.GENERATED_WARNING_HEADER:)
+
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
+
 # Parse parameters
 while [[ $# -gt 0 ]]; do
     key="$1"
@@ -92,14 +111,14 @@ if [ ! $INCREMENTAL ]; then
     # Clone and build dependencies
 .   for use where defined (use.tarball)
     if [ ! -e \$(basename "$(use.tarball)") ]; then
-        wget $(use.tarball)
+        $CI_TIME wget $(use.tarball)
         tar -xzf \$(basename "$(use.tarball)")
     fi
     pushd \$(basename "$(use.tarball)" .tar.gz)
     (
-        ./configure "${CONFIG_OPTS[@]}"
-        make -j4
-        make install
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        $CI_TIME make -j4
+        $CI_TIME make install
     ) || exit 1
     popd
 
@@ -107,34 +126,34 @@ if [ ! $INCREMENTAL ]; then
 .   for use where defined (use.repository) & ! defined (use.tarball)
     if [ ! -e $(use.project) ]; then
 .      if defined (use.release)
-        git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+        $CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
 .      else
-        git clone --quiet --depth 1 $(use.repository) $(use.project)
+        $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .      endif
     fi
     pushd $(use.project)
     (
         if [ $UPDATE ]; then
-            git pull --rebase
+            $CI_TIME git pull --rebase
         fi
         git --no-pager log --oneline -n1
         if [ -e autogen.sh ]; then
-            ./autogen.sh 2> /dev/null
+            $CI_TIME ./autogen.sh 2> /dev/null
         fi
         if [ -e buildconf ]; then
-            ./buildconf 2> /dev/null
+            $CI_TIME ./buildconf 2> /dev/null
         fi
         if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-            libtoolize --copy --force && \\
-            aclocal -I . && \\
-            autoheader && \\
-            automake --add-missing --copy && \\
-            autoconf || \\
-            autoreconf -fiv
+            $CI_TIME libtoolize --copy --force && \\
+            $CI_TIME aclocal -I . && \\
+            $CI_TIME autoheader && \\
+            $CI_TIME automake --add-missing --copy && \\
+            $CI_TIME autoconf || \\
+            $CI_TIME autoreconf -fiv
         fi
-        ./configure "${CONFIG_OPTS[@]}"
-        make -j4
-        make install
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        $CI_TIME make -j4
+        $CI_TIME make install
     ) || exit 1
     popd
 
@@ -144,10 +163,10 @@ fi
 # Cross build this project
 pushd ../..
 (
-    ./autogen.sh 2> /dev/null
-    ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
-    make -j4
-    make install
+    $CI_TIME ./autogen.sh 2> /dev/null
+    $CI_TIME ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
+    $CI_TIME make -j4
+    $CI_TIME make install
 ) || exit 1
 popd
 

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -29,12 +29,18 @@ sudo: false
 services:
 - docker
 
+# Set CI_TIME=true to enable build-step profiling in Travis
+# Set CI_TRACE=true to enable shell script tracing in Travis
 env:
-- BUILD_TYPE=default
-- BUILD_TYPE=default-Werror
-- BUILD_TYPE=cmake
-#- BUILD_TYPE=android
-#- BUILD_TYPE=check-py
+  global:
+    - CI_TIME=false
+    - CI_TRACE=false
+  matrix:
+    - BUILD_TYPE=default
+    - BUILD_TYPE=default-Werror
+    - BUILD_TYPE=cmake
+#   - BUILD_TYPE=android
+#   - BUILD_TYPE=check-py
 
 matrix:
   include:
@@ -91,8 +97,25 @@ deploy:
 
 $(project.GENERATED_WARNING_HEADER)
 
-set -x
 set -e
+
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
 
 if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ "$BUILD_TYPE" == "valgrind" ]; then
     LANG=C
@@ -235,6 +258,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     fi
 
     # Clone and build dependencies
+    [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 .   for use where defined (use.tarball)
 .      if defined (use.debian_name)
     if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
@@ -245,7 +269,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
 .      endif
            (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
         BASE_PWD=${PWD}
-        wget $(use.tarball)
+        $CI_TIME wget $(use.tarball)
         tar -xzf \$(basename "$(use.tarball)")
         cd \$(basename "$(use.tarball)" .tar.gz)
 .       if defined (use.builddir)
@@ -254,22 +278,22 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR
         if [ -e autogen.sh ]; then
-            ./autogen.sh 2> /dev/null
+            $CI_TIME ./autogen.sh 2> /dev/null
         fi
         if [ -e buildconf ]; then
-            ./buildconf 2> /dev/null
+            $CI_TIME ./buildconf 2> /dev/null
         fi
         if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-            libtoolize --copy --force && \\
-            aclocal -I . && \\
-            autoheader && \\
-            automake --add-missing --copy && \\
-            autoconf || \\
-            autoreconf -fiv
+            $CI_TIME libtoolize --copy --force && \\
+            $CI_TIME aclocal -I . && \\
+            $CI_TIME autoheader && \\
+            $CI_TIME automake --add-missing --copy && \\
+            $CI_TIME autoconf || \\
+            $CI_TIME autoreconf -fiv
         fi
-        ./configure "${CONFIG_OPTS[@]}"
-        make -j4
-        make install
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        $CI_TIME make -j4
+        $CI_TIME make install
         cd "${BASE_PWD}"
     fi
 .   endfor
@@ -283,9 +307,9 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
 .      endif
            (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
 .      if defined (use.release)
-        git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+        $CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
 .      else
-        git clone --quiet --depth 1 $(use.repository) $(use.project)
+        $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .      endif
         BASE_PWD=${PWD}
 .       if defined (use.builddir)
@@ -297,40 +321,41 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         export CCACHE_BASEDIR
         git --no-pager log --oneline -n1
         if [ -e autogen.sh ]; then
-            ./autogen.sh 2> /dev/null
+            $CI_TIME ./autogen.sh 2> /dev/null
         fi
         if [ -e buildconf ]; then
-            ./buildconf 2> /dev/null
+            $CI_TIME ./buildconf 2> /dev/null
         fi
         if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-            libtoolize --copy --force && \\
-            aclocal -I . && \\
-            autoheader && \\
-            automake --add-missing --copy && \\
-            autoconf || \\
-            autoreconf -fiv
+            $CI_TIME libtoolize --copy --force && \\
+            $CI_TIME aclocal -I . && \\
+            $CI_TIME autoheader && \\
+            $CI_TIME automake --add-missing --copy && \\
+            $CI_TIME autoconf || \\
+            $CI_TIME autoreconf -fiv
         fi
-        ./configure "${CONFIG_OPTS[@]}"
-        make -j4
-        make install
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        $CI_TIME make -j4
+        $CI_TIME make install
         cd "${BASE_PWD}"
     fi
 .   endfor
 
     # Build and check this project; note that zprojects always have an autogen.sh
+    [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project with DRAFT APIs..."
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
     # Only use --enable-Werror on projects that are expected to have it
     # (and it is not our duty to check prerequisite projects anyway)
     CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")
-    ./autogen.sh 2> /dev/null
-    ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
+    $CI_TIME ./autogen.sh 2> /dev/null
+    $CI_TIME ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     if [ "$BUILD_TYPE" == "valgrind" ] ; then
         # Build and check this project
-        make VERBOSE=1 memcheck
+        $CI_TIME make VERBOSE=1 memcheck
         exit $?
     fi
-    make VERBOSE=1 all
+    $CI_TIME make VERBOSE=1 all
 
     echo "=== Are GitIgnores good after 'make all' with drafts? (should have no output below)"
     git status -s || true
@@ -341,7 +366,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
 .   else
     (
         export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
-        make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
+        $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
 
         echo "=== Are GitIgnores good after 'make distcheck' with drafts? (should have no output below)"
         git status -s || true
@@ -350,23 +375,25 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
 .   endif
 
     # Build and check this project without DRAFT APIs
+    [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project without DRAFT APIs..."
     make distclean
 
     git clean -f
     git reset --hard HEAD
     (
-        ./autogen.sh 2> /dev/null
-        ./configure --enable-drafts=no "${CONFIG_OPTS[@]}" --with-docs=yes
-        make VERBOSE=1 all || exit $?
+        $CI_TIME ./autogen.sh 2> /dev/null
+        $CI_TIME ./configure --enable-drafts=no "${CONFIG_OPTS[@]}" --with-docs=yes
+        $CI_TIME make VERBOSE=1 all || exit $?
 .   if travis_distcheck ?= 0
         make check
 .   else
         (
             export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]} --with-docs=yes" && \\
-            make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
+            $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
         )
 .   endif
     ) || exit 1
+    [ -z "$CI_TIME" ] || echo "`date`: Builds completed without fatal errors!"
 
     echo "=== Are GitIgnores good after 'make distcheck' without drafts? (should have no output below)"
     git status -s || true


### PR DESCRIPTION
…Also, CI scripts are unavoidably traced (hardcoded "set -x").

Solutions: to find bottlenecks and prove improvements in Travis integration, the steps (build and test of prerequisites and project itself) should be profiled, at least by adding date'd echo's and time'd invokations. Add CI_TRACE toggle as a Travis global envvar to toggle "set -x" in CI scripts. Per discussion of earlier PoC, make this activity togglable (and invisible by default).

Currently timing is enabled in travis.yml for zproject itself, but disabled by default in generated travis files. Tracing is disabled by default in both cases.