### PR TITLE
Problem: cfg.example magically added to debian/rh recipes

### DIFF
--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -208,9 +208,6 @@ usr/bin/$(main.name)
 usr/share/man/man1/$(main.name).1
 .          endif
 .       endif
-.       if file.exists ("src/$(main.name).cfg.example")
-etc/$(project.name)/$(main.name).cfg.example
-.       endif
 .   endfor
 .   for project.bin
 usr/bin/$(bin.name)

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -197,10 +197,6 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .   if man1 ?<> ""
 %{_mandir}/man1/$(main.name)*
 .   endif
-.if file.exists ("src/$(main.name).cfg.example")
-%{_sysconfdir}/$(project.name)/$(main.name).cfg.example
-.etc_exists = 1
-.endif
 .endfor
 .for project.bin
 %{_bindir}/$(bin.name)


### PR DESCRIPTION
Solution: drop that magic