### PR TITLE
Problem: when regenerating a zproject, we don't know which existing files were skipped

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1040,15 +1040,22 @@ $(project.GENERATED_WARNING_HEADER:)
 .if !file.exists ("src/$(main.name).cfg.in")
 .       output "src/$(main.name).cfg.in"
 #   $(main.name) configuration
+# This is a skeleton created by zproject.
+# You can add hand-written code here.
 
 server
     timeout = 10000     #   Client connection timeout, msec
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     verbose = 0         #   Do verbose logging of activity?
+.else
+.   echo "NOT regenerating an existing src/$(main.name).cfg.in file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .if !file.exists ("src/$(main.name).service.in")
 .   output "src/$(main.name).service.in"
+# This is a skeleton created by zproject.
+# You can add hand-written code here.
+
 [Unit]
 Description=$(main.name) service
 After=network.target
@@ -1060,6 +1067,8 @@ ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
 
 [Install]
 WantedBy=multi-user.target
+.else
+.   echo "NOT regenerating an existing src/$(main.name).service.in file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .endfor
 .close
@@ -1483,10 +1492,15 @@ cc ['flags'] 'files' -l$(project.linkname) ['libraries']
 DESCRIPTION
 -----------
 
+This is a skeleton created by zproject.
+You should add hand-written text here.
+
 Classes
 ~~~~~~~
 
 Something.
+.else
+.   echo "NOT regenerating an existing doc/$(project.name).txt boilerplate file; but you probably should not care"
 .endif
 .endmacro
 

--- a/zproject_bench.gsl
+++ b/zproject_bench.gsl
@@ -153,6 +153,8 @@ int main (void)
 
     return 0;
 }
+.else
+.   echo "NOT regenerating an existing bench/$(bench.name).c skeleton file; but you probably should not care"
 .endif
 .endmacro
 

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -36,6 +36,8 @@
 //  Add your own public definitions here, if you need them
 
 #endif
+.else
+.   echo "NOT regenerating an existing include/$(project.header) skeleton file; but you probably should not care"
 .endif
 .output "include/$(project.prefix)_library.h"
 /*  =========================================================================

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -13,6 +13,8 @@
 if !file.exists (".gitignore")
     echo "Generating initial .gitignore file"
     output ".gitignore"
+    ># This is a skeleton created by zproject.
+    ># You can add hand-written code here.
     >save.xml
     ># Object files
     >*.o
@@ -144,6 +146,8 @@ endif
 if !file.exists (".gitattributes")
     echo "Generating initial .gitattributes file"
     output ".gitattributes"
+    ># This is a skeleton created by zproject.
+    ># You can add hand-written code here.
     ># disables auto CRLF conversion for all files; create the file correctly and it will be allright
     >* -text
 else

--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -33,11 +33,16 @@ $(use.project)/
 .output "$(topdir)/.prebuildrc"
 prebuild[] = 4.2.4
 prebuild[] = 5.6.0
+.else
+.   echo "NOT regenerating an existing $(topdir)/.prebuildrc file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .if !file.exists ("$(topdir)/index.js")
 .output "$(topdir)/index.js"
 /*
     $(project.name:) exported constants and other initializations
+
+    This is a skeleton created by zproject.
+    You can add hand-written code here.
 
 .   for project.license
     $(string.trim (license.):block                                         )
@@ -48,6 +53,8 @@ module.exports = {
     $(PROJECT.PREFIX)_WHATEVER: 1
 }
 
+.else
+.   echo "NOT regenerating an existing $(topdir)/index.js boilerplate file; but you probably should not care (unless your licenses changed)"
 .endif
 .output "$(topdir)/build.sh"
 #! /bin/bash

--- a/zproject_qml.gsl
+++ b/zproject_qml.gsl
@@ -379,18 +379,23 @@ TestCase {
     verify(true)
   }
 }
-
+.else
+.   echo "NOT regenerating an existing bindings/qml/test/tst_$(project.QmlName).qml file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .#
 .if !file.exists ("bindings/qml/.gitignore")
 .output "bindings/qml/.gitignore"
 build/
+.else
+.   echo "NOT regenerating an existing bindings/qml/.gitignore skeleton file; but you probably should not care"
 .endif
 .#
 .if !file.exists ("bindings/qml/src/qmldir")
 .output "bindings/qml/src/qmldir"
 module $(project.QmlName:)
 plugin $(project.qml_soname:)
+.else
+.   echo "NOT regenerating an existing bindings/qml/src/qmldir skeleton file; but you probably should not care"
 .endif
 .#
 .output "bindings/qml/$(project.qml_soname:)_bindings.pro"

--- a/zproject_qt.gsl
+++ b/zproject_qt.gsl
@@ -491,6 +491,8 @@ $(project.GENERATED_WARNING_HEADER:)
 .  output "bindings/qt/config.pri"
 $(PROJECT.QTNAME)_LIBRARY = yes
 .  close
+.else
+.   echo "NOT regenerating an existing bindings/qt/config.pri file; but you probably should not care"
 .endif
 .###############################################################################
 .#                                                                             #

--- a/zproject_ruby.gsl
+++ b/zproject_ruby.gsl
@@ -601,6 +601,8 @@ task :default => :test
 # Run tests.
 RSpec::Core::RakeTask.new :test do |c|
 end
+.else
+.   echo "NOT regenerating an existing bindings/ruby/Rakefile file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .#
 .directory.create ("bindings/ruby/spec")
@@ -614,6 +616,8 @@ RSpec.configure do |c|
   c.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
   c.mock_with(:rspec)   { |c| c.syntax = [:should, :expect] }
 end
+.else
+.   echo "NOT regenerating an existing bindings/ruby/spec/spec_helper.rb file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .#
 .output "bindings/ruby/spec/ffi_spec.rb"

--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -63,6 +63,8 @@ int main (int argc, char *argv [])
     return 0;
 }
 .   close
+. else
+.   echo "NOT regenerating an existing $(main.source) skeleton file; but you probably should not care"
 . endif
 .endmacro
 
@@ -130,6 +132,8 @@ $(PROJECT.PREFIX)_EXPORT void
 
 #endif
 .   close
+. else
+.   echo "NOT regenerating an existing $(actor.header) skeleton file; but you probably should not care"
 . endif
 .endmacro
 
@@ -306,6 +310,8 @@ $(actor.name:c)_test (bool verbose)
 }
 .   endif
 .   close
+. else
+.   echo "NOT regenerating an existing $(actor.source) skeleton file; but you probably should not care"
 . endif
 .endmacro
 
@@ -364,6 +370,8 @@ $(PROJECT.PREFIX)_EXPORT void
 
 #endif
 .   close
+. else
+.   echo "NOT regenerating an existing $(class.header) skeleton file; but you probably should not care"
 . endif
 .endmacro
 
@@ -444,5 +452,7 @@ $(class.c_name)_test (bool verbose)
 }
 .   endif
 .   close
+. else
+.   echo "NOT regenerating an existing $(class.source) skeleton file; but you probably should not care"
 . endif
 .endmacro

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -17,6 +17,9 @@ register_target ("travis", "Travis CI scripts")
 .   echo "Generating skeleton .travis.yml script"
 .   output ".travis.yml"
 # Travis CI script
+# This is a skeleton created by zproject.
+# You can add hand-written code here.
+
 language: c
 
 cache: ccache
@@ -92,6 +95,8 @@ deploy:
     tags: true
     condition: $TRAVIS_OS_NAME =~ (linux) && $BUILD_TYPE =~ (default)
 .   close
+.else
+.   echo "NOT regenerating an existing .travis.yml file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .
 .output "ci_build.sh"

--- a/zproject_valgrind.gsl
+++ b/zproject_valgrind.gsl
@@ -44,4 +44,6 @@ if !file.exists ("src/.valgrind.supp")
     >   fun:_GLOBAL__sub_I_eh_alloc.cc
     >   ...
     >}
+else
+    echo "NOT regenerating an existing src/.valgrind.supp file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 endif


### PR DESCRIPTION
Solution: wherever "!file.exists()" check is used, report that a file was not overwritten (and propose an estimate if it matters or not - e.g. should the user move away the existing file and re-run GSL, or not)