### PR TITLE
Problem: recent fix to mkman did not fallback for headers

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1219,6 +1219,9 @@ sub generate_manpage {
         # Support mixed-source projects (named C in config,
         # but having both .c and .cc files in reality)
         printf "Can't open C '$source', retry for C++\n";
+        if ($header == $source) {
+            $header .= "c";
+        }
         $source .= "c"; # Retry for a *.cc filename
     }
 .endif

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1225,7 +1225,6 @@ sub generate_manpage {
     die "Can't open '$source'"
         unless open (SOURCE, $source);
     $_ = <SOURCE>;
-    $_ = <SOURCE>;
     $title = "no title found";
     $title = $1 if (/    \\w+ - (.*)/);
     close (SOURCE);


### PR DESCRIPTION
Solution: also fallback from C to CC if header == source (MAN1 codepath)