### PR TITLE
Problem: different systemd units can be delivered by projects

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -195,7 +195,7 @@ usr/bin/$(bin.name)
 .# generate service file names
 .   for project.main where main.service ?= 1
 etc/$(project.name)/$(main.name).cfg
-lib/systemd/system/$(main.name).service
+lib/systemd/system/$(main.name){,@*}.{service,timer,path,target,socket}
 .   endfor
 .endif
 

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -196,7 +196,7 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .# generate service file names
 .for project.main where main.service ?= 1
 %config(noreplace) %{_sysconfdir}/$(project.name)/$(main.name).cfg
-/usr/lib/systemd/system/$(main.name).service
+/usr/lib/systemd/system/$(main.name){,@*}.{service,timer,path,target,socket}
 .etc_exists = 1
 .endfor
 .if etc_exists ?= 1
@@ -207,19 +207,19 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %post
 %systemd_post\
 .   for project.main where main.service ?= 1
- $(main.name).service\
+ $(main.name){,@*}.{service,timer,path,target,socket}\
 .   endfor
 
 %preun
 %systemd_preun\
 .   for project.main where main.service ?= 1
- $(main.name).service\
+ $(main.name){,@*}.{service,timer,path,target,socket}\
 .   endfor
 
 %postun
 %systemd_postun_with_restart\
 .   for project.main where main.service ?= 1
- $(main.name).service\
+ $(main.name){,@*}.{service,timer,path,target,socket}\
 .   endfor
 
 %endif


### PR DESCRIPTION
Solution: rather than fixed `$name.service` strings, allow packaging of certain globs on top of this.

TODO: Test resulting markup with some packaging system (OBS?); by docs globs should be supported.