### PR TITLE
Problem: zproject allows to constrain only minimal version of dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ Model is described in `zproject_known_projects.xml` file:
         repository = "https://github.com/zeromq/libzmq.git"
         test = "zmq_init" />
 
+    <!-- Note: if your project requires an older CZMQ (e.g. if you need
+        `release = "v3.0.2"`), you may need to `test = "zctx_test"`.
+        Also note that you can instead require particular package
+        version (as reported by pkg-config records). -->
     <use project = "czmq" libname = "libczmq"
         repository = "https://github.com/zeromq/czmq.git"
         test = "zhashx_test">

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ zproject's `project.xml` contains an extensive description of the available conf
         The travis ci will use the installed packages when building instead of
         rebuilding if available.
     <use project = "zyre" min_major= "1" min_minor = "1" min_patch = "0" />
+    <use project = "czmq"
+        min_major= "3" min_minor = "0" min_patch = "2"
+        next_incompatible_major = "4"
+        />
     <use project = "uuid" optional= "1" implied = "1" />
     <use project = "myfirstlib" repository = "http://myfirstlib.org/myfirstlib.git" />
     <use project = "mysecondlib" tarball = "http://mysecondlib.org/mysecondlib-1.2.3.tar.gz" />

--- a/project.xml
+++ b/project.xml
@@ -74,6 +74,10 @@
         The travis ci will use the installed packages when building instead of
         rebuilding if available.
     <use project = "zyre" min_major= "1" min_minor = "1" min_patch = "0" />
+    <use project = "czmq"
+        min_major= "3" min_minor = "0" min_patch = "2"
+        next_incompatible_major = "4"
+        />
     <use project = "uuid" optional= "1" implied = "1" />
     <use project = "myfirstlib" repository = "http://myfirstlib.org/myfirstlib.git" />
     <use project = "mysecondlib" tarball = "http://mysecondlib.org/mysecondlib-1.2.3.tar.gz" />

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -156,7 +156,14 @@ PREVIOUS_LIBS="${LIBS}"
 
 was_$(use.project:c)_check_lib_detected=no
 
-PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
+PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
+.  if defined(use.max_version)
+ $(use.libname) <= $(use.max_version)\
+.  endif
+.  if defined(use.next_incompatible_version)
+ $(use.libname) < $(use.next_incompatible_version)\
+.  endif
+],
     [
 .  if optional
         AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
@@ -164,7 +171,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
         PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
     ],
     [
-.  if use.min_version = '0.0.0'
+.  if use.min_version = '0.0.0' & !defined(use.max_version) & !defined(use.next_incompatible_version)
         AC_ARG_WITH([$(use.libname)],
             [
                 AS_HELP_STRING([--with-$(use.libname)],
@@ -207,10 +214,25 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)],
             ],
             [AC_MSG_ERROR([cannot link with -l$(use.linkname), install $(use.libname)])])
 .       endif
-.   elsif optional
-        AC_MSG_WARN([Cannot find $(use.libname) $(use.min_version) or higher])
 .   else
-        AC_MSG_ERROR([Cannot find $(use.libname) $(use.min_version) or higher])
+.       if optional
+        AC_MSG_WARN([\
+.       else
+        AC_MSG_ERROR([\
+.       endif
+Cannot find $(use.libname)\
+.       if defined(use.max_version) | defined(use.next_incompatible_version)
+ >= $(use.min_version)\
+.           if defined(use.max_version)
+ and <= $(use.max_version)\
+.           endif
+.           if defined(use.next_incompatible_version)
+ and < $(use.next_incompatible_version)\
+.           endif
+.       else
+ $(use.min_version) or higher\
+.       endif
+])
 .   endif
     ])
 
@@ -1096,6 +1118,17 @@ Requires:\
 $(use.libname)\
 .       if (use.min_version <> '0.0.0')
  >= $(use.min_version)\
+.       endif
+.       if defined(use.max_version) | defined(use.next_incompatible_version)
+.           if (use.min_version = '0.0.0')
+ >= 0.0.0
+.           endif
+.           if defined(use.max_version)
+ $(use.libname) <= $(use.max_version)\
+.           endif
+.           if defined(use.next_incompatible_version)
+ $(use.libname) < $(use.next_incompatible_version)\
+.           endif
 .       endif
 .       if !last ()
  \

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -35,6 +35,10 @@
         repository = "https://github.com/zeromq/libzmq.git"
         test = "zmq_init" />
 
+    <!-- Note: if your project requires an older CZMQ (e.g. if you need
+        `release = "v3.0.2"`), you may need to `test = "zctx_test"`.
+        Also note that you can instead require particular package
+        version (as reported by pkg-config records). -->
     <use project = "czmq" libname = "libczmq"
         repository = "https://github.com/zeromq/czmq.git"
         test = "zhashx_test">

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -45,14 +45,46 @@ function resolve_project_dependency (use)
     my.use.min_major ?= 0
     my.use.min_minor ?= 0
     my.use.min_patch ?= 0
+    # The "use" tags may also define a "max_version" (<= comparison)
+    # and/or "next_incompatible_version" (< comparison) explicitly
+    # or using the major/minor/patch scheme named values to bump
+    # partial version values compared to respective "min" fields.
+    # If not set, these limits are empty and so are not considered.
+    # If both are set, they all apply by common mathematics rules:
+    # "version >= min && <= max && < next" - so ensure the numbers
+    # make sense.
 
     # For values with no reasonable fallback, print error
     if !defined (my.use.test)
         echo "Project $(my.use.project) needs a 'test' attribute"
     endif
 
-    # Calculate all non-model values from model values
+    # Calculate all non-model values from model values (defaults
+    # to "0.0.0" if not set in project.xml:
     my.use.min_version = "$(min_major).$(min_minor).$(min_patch)"
+
+    # Note: Logic below would produce a bump in only one field, if one is
+    # passed, e.g. when min == "3.0.2" and next_incompatible_major == "4"
+    # then the next_incompatible := "4.0.2" (4.0.0 might be more reasonable
+    # but spelling out the comparisons below would be complicated - TODO
+    # later, when someone steps on this as a practical problem); same for max.
+    if !defined(my.use.max_version)
+        if defined(my.use.max_major) | defined(my.use.max_minor) | defined(my.use.max_patch)
+            my.use.max_major ?= my.use.min_major
+            my.use.max_minor ?= my.use.min_minor
+            my.use.max_patch ?= my.use.min_patch
+            my.use.max_version = "$(max_major).$(max_minor).$(max_patch)"
+        endif
+    endif
+
+    if !defined(my.use.next_incompatible_version)
+        if defined(my.use.next_incompatible_major) | defined(my.use.next_incompatible_minor) | defined(my.use.next_incompatible_patch)
+            my.use.next_incompatible_major ?= my.use.min_major
+            my.use.next_incompatible_minor ?= my.use.min_minor
+            my.use.next_incompatible_patch ?= my.use.min_patch
+            my.use.next_incompatible_version = "$(next_incompatible_major).$(next_incompatible_minor).$(next_incompatible_patch)"
+        endif
+    endif
 
     # Copy all dependencies implied by this one into the project
     for my.use.use as implied_use


### PR DESCRIPTION
Solution: add support for optional maximum and next known-incompatible versions

Verified to produce reasonable output in both `configure.ac` and `*-pc.in` files.