### PR TITLE
Problem: It is risky to always define CLEANFILES etc. from scratch in Makemodules-local.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,11 @@ noinst_PROGRAMS =
 check_PROGRAMS =
 noinst_LTLIBRARIES =
 TESTS =
+# Prepare variables that can be populated (appended) in generated Makefiles or
+# manually maintained src/Makemodules-local.am
 EXTRA_DIST =
+CLEANFILES =
+DISTCLEANFILES =
 
 if ENABLE_DIST_CMAKEFILES
 EXTRA_DIST += \

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -797,7 +797,11 @@ noinst_PROGRAMS =
 check_PROGRAMS =
 noinst_LTLIBRARIES =
 TESTS =
+# Prepare variables that can be populated (appended) in generated Makefiles or
+# manually maintained src/Makemodules-local.am
 EXTRA_DIST =
+CLEANFILES =
+DISTCLEANFILES =
 
 if ENABLE_DIST_CMAKEFILES
 EXTRA_DIST += \\


### PR DESCRIPTION
Solution: Define the cleanup variables in main generated makefile, so the manual one can always just append (and not risk overwriting something a later version of zproject might put there)