### PR TITLE
Problem: uuid redhat package name uses old library

### DIFF
--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -118,6 +118,7 @@
     <use project = "uuid"
         test = "uuid_generate"
         header = "uuid/uuid.h"
+        redhat_name = "libuuid-devel"
         debian_name = "uuid-dev" />
 
     <use project = "asound"


### PR DESCRIPTION
Solution: use libuuid-dev to use util-linux library instead of the
very old and unmaintained ossp uuid