### PR TITLE
Problem: need to automate self-testing of private classes

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -905,6 +905,17 @@ $(last ()?? "\n"? " \\")
 endif
 
 .endif
+.if count (class)
+if ENABLE_DRAFTS
+src_$(project.libname)_la_SOURCES += \\
+.   if project.use_cxx
+    src/$(project.prefix)_private_selftest.cc
+.   else
+    src/$(project.prefix)_private_selftest.c
+.   endif
+endif
+
+.endif
 src_$(project.libname)_la_CPPFLAGS = ${AM_CPPFLAGS}
 .if project.use_cxx
 src_$(project.libname)_la_CXXFLAGS = ${AM_CXXFLAGS}

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -166,6 +166,12 @@ typedef struct _$(class.c_name)_t $(class.c_name)_t;
 .   endif
 .endfor
 
+#ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+//  Self test for private classes
+$(PROJECT.PREFIX)_EXPORT void
+    $(project.prefix)_private_selftest (bool verbose);
+#endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
+
 #endif
 /*
 $(project.GENERATED_WARNING_HEADER:)
@@ -217,6 +223,9 @@ all_tests [] = {
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif
 .endfor
+#ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+    { "private_classes", $(project.prefix)_private_selftest },
+#endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
     {0, 0}          //  Sentinel
 };
 
@@ -282,7 +291,7 @@ main (int argc, char **argv)
         ||  streq (argv [argn], "-l")) {
             puts ("Available tests:");
 .for class where selftest & private ?<> 1
-            puts ("    $(class.c_name)\\t- \
+            puts ("    $(class.c_name)\\t\\t- \
 .   if class.draft
 draft\
 .   else
@@ -290,6 +299,7 @@ stable\
 .   endif
 ");
 .endfor
+            puts ("    private_classes\\t- draft");
             return 0;
         }
         else
@@ -327,6 +337,58 @@ stable\
         test_runall (verbose);
 
     return 0;
+}
+/*
+$(project.GENERATED_WARNING_HEADER:)
+*/
+.#
+.#  Build the project private classes selftest module
+.#
+.if project.use_cxx
+.output "src/$(project.prefix)_private_selftest.cc"
+.else
+.output "src/$(project.prefix)_private_selftest.c"
+.endif
+/*  =========================================================================
+    $(project.prefix)_private_selftest.c - run private classes selftests
+
+    Runs all private classes selftests.
+
+    -------------------------------------------------------------------------
+.   for project.license
+    $(string.trim (license.):block                                         )
+.   endfor
+
+$(project.GENERATED_WARNING_HEADER:)
+    =========================================================================
+*/
+
+#include "$(project.prefix)_classes.h"
+
+
+//  -------------------------------------------------------------------------
+//  Run all private classes tests.
+//
+
+void
+$(project.prefix)_private_selftest (bool verbose)
+{
+.for class where !draft & selftest & private ?= 1
+.   if first ()
+// Tests for stable private classes:
+.   endif
+    $(class.c_name)_test (verbose);
+.endfor
+.for class where draft & selftest & private ?= 1
+.   if first ()
+#ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+// Tests for draft private classes:
+.   endif
+    $(class.c_name)_test (verbose);
+.   if last ()
+#endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
+.   endif
+.endfor
 }
 /*
 $(project.GENERATED_WARNING_HEADER:)
@@ -397,6 +459,10 @@ $(PROJECT.PREFIX)_PRIVATE $(c_method_signature (method):)\
 .       endif
 .   endfor
 .endfor
+
+//  Self test for private classes
+$(PROJECT.PREFIX)_PRIVATE void
+    $(project.prefix)_private_selftest (bool verbose);
 
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -197,6 +197,18 @@ IF (ENABLE_DRAFTS)
 ENDIF (ENABLE_DRAFTS)
 
 .endif
+.if count (class)
+IF (ENABLE_DRAFTS)
+    list (APPEND $(project.linkname)_sources
+.   if project.use_cxx
+        src/$(project.prefix)_private_selftest.cc
+.   else
+        src/$(project.prefix)_private_selftest.c
+.   endif
+    )
+ENDIF (ENABLE_DRAFTS)
+
+.endif
 source_group("Source Files" FILES ${$(project.linkname)_sources})
 if (NOT DEFINED BUILD_SHARED_LIBS)
     SET(BUILD_SHARED_LIBS ON)
@@ -309,6 +321,14 @@ IF (ENABLE_DRAFTS)
 .   for class where draft & private ?<> 1
     $(name:c)
 .   endfor
+    )
+ENDIF (ENABLE_DRAFTS)
+
+.endif
+.if count (class)
+IF (ENABLE_DRAFTS)
+    list (APPEND TEST_CLASSES
+    private_classes
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/zproject_cygwin.gsl
+++ b/zproject_cygwin.gsl
@@ -28,6 +28,9 @@ OBJS =\
 .for class
  $(name:c).o\
 .endfor
+.if count (class)
+ $(project.prefix)_private_selftest.o
+.endif
 
 %.o: ../../src/%.c
 	$\(CC) -c -o $@ $< $\(CFLAGS)

--- a/zproject_gyp.gsl
+++ b/zproject_gyp.gsl
@@ -181,6 +181,11 @@ $(project.GENERATED_WARNING_HEADER:)
 .   endfor
         '../../include/$(project.prefix)_library.h',
         '../../src/$(project.prefix)_selftest.c',
+.   if project.use_cxx
+        '../../src/$(project.prefix)_private_selftest.cc',
+.   else
+        '../../src/$(project.prefix)_private_selftest.c',
+.   endif
         '../../src/$(project.prefix)_classes.h'
       ],
       'dependencies': [

--- a/zproject_mingw32.gsl
+++ b/zproject_mingw32.gsl
@@ -28,6 +28,9 @@ OBJS =\
 .for class
  $(name:c).o\
 .endfor
+.if count (class)
+ $(project.prefix)_private_selftest.o
+.endif
 
 %.o: ../../src/%.c
 	$\(CC) -c -o $@ $< $\(CFLAGS)

--- a/zproject_vs2008.gsl
+++ b/zproject_vs2008.gsl
@@ -314,6 +314,44 @@ $(project.GENERATED_WARNING_HEADER:)
         </FileConfiguration>
       </File>
 .endfor
+.if count (class)
+.   if project.use_cxx
+      <File RelativePath="..\\..\\..\\..\\src\\$(project.prefix)_private_selftest.cc">
+.   else
+      <File RelativePath="..\\..\\..\\..\\src\\$(project.prefix)_private_selftest.c">
+.   endif
+        <FileConfiguration Name="Release|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Release|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+      </File>
+.endif
     </Filter>
     <Filter Name="Header Files">
       <File RelativePath="..\\..\\..\\..\\builds\\msvc\\platform.h" />


### PR DESCRIPTION
Solution: add a new module, $project_private_selftest, which will
call every private class selftest function. This module exposes a
single void $project_private_selftest (bool verbose) function which
is then called from the selftest binary.
This way there is a single, common and stable public symbol and
private classes symbols are not exposed.
Note that for now it's exposed as a DRAFT functionality to allow for
testing.
Fixes #808