### PR TITLE
Debian: no empty lines must be between Build* tags

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -18,7 +18,6 @@ Build-Depends: debhelper (>= 9),
     pkg-config,
     generator-scripting-language,
     dh-autoreconf
-
 Build-Depends-Indep: asciidoc,
                      xmlto
 

--- a/packaging/debian/zproject.dsc.obs
+++ b/packaging/debian/zproject.dsc.obs
@@ -8,7 +8,6 @@ Build-Depends: debhelper (>= 9),
     pkg-config,
     generator-scripting-language,
     dh-autoreconf
-
 Build-Depends-Indep: asciidoc,
                      xmlto
 

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -55,7 +55,6 @@ Build-Depends: debhelper (>= 9),
     dh-systemd,
 .endif
     dh-autoreconf
-
 Build-Depends-Indep: asciidoc,
                      xmlto
 
@@ -244,7 +243,6 @@ Build-Depends: debhelper (>= 9),
     dh-systemd,
 .endif
     dh-autoreconf
-
 Build-Depends-Indep: asciidoc,
                      xmlto
 


### PR DESCRIPTION
Try to fix fallout from PR #803 