### PR TITLE
problem : on windows, unit tests do not exit gracefully because of dl…

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -338,6 +338,9 @@ stable\
     else
         test_runall (verbose);
 
+#ifdef __WINDOWS__
+    zsys_shutdown();
+#endif
     return 0;
 }
 /*
@@ -552,7 +555,7 @@ $(VISIBILITY) $(c_method_signature (method):)\
 for class
     skeleton_class_header ()
     skeleton_class_source ()
-    
+
     if !defined (class.api)
         resolve_c_class (class)
     endif


### PR DESCRIPTION
problem : on windows, unit tests do not exit gracefully because of dll behaviour (atexit not called)
    
solution : explicitly call zsys_shutdown() before exit in selftest executables