### PR TITLE
Problem: [debian] removed comment used a reminder

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -51,6 +51,7 @@ Build-Depends: debhelper (>= 9),
 .endif
 .endfor
 .if systemd ?= 1
+.# necessary for systemd.pc to get unit install path
     systemd,
     dh-systemd,
 .endif


### PR DESCRIPTION
Solution: Re-insert comment as GSL comment so the OBS build service
will not break.