### PR TITLE
do not use specific locations for executables

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -231,9 +231,6 @@ add_library($(project.linkname) ${$(project.linkname)_sources})
 set_target_properties($(project.linkname)
     PROPERTIES DEFINE_SYMBOL "$(PROJECT.PREFIX)_EXPORTS"
 )
-set_target_properties($(project.linkname)
-    PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
-)
 set_target_properties ($(project.linkname)
 .if defined (project->abi)
     PROPERTIES SOVERSION "$(project->abi.current - project->abi.age).$(project->abi.age).$(project->abi.revision)"
@@ -555,7 +552,7 @@ CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 .for use where defined (use.tarball)
 if \
-.   if defined (use.debian_name) 
+.   if defined (use.debian_name)
 .       if !(use.debian_name = '')
 \! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
 .       endif


### PR DESCRIPTION
for windows build, the .exe should not be separated from executables. this makes interactive debugging in visual studio easy, and allows to fix the execution of unit test on appveyor, see https://github.com/zeromq/czmq/pull/1601/

I do not know if this change should be msvc only or could be applied for all platforms

(BTW is cmake used only on windows ?)