### PR TITLE
Problem: make distcheck does not see it is under .git repo

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -549,7 +549,13 @@ if test "x$cross_compiling" = "xyes"; then
 else
     # enable draft API by default if we're in a git repository
     # else disable it by default; then allow --enable-drafts=yes/no override
-    AC_CHECK_FILE($srcdir/.git, [defaultval=yes], [defaultval=no])
+    AC_CHECK_FILE($srcdir/.git, [defaultval=yes],
+        [AC_MSG_CHECKING([running under a git repository workspace])
+         AS_IF([git rev-parse --show-toplevel 2>/dev/null],
+            [defaultval=yes],
+            [defaultval=no])
+         AC_MSG_RESULT($defaultval)
+        ])
 fi
 
 AC_ARG_ENABLE([drafts],


### PR DESCRIPTION
Solution: beside checking under srcdir/.git, also ask GIT if it can find the workpace up the tree

Follow-up to discussion in #820 : now `make all && make distcheck` is consistent regarding enablement of Draft API by default (without explicit flags) when running somewhere under a git repo.