### PR TITLE
Problem: can't install additional files via project.xml

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -432,6 +432,28 @@ Using autotools or CMake, you can specify --with-drafts to enable draft APIs, an
 make uninstall
 ```
 
+## Additional files
+Installation of third party files is a *hard* problem. It is not platform
+independent, became hard to maintain and impossible to use correctly. One of
+zproject's goals is a simplicity. There is a simple installation model
+
+### Design goals
+* KISS, less configuration options the better
+* no conditionals in the model, those SHALL be handled in background
+* each option solves a REAL problem, avoid extending it because you can
+
+### Example
+```
+    <main name = "MAIN">
+        <install type = "systemd-tmpfiles" />
+    </main>
+```
+
+This will add install information about systemd tmpfiles.d configuration files
+to autotools, packaging, and so. The resulting file
+/usr/lib/tmpfiles.d/MAIN.conf will be installed only if configure was called
+with --with-systemd-units.
+
 ## Notes for Writing Language Targets
 
 This is the general form of a target:

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -172,6 +172,9 @@ gsl from "zproject_bench.gsl"
 gsl from "zproject_git.gsl"
 gsl from "zproject_valgrind.gsl"
 
+# zinstall must run before all the targets
+gsl from "zproject_install.gsl"
+
 #   Load all targets
 gsl from "zproject_android.gsl"
 gsl from "zproject_autotools.gsl"

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -635,6 +635,8 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
 
 .endif
 
+.zinstall_include ("builds/zinstall/configure.ac")
+
 AC_OUTPUT
 
 # Print configure summary and list make options
@@ -1073,6 +1075,8 @@ coverage: src/$(project.prefix)_selftest
 \t@echo "call make clean && configure --with-gcov to enable code coverage"
 \t@exit 1
 endif
+.zinstall_include ("builds/zinstall/Makemodule.am")
+
 
 $(project.GENERATED_WARNING_HEADER:)
 .#

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -220,6 +220,7 @@ usr/bin/$(bin.name)
 etc/$(project.name)/$(main.name).cfg
 lib/systemd/system/$(main.name){,@*}.{service,*}
 .   endfor
+.zinstall_include ("builds/zinstall/$(project.name).install")
 .endif
 
 .if project.exports_classes

--- a/zproject_install.gsl
+++ b/zproject_install.gsl
@@ -1,0 +1,52 @@
+#   Generate install files snippets for zproject
+#
+#   This is a code generator built using the iMatix GSL code generation
+#   language. See https://github.com/imatix/gsl for details.
+#
+#   Copyright (c) the Contributors as noted in the AUTHORS file.
+#   This file is part of zproject.
+#
+#   This Source Code Form is subject to the terms of the Mozilla Public
+#   License, v. 2.0. If a copy of the MPL was not distributed with this
+#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+function zinstall_include (filename)
+    if file.exists ("$(my.filename:)")
+        input = file.open ("$(my.filename:)")
+        xline = file.read (input)
+        while defined (xline)
+            >$(string.replace (xline, "\n|"))
+            xline = file.read (input)?
+        endwhile
+    endif
+endfunction
+
+echo "###### zinstall #####"
+directory.create ("builds/zinstall")
+for project.main where defined (main->install)
+    for install
+        if install.type = "systemd-tmpfiles"
+
+            output "builds/zinstall/configure.ac"
+>AM_COND_IF([WITH_SYSTEMD_UNITS],
+>    [AC_CONFIG_FILES([
+>                 src/$(main.name).conf
+>    ])],
+>    [])
+            output "builds/zinstall/Makemodule.am"
+>if WITH_SYSTEMD_UNITS
+>$(main.name:c)_tmpfiles_ddir = /usr/lib/tmpfiles.d/
+>$(main.name:c)_tmpfiles_d_DATA = src/$(main.name).conf
+>endif #WITH_SYSTEMD_UNITS
+
+            output "builds/zinstall/$(project.name).spec"
+>%dir /usr/lib/tmpfiles.d/
+>%config /usr/lib/tmpfiles.d/$(main.name).conf
+
+            output "builds/zinstall/$(project.name).install"
+>usr/lib/tmpfiles.d/$(main.name).conf
+
+        endif #systemd-tmpfiles
+    endfor
+endfor

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -214,6 +214,7 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .if etc_exists ?= 1
 %dir %{_sysconfdir}/$(project.name)
 .endif
+.zinstall_include ("builds/zinstall/$(project.name).spec")
 .if systemd ?= 1
 %if 0%{?suse_version} > 1315
 %post


### PR DESCRIPTION
Solution: introduce zinstall, the zero model for file installation

The beauty of this model (as opposite of PR#539) is that it impose clear
protocol between model and rest of the generators. This protocol are
files in builds/zinstall/, which are then included in generated files.

This has two main advantages over older attempts
1. installation model fully implemented in ONE place
2. because of the protocol, there can be more models w/o any impact on
backend

Design goals are stated in README.txt, but let's repease
1. KISS - the less options the better
2. No conditionals - please don't create an another half-baked XML
programming langugage like ant
3. Real problems - don't add more options because you can
... or you will get replaced by zinstall2 ;-)

foundation for closing #810

cc @bluca @sappo @jimklimov @karolhrdina 

extra-cc @hintjens  - sorry, but I was so slooow with solving this :-(