### PR TITLE
Problem: stale version.sh files can break builds

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -56,6 +56,9 @@ fi
 
 $(project.GENERATED_WARNING_HEADER:)
 .chmod_x ("autogen.sh")
+.if file.exists ("version.sh")
+.   echo "WARNING: Your workspace has a 'version.sh' - note that zproject no longer generates this, and its presence may confuse your builds; you may want to remove it (or bump manually for project version '$(project->version.major).$(project->version.minor).$(project->version.patch)')"
+.endif
 .output "configure.ac"
 $(project.GENERATED_WARNING_HEADER:)
 


### PR DESCRIPTION
Solution: when regenerating a project, warn the user about present obsolete version.sh (followup to https://github.com/zeromq/zproject/commit/2993efe965c2f5bc740e28c226b74e57177e59b5 which dropped it)