### PR TITLE
Problem: cmake installs private executables

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -277,9 +277,11 @@ set_target_properties(
     $(main.name)
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
 )
+.   if main.scope = "public"
 install(TARGETS $(main.name)
     RUNTIME DESTINATION bin
 )
+.   endif
 .endfor
 
 ########################################################################


### PR DESCRIPTION
Solution: check scope before adding an install rule