### PR TITLE
Problem: underscore is not valid debian package name

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -74,9 +74,9 @@ addons:
 .                 echo "WARNING: debian_name=='' for $(use.project) - not added to .travis.yml"
 .             endif
 .         elsif defined (use.libname)
-    - $(use.libname)-dev
+    - $(string.replace (use.libname, "_|-"):lower)-dev
 .         else
-    - $(use.project)-dev
+    - $(string.replace (use.project, "_|-"))-dev
 .         endif
 .      endfor
 


### PR DESCRIPTION
Solution: call string.replace in travis script, like debian do

cc @jimklimov 