### PR TITLE
Problem: got issues building against lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ zproject's `project.xml` contains an extensive description of the available conf
     <use project = "uuid" optional= "1" implied = "1" />
     <use project = "myfirstlib" repository = "http://myfirstlib.org/myfirstlib.git" />
     <use project = "mysecondlib" tarball = "http://mysecondlib.org/mysecondlib-1.2.3.tar.gz" />
+    <use project = "lua-5.1" am_lib_macro = "LUA_5_1" tarball = "..." />
     -->
 
     <use project = "gsl" type = "runtime" />

--- a/project.xml
+++ b/project.xml
@@ -81,6 +81,7 @@
     <use project = "uuid" optional= "1" implied = "1" />
     <use project = "myfirstlib" repository = "http://myfirstlib.org/myfirstlib.git" />
     <use project = "mysecondlib" tarball = "http://mysecondlib.org/mysecondlib-1.2.3.tar.gz" />
+    <use project = "lua-5.1" am_lib_macro = "LUA_5_1" tarball = "..." />
     -->
 
     <use project = "gsl" type = "runtime" />

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -171,7 +171,12 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
         PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
     ],
     [
-.  if use.min_version = '0.0.0' & !defined(use.max_version) & !defined(use.next_incompatible_version)
+.  if defined(use.test)
+        AC_MSG_NOTICE([Package $(use.libname) not found\
+.       if !(use.min_version = '0.0.0') | defined(use.max_version) |defined(use.next_incompatible_version)
+ with needed constraints\
+.       endif
+; falling back to defined compilability tests])
         AC_ARG_WITH([$(use.libname)],
             [
                 AS_HELP_STRING([--with-$(use.libname)],
@@ -232,7 +237,7 @@ Cannot find $(use.libname)\
 .       else
  $(use.min_version) or higher\
 .       endif
-])
+, and no compilability tests were defined either])
 .   endif
     ])
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -166,7 +166,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
 ],
     [
 .  if optional
-        AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
+        AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The $(use.libname) library is to be used])
 .  endif
         PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
     ],
@@ -212,7 +212,7 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
                 was_$(use.project:c)_check_lib_detected=yes
                 PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -l$(use.linkname)"
 .       if optional
-                AC_DEFINE(HAVE_$(USE.LIBNAME), 1, [The $(use.libname) library is to be used])
+                AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The $(use.libname) library is to be used])
             ],
             [])
 .       else

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -62,7 +62,9 @@ $(project.GENERATED_WARNING_HEADER:)
 //  External dependencies
 .for use where !defined (implied)
 .    if (use.optional = 1)
-#if defined (HAVE_$(USE.LIBNAME))
+.# TODO: Fix up GSL to only reference same macro once (e.g. if variants are
+.# defined for OS packages named vastly different in various distros, like lua)
+#if defined (HAVE_$(USE.AM_LIB_MACRO))
 #include <$(use.header)>
 #endif
 .    else

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -540,14 +540,18 @@ CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 # Clone and build dependencies
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 .for use where defined (use.tarball)
-.   if defined (use.debian_name)
-if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
+if \
+.   if defined (use.debian_name) 
+.       if !(use.debian_name = '')
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
+.       endif
 .   elsif defined (use.libname)
-if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
 .   else
-if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
 .   endif
-       (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
+       (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
+; then
     BASE_PWD=${PWD}
     wget $(use.tarball)
     tar -xzf \$(basename "$(use.tarball)")

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -42,7 +42,11 @@ Build-Depends: debhelper (>= 9),
     pkg-config,
 .for project.use
 .if defined(use.debian_name)
+.   if !(use.debian_name = '')
     $(use.debian_name),
+.   else
+.       echo "WARNING: debian_name=='' for $(use.project) - not added to packaging/debian/control"
+.   endif
 .elsif regexp.match("^lib", use.libname)
     $(string.replace (use.libname, "_|-"))-dev,
 .else
@@ -74,7 +78,11 @@ Section: libdevel
 Depends:
 .for project.use
 .if defined(use.debian_name)
+.   if !(use.debian_name = '')
     $(use.debian_name),
+.   else
+.       echo "WARNING: debian_name=='' for $(use.project) - not added to packaging/debian/control"
+.   endif
 .elsif regexp.match("^lib", use.libname)
     $(string.replace (use.libname, "_|-"))-dev,
 .else
@@ -96,7 +104,11 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
 .for project.use where use.type ?= "runtime"
 .if defined(use.debian_name)
+.   if !(use.debian_name = '')
     $(use.debian_name),
+.   else
+.       echo "WARNING: debian_name=='' for $(use.project) - not added to packaging/debian/control"
+.   endif
 .elsif regexp.match("^lib", use.libname)
     $(string.replace (use.libname, "_|-")),
 .else
@@ -242,7 +254,11 @@ Build-Depends: debhelper (>= 9),
     pkg-config,
 .for project.use
 .if defined(use.debian_name)
+.   if !(use.debian_name = '')
     $(use.debian_name),
+.   else
+.       echo "WARNING: debian_name=='' for $(use.project) - not added to packaging/debian/control"
+.   endif
 .elsif regexp.match("^lib", use.libname)
     $(string.replace (use.libname, "_|-"))-dev,
 .else

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -41,6 +41,7 @@ function resolve_project_dependency (use)
     my.use.linkname ?= my.use.prefix
     my.use.header ?= my.use.prefix + ".h"
     my.use.libname ?= my.use.project
+    my.use.am_lib_macro ?= my.use.libname
     my.use.optional ?= 0
     my.use.min_major ?= 0
     my.use.min_minor ?= 0

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -75,8 +75,8 @@ BuildRequires:  $(use.project)-devel
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 .if project.has_main | count(project.bin) > 0
 .for project.use where use.type ?= "runtime"
-.if defined(use.debian_name)
-Requires: $(use.debian_name)
+.if defined(use.redhat_name)
+Requires: $(use.redhat_name)
 .elsif regexp.match("^lib", use.libname)
 Requires: $(string.replace (use.libname, "_|-"))
 .else

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -67,7 +67,11 @@ BuildRequires:  gcc-c++
 .endif
 .for project.use
 .if defined(use.redhat_name)
+.   if !(use.redhat_name = '')
 BuildRequires:  $(use.redhat_name)
+.   else
+.       echo "WARNING: redhat_name=='' for $(use.project) - not added to packaging/redhat/$(project.name).spec"
+.   endif
 .else
 BuildRequires:  $(use.project)-devel
 .endif
@@ -76,7 +80,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 .if project.has_main | count(project.bin) > 0
 .for project.use where use.type ?= "runtime"
 .if defined(use.redhat_name)
+.   if !(use.redhat_name = '')
 Requires: $(use.redhat_name)
+.   else
+.       echo "WARNING: redhat_name=='' for $(use.project) - not added to packaging/redhat/$(project.name).spec"
+.   endif
 .elsif regexp.match("^lib", use.libname)
 Requires: $(string.replace (use.libname, "_|-"))
 .else
@@ -117,7 +125,11 @@ Group:          System/Libraries
 Requires:       $(project.libname)$(my.abi_ver) = %{version}
 .for project.use
 .if defined(use.redhat_name)
+.   if !(use.redhat_name = '')
 Requires:       $(use.redhat_name)
+.   else
+.       echo "WARNING: redhat_name=='' for $(use.project) - not added to packaging/redhat/$(project.name).spec"
+.   endif
 .else
 Requires:       $(use.project)-devel
 .endif

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -68,7 +68,11 @@ addons:
     - xmlto
 .      for use
 .         if defined (use.debian_name)
+.             if !(use.debian_name = '')
     - $(use.debian_name)
+.             else
+.                 echo "WARNING: debian_name=='' for $(use.project) - not added to .travis.yml"
+.             endif
 .         elsif defined (use.libname)
     - $(use.libname)-dev
 .         else
@@ -272,14 +276,18 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
 .   for use
 
     # Start of recipe for dependency: $(use.project)
+    if \
 .      if defined (use.debian_name)
-    if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
+.           if !(use.debian_name = '')
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
+.           endif
 .      elsif defined (use.libname)
-    if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
 .      else
-    if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
 .      endif
-           (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
+           (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
+    ; then
         echo ""
 .       if ! defined (use.repository) & ! defined (use.tarball)
         echo "WARNING: Can not build prerequisite '$(use.project)'" >&2


### PR DESCRIPTION
Solution:
* enable fallback testing if pkg-config data not present
* enable opting-out of redhat and debian package install/req/check by providing empty string as the name

Usecase that passes build is:

````
    <!-- Note: the optional flag causes "configure" script to not fail
         if pkg-config metadata (or tests) do not succeed on a distro;
         the project build would fail if no LUA-5.1 library if present.
         This also causes some duplicates in generated code, but these
         "should" be harmless in practice. Also, these packages are not
         generated into the list of "required" for a build in spec/dsc
         files and have to be plugged there manually. -->
    <use project = "lua-5.1-redhat" libname = "lua" prefix="lua"
        optional = "1" am_lib_macro = "LUA_5_1"
        min_major = "5" min_minor = "1" mit_patch = "0"
        debian_name="" redhat_name="lua-devel"
        test = "lua_close"
    />
    <use project = "lua-5.1-debian" libname = "lua5.1" prefix="lua"
        optional = "1" am_lib_macro = "LUA_5_1"
        min_major = "5" min_minor = "1" mit_patch = "0"
        debian_name="liblua5.1-0-dev" redhat_name=""
        test = "lua_close"
    />
````