### PR TITLE
Problem: unavoidable "configure --quiet" obstructs justice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ sudo: false
 
 # Set CI_TIME=true to enable build-step profiling in Travis
 # Set CI_TRACE=true to enable shell script tracing in Travis
+# Set CI_CONFIG_QUIET=true to enable "configure --quiet" (only report stderr)
 env:
   global:
     - CI_TIME=true
     - CI_TRACE=false
+    - CI_QUIET=true
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=check_zproject

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -37,7 +37,9 @@ CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
 CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
 CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
 CONFIG_OPTS+=("--with-docs=no")
-CONFIG_OPTS+=("--quiet")
+if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
+    CONFIG_OPTS+=("--quiet")
+fi
 
 CMAKE_OPTS=()
 CMAKE_OPTS+=("-DCMAKE_INSTALL_PREFIX:PATH=${BUILD_PREFIX}")

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -507,7 +507,9 @@ CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
 CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
 CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
 CONFIG_OPTS+=("--with-docs=no")
-CONFIG_OPTS+=("--quiet")
+if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
+    CONFIG_OPTS+=("--quiet")
+fi
 
 CMAKE_OPTS=()
 CMAKE_OPTS+=("-DCMAKE_INSTALL_PREFIX:PATH=${BUILD_PREFIX}")

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -620,7 +620,9 @@ CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
 CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
 CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
 CONFIG_OPTS+=("--with-docs=no")
-CONFIG_OPTS+=("--quiet")
+if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
+    CONFIG_OPTS+=("--quiet")
+fi
 
 pushd ../../..
 

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -31,10 +31,12 @@ services:
 
 # Set CI_TIME=true to enable build-step profiling in Travis
 # Set CI_TRACE=true to enable shell script tracing in Travis
+# Set CI_CONFIG_QUIET=true to enable "configure --quiet" (only report stderr)
 env:
   global:
     - CI_TIME=false
     - CI_TRACE=false
+    - CI_QUIET=true
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=default-Werror
@@ -204,7 +206,9 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
     CONFIG_OPTS+=("--with-docs=no")
-    CONFIG_OPTS+=("--quiet")
+    if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
+        CONFIG_OPTS+=("--quiet")
+    fi
 
     if [ "$HAVE_CCACHE" = yes ] && [ "${COMPILER_FAMILY}" = GCC ]; then
         PATH="/usr/lib/ccache:$PATH"


### PR DESCRIPTION
Solution: when travis tests go south, more insight can be desired - so make the quiet configure operation default, but togglable