### PR TITLE
Problem: generated debian control file ended a list with comma

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -16,8 +16,9 @@ Maintainer:     zproject Developers <zeromq-dev@lists.zeromq.org>
 Standards-Version: 3.9.7
 Build-Depends: debhelper (>= 9),
     pkg-config,
-    dh-autoreconf,
     generator-scripting-language,
+    dh-autoreconf
+
 Build-Depends-Indep: asciidoc,
                      xmlto
 

--- a/packaging/debian/zproject.dsc.obs
+++ b/packaging/debian/zproject.dsc.obs
@@ -6,8 +6,9 @@ Maintainer: zproject Developers <zeromq-dev@lists.zeromq.org>
 Architecture: any
 Build-Depends: debhelper (>= 9),
     pkg-config,
-    dh-autoreconf,
     generator-scripting-language,
+    dh-autoreconf
+
 Build-Depends-Indep: asciidoc,
                      xmlto
 

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -40,7 +40,6 @@ Maintainer:     $(project.name) Developers <$(project.email)>
 Standards-Version: 3.9.7
 Build-Depends: debhelper (>= 9),
     pkg-config,
-    dh-autoreconf,
 .for project.use
 .if defined(use.debian_name)
     $(use.debian_name),
@@ -54,6 +53,8 @@ Build-Depends: debhelper (>= 9),
     systemd,
     dh-systemd,
 .endif
+    dh-autoreconf
+
 Build-Depends-Indep: asciidoc,
                      xmlto
 
@@ -228,7 +229,6 @@ Maintainer: $(project.name) Developers <$(project.email)>
 Architecture: any
 Build-Depends: debhelper (>= 9),
     pkg-config,
-    dh-autoreconf,
 .for project.use
 .if defined(use.debian_name)
     $(use.debian_name),
@@ -242,6 +242,8 @@ Build-Depends: debhelper (>= 9),
     systemd,
     dh-systemd,
 .endif
+    dh-autoreconf
+
 Build-Depends-Indep: asciidoc,
                      xmlto
 


### PR DESCRIPTION
Solution: shuffle around the required package names so the end of list is definitive