### PR TITLE
Problem: only one pkg-config metadata name is inspected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,21 @@ else
     AM_CONDITIONAL(WITH_GCOV, false)
 fi
 
+# Set pkgconfigdir
+AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
+    [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),
+    [pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
+AC_SUBST([pkgconfigdir])
+
+# Use the provided pkgconfigdir not only to write our pkg-config data,
+# but also as an additional location to look for other packages metadata.
+AS_IF([test -n "${pkgconfigdir}" -a -d "${pkgconfigdir}"],
+    [AS_IF([test -z "${PKG_CONFIG_PATH}"],
+        [PKG_CONFIG_PATH="${pkgconfigdir}"],
+        [PKG_CONFIG_PATH="${pkgconfigdir}:${PKG_CONFIG_PATH}"])
+     export PKG_CONFIG_PATH
+    ])
+
 # Will be used to add flags to pkg-config useful when apps want to statically link
 PKGCFG_LIBS_PRIVATE=""
 
@@ -275,12 +290,6 @@ AM_CONDITIONAL(ENABLE_DIST_CMAKEFILES, test "x$enable_dist_cmakefiles" = "xyes")
 # Checks for library functions.
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday memset getifaddrs)
-
-# Set pkgconfigdir
-AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
-    [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),
-    [pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
-AC_SUBST([pkgconfigdir])
 
 
 # enable specific system integration features

--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ fi
 # Will be used to add flags to pkg-config useful when apps want to statically link
 PKGCFG_LIBS_PRIVATE=""
 
+# Archive user supplied flags
 PREVIOUS_CFLAGS="${CFLAGS}"
 PREVIOUS_LIBS="${LIBS}"
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -203,6 +203,10 @@ AS_IF([test x"${search_$(use.libname:c)}" = xno],
 .  endif
 
 AS_IF([test x"${search_$(use.libname:c)}" = xyes], [
+    # Archive previously detected and supplied flags
+    PRE_SEARCH_CFLAGS="${CFLAGS}"
+    PRE_SEARCH_LIBS="${LIBS}"
+
     PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
 .  if defined(use.max_version)
  $(use.libname) <= $(use.max_version)\
@@ -252,6 +256,11 @@ Header file $(use.header) was not found in default search paths])
                 )
         fi
 
+.# TODO: I doubt this really finds libraries in non-default paths (including
+.# our --with-... argument above); verify and perhaps set temporary LIBS and
+.# CFLAGS values with added tested location for header and library files
+.# using the PRE_SEARCH_LIBS and PRE_SEARCH_CFLAGS defined above just for
+.# such sort of use-cases.
         AC_CHECK_LIB([$(use.prefix)], [$(use.test:)],
             [
                 was_$(use.project:c)_check_lib_detected=yes

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -152,6 +152,8 @@ PREVIOUS_CFLAGS="${CFLAGS}"
 PREVIOUS_LIBS="${LIBS}"
 
 .for use
+.# Far below, if the dependency search was not for a library, it will be done
+.# for a program.
 . if use.libname ?<> ""
 
 was_$(use.project:c)_check_lib_detected=no
@@ -287,6 +289,8 @@ if test "x$was_$(use.project:c)_check_lib_detected" = "xno"; then
     LIBS="${$(use.project:c)_LIBS} ${LIBS}"
 fi
 . else
+.# TODO: Extend with support for 'optional'
+.# TODO: Extend with support for '--with-...=path/to/prog' and '--without-...'
 AC_CHECK_PROG(HAVE_$(USE.PROJECT:C), $(use.project:c), yes)
 if test x"$HAVE_$(USE.PROJECT:C)" != x"yes" ; then
     AC_MSG_ERROR([Cannot find $(use.project)])

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -156,6 +156,37 @@ PREVIOUS_LIBS="${LIBS}"
 
 was_$(use.project:c)_check_lib_detected=no
 
+.  if optional
+search_$(use.libname:c)="no"
+.  else
+search_$(use.libname:c)="yes"
+.  endif
+
+.# TOTHINK: Should this still be libname or ...
+.# (loop over variants of libname, projname, linkname, pkgconfig?..)
+AC_ARG_WITH([$(use.libname)],
+    [
+        AS_HELP_STRING([--with-$(use.libname)],
+.# TODO: Should an explicit path win over pkgconfig?
+        [yes or no. Optionally specify $(use.libname) prefix (directory where its include/ and lib/ are located), but that is only used if pkgconfig metadata is not found first])
+    ],
+    [
+        search_$(use.libname:c)="yes"
+    ],
+    [])
+AS_CASE([x"${with_$(use.libname:c)}"],
+    [xyes], [search_$(use.libname:c)="yes"],
+    [xno],  [search_$(use.libname:c)="no"])
+
+.  if !optional
+dnl We do not abort right now, because the maintainer/developer may have
+dnl something particular in mind, e.g. to build just parts of a project.
+AS_IF([test x"${search_$(use.libname:c)}" = xno],
+    [AC_MSG_WARN([Required dependency on $(use.project:c) was explicitly disabled during configuration by '--with-$(use.libname)=no'; subsequent full build of $(project.name) may fail])])
+.  endif
+
+AS_IF([test x"${search_$(use.libname:c)}" = xyes], [
+. if use.pkgconfig ?<> ""
 PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
 .  if defined(use.max_version)
  $(use.libname) <= $(use.max_version)\
@@ -177,21 +208,14 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
  with needed constraints\
 .       endif
 ; falling back to defined compilability tests])
-        AC_ARG_WITH([$(use.libname)],
-            [
-                AS_HELP_STRING([--with-$(use.libname)],
-                [Specify $(use.libname) prefix])
-            ],
-            [search_$(use.libname)="yes"],
-            [])
 
         $(use.project:c)_synthetic_cflags=""
         $(use.project:c)_synthetic_libs="-l$(use.linkname)"
 
-        if test "x$search_$(use.libname)" = "xyes"; then
-            if test -r "${with_$(use.libname)}/include/$(use.header)"; then
-                $(use.project:c)_synthetic_cflags="-I${with_$(use.libname)}/include"
-                $(use.project:c)_synthetic_libs="-L${with_$(use.libname)}/lib -l$(use.linkname)"
+        if test -n "${with_$(use.libname:c)}" && test x"${with_$(use.libname:c)}" != xyes && test x"${with_$(use.libname:c)}" != xno; then
+            if test -r "${with_$(use.libname:c)}/include/$(use.header)"; then
+                $(use.project:c)_synthetic_cflags="-I${with_$(use.libname:c)}/include"
+                $(use.project:c)_synthetic_libs="-L${with_$(use.libname:c)}/lib -l$(use.linkname)"
             else
                 AC_MSG_ERROR([${with_$(use.libname)}/include/$(use.header) not found. Please check $(use.libname) prefix])
             fi
@@ -240,6 +264,9 @@ Cannot find $(use.libname)\
 , and no compilability tests were defined either])
 .   endif
     ])
+.endif
+])
+dnl END of enabled attempts to search for $(use.libname:c)
 
 if test "x$was_$(use.project:c)_check_lib_detected" = "xno"; then
     CFLAGS="${$(use.project:c)_CFLAGS} ${CFLAGS}"

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -169,7 +169,13 @@ PREVIOUS_LIBS="${LIBS}"
 .for use
 .# Far below, if the dependency search was not for a library, it will be done
 .# for a program.
-. if use.libname ?<> ""
+.# Debugging for using either a list of variants or a single name per legacy
+.# (or simpler use-case) setup. Note that despite the same apparent name for
+.# addressing, the variable and list contexts are different and separate.
+.# Far below, if the dependency search was not for a library, it will be done
+.# for a program.
+.###echo "PROJECT: $(use.project) : '$(use.libname)' '$(use.pkgconfig)' '$(count(use.pkgconfig))' '$(count(use.linkname))'"
+. if use.libname ?<> "" | use.pkgconfig ?<> "" | count(use.pkgconfig) > 0 | count(use.linkname) > 0
 
 was_$(use.project:c)_check_lib_detected=no
 
@@ -207,29 +213,91 @@ AS_IF([test x"${search_$(use.libname:c)}" = xyes], [
     PRE_SEARCH_CFLAGS="${CFLAGS}"
     PRE_SEARCH_LIBS="${LIBS}"
 
-    PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
+    found_pkgconfig=""
+    found_linkname=""
+. if use.pkgconfig ?<> ""
+    PKG_CHECK_MODULES([$(use.project:c)], [$(use.pkgconfig) >= $(use.min_version)\
 .  if defined(use.max_version)
- $(use.libname) <= $(use.max_version)\
+ $(use.pkgconfig) <= $(use.max_version)\
 .  endif
 .  if defined(use.next_incompatible_version)
- $(use.libname) < $(use.next_incompatible_version)\
+ $(use.pkgconfig) < $(use.next_incompatible_version)\
 .  endif
 ],
     [
 .  if optional
-        AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The optional $(use.libname) library is to be used])
+        AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The optional\
+.# At least one of these values is available, per check above
+.   if use.pkgconfig ?<> "" & use.pkgconfig ?<> use.libname
+ $(use.pkgconfig) pkg-config metadata\
+.   endif
+.   if use.libname ?<> ""
+ $(use.libname) library\
+.   endif
+ is to be used])
 .  endif
         PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
         was_$(use.project:c)_check_lib_detected=pkgcfg
+        found_pkgconfig="$(use.pkgconfig)"
     ],
     [
-.  if defined(use.test)
-        AC_MSG_NOTICE([Package $(use.libname) not found\
+. endif
+.# The alternate variants can be fallbacks to main pkgconfig (if defined)
+.# or standalone (if only the list is provided)
+. if count(use.pkgconfig) > 0
+.   for use.pkgconfig as pkgconfig_variant
+        AC_MSG_NOTICE([Retry by looking at another variant of pkg-config metadata: $(pkgconfig_variant)])
+        PKG_CHECK_MODULES([$(use.project:c)], [$(pkgconfig_variant) >= $(use.min_version)\
+.     if defined(use.max_version)
+ $(pkgconfig_variant) <= $(use.max_version)\
+.     endif
+.     if defined(use.next_incompatible_version)
+ $(pkgconfig_variant) < $(use.next_incompatible_version)\
+.     endif
+],
+            [
+.     if optional
+                AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The\
+.# At least one of these values is available, per check above
+.       if use.pkgconfig ?<> "" & use.pkgconfig ?<> use.libname
+ $(pkgconfig_variant) pkg-config metadata\
+.       endif
+.       if use.libname ?<> ""
+ $(use.libname) library\
+.       endif
+ is to be used])
+.     endif
+                PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
+                was_$(use.project:c)_check_lib_detected=pkgcfg
+                found_pkgconfig="$(pkgconfig_variant)"
+            ],
+            [
+.   endfor
+. endif
+.# Code below is either fallback for failed pkgconfig search(es)
+.# (if string and/or list was not empty) or a standalone linkability test
+.  if defined(use.test) & use.libname ?<> "" & ( use.linkname ?<> "" | count(use.linkname) > 0 )
+.   if use.pkgconfig ?<> "" | count(use.pkgconfig) > 0
+        AC_MSG_NOTICE([Package\
+.     if ( use.pkgconfig ?<> "" & count(use.pkgconfig) > 0 ) | count(use.pkgconfig) > 1
+s\
+.     endif
+.     if use.pkgconfig ?<> ""
+ $(use.pkgconfig)\
+.     endif
+.     if count(use.pkgconfig) > 0
+.       for use.pkgconfig as pkgconfig_variant
+ $(pkgconfig_variant)\
+.       endfor
+.     endif
+ not found\
 .       if !(use.min_version = '0.0.0') | defined(use.max_version) |defined(use.next_incompatible_version)
  with needed constraints\
 .       endif
 ; falling back to defined compilability tests])
+.   endif
 
+.# TODO: loop for alternate linknames - all zproject infrastructure is here
         $(use.project:c)_synthetic_cflags=""
         $(use.project:c)_synthetic_libs="-l$(use.linkname)"
 
@@ -265,25 +333,38 @@ Header file $(use.header) was not found in default search paths])
             [
                 was_$(use.project:c)_check_lib_detected=yes
                 PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -l$(use.linkname)"
+                found_linkname="$(use.linkname)"
 .       if optional
-                AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The optional $(use.libname) library is to be used])
+                AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The optional $(use.libname) library is to be used (as -l$(use.linkname))])
             ],
             [])
 .       else
             ],
             [AC_MSG_ERROR([cannot link with -l$(use.linkname), install $(use.libname)])])
 .       endif
-.   else
+.  else
         AC_MSG_WARN([Attribute 'test' is not set on zproject dependency '$(use.project)' - please ensure it is set])
-.   endif
+.  endif
+.# if count of list of alternates is nonzero, close those fallback clauses too
+.if count(use.pkgconfig) > 0
+.  for use.pkgconfig
+        ])
+.  endfor
+.endif
+.if use.pkgconfig ?<> ""
+.# if string was empty, code above was a standalone linkability test
     ])
+.endif
+
 dnl END of PKG_CHECK_MODULES and/or direct tests for $(use.libname:c)
     AS_CASE(["x${was_$(use.project:c)_check_lib_detected}"],
         [xpkgcfg], [
+                AC_SUBST([pkgconfig_name_$(use.libname:c)],[${found_pkgconfig}])
                 CFLAGS="${$(use.project:c)_CFLAGS} ${CFLAGS}"
                 LIBS="${$(use.project:c)_LIBS} ${LIBS}"
             ],
         [xyes], [
+                AC_SUBST([pkgconfig_name_$(use.libname:c)],[${found_linkname}])
                 CFLAGS="${$(use.project:c)_synthetic_cflags} ${CFLAGS}"
                 LDFLAGS="${$(use.project:c)_synthetic_libs} ${LDFLAGS}"
                 LIBS="${$(use.project:c)_synthetic_libs} ${LIBS}"
@@ -292,23 +373,33 @@ dnl END of PKG_CHECK_MODULES and/or direct tests for $(use.libname:c)
                 AC_SUBST([$(use.project:c)_LIBS],[${$(use.project:c)_synthetic_libs}])
             ],
         [xno], [
+                AC_SUBST([pkgconfig_name_$(use.libname:c)],[$(use.libname)])
+.# No data defined to use a linkability test, or test failed
 .   if optional
             AC_MSG_WARN([\
 .   else
             AC_MSG_ERROR([\
 .   endif
-Cannot find $(use.libname)\
-.   if defined(use.max_version) | defined(use.next_incompatible_version)
+Cannot find\
+.       if use.pkgconfig ?<> "" | count(use.pkgconfig) > 0
+ pkg-config metadata for $(use.libname)\
+.        if defined(use.max_version) | defined(use.next_incompatible_version)
  >= $(use.min_version)\
-.       if defined(use.max_version)
+.           if defined(use.max_version)
  and <= $(use.max_version)\
-.       endif
-.       if defined(use.next_incompatible_version)
+.           endif
+.           if defined(use.next_incompatible_version)
  and < $(use.next_incompatible_version)\
-.       endif
-.   else
+.           endif
+.       else
  $(use.min_version) or higher\
-.   endif
+.        endif
+.       endif
+.# NOTE: No excessive looping tests for list of names below...
+.# it is possible, but not worth the effort for cosmetics...
+.       if use.libname ?<> "" & use.pkgconfig ?<> use.libname
+ library $(use.libname)\
+.       endif
 .       if !(defined(use.test) | use.libname ?<> "")
 , and no compilability tests were defined either\
 .       endif
@@ -1211,7 +1302,7 @@ Version: @VERSION@
 .if count (use)
 Requires:\
 .   for use where use.optional = 0
-$(use.libname)\
+@pkgconfig_name_$(use.libname:c)@\
 .       if (use.min_version <> '0.0.0')
  >= $(use.min_version)\
 .       endif

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -144,6 +144,21 @@ else
     AM_CONDITIONAL(WITH_GCOV, false)
 fi
 
+# Set pkgconfigdir
+AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
+    [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),
+    [pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
+AC_SUBST([pkgconfigdir])
+
+# Use the provided pkgconfigdir not only to write our pkg-config data,
+# but also as an additional location to look for other packages metadata.
+AS_IF([test -n "${pkgconfigdir}" -a -d "${pkgconfigdir}"],
+    [AS_IF([test -z "${PKG_CONFIG_PATH}"],
+        [PKG_CONFIG_PATH="${pkgconfigdir}"],
+        [PKG_CONFIG_PATH="${pkgconfigdir}:${PKG_CONFIG_PATH}"])
+     export PKG_CONFIG_PATH
+    ])
+
 # Will be used to add flags to pkg-config useful when apps want to statically link
 PKGCFG_LIBS_PRIVATE=""
 
@@ -519,12 +534,6 @@ AM_COND_IF([ENABLE_$(NAME:c)], [AC_MSG_NOTICE([ENABLE_$(NAME:c) defined])])
 # Checks for library functions.
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday memset getifaddrs)
-
-# Set pkgconfigdir
-AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
-    [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),
-    [pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
-AC_SUBST([pkgconfigdir])
 
 .if file.exists ("src/$(project.libname).sym")
 # Symbol versioning support: snatched and adapted from libpng:

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -188,8 +188,7 @@ AS_IF([test x"${search_$(use.libname:c)}" = xno],
 .  endif
 
 AS_IF([test x"${search_$(use.libname:c)}" = xyes], [
-. if use.pkgconfig ?<> ""
-PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
+    PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
 .  if defined(use.max_version)
  $(use.libname) <= $(use.max_version)\
 .  endif
@@ -199,9 +198,10 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
 ],
     [
 .  if optional
-        AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The $(use.libname) library is to be used])
+        AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The optional $(use.libname) library is to be used])
 .  endif
         PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $$(use.project:c)_LIBS"
+        was_$(use.project:c)_check_lib_detected=pkgcfg
     ],
     [
 .  if defined(use.test)
@@ -236,23 +236,13 @@ Header file ${with_$(use.libname)}/include/$(use.header) was not found. Please c
 Header file $(use.header) was not found in default search paths])
                 )
         fi
-.       if !defined(use.test)
-.           abort "test is not set on project " + use.project + " please ensure it is set"
-.       endif
-
 
         AC_CHECK_LIB([$(use.prefix)], [$(use.test:)],
             [
-                CFLAGS="${$(use.project:c)_synthetic_cflags} ${CFLAGS}"
-                LDFLAGS="${$(use.project:c)_synthetic_libs} ${LDFLAGS}"
-                LIBS="${$(use.project:c)_synthetic_libs} ${LIBS}"
-
-                AC_SUBST([$(use.project:c)_CFLAGS],[${$(use.project:c)_synthetic_cflags}])
-                AC_SUBST([$(use.project:c)_LIBS],[${$(use.project:c)_synthetic_libs}])
                 was_$(use.project:c)_check_lib_detected=yes
                 PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -l$(use.linkname)"
 .       if optional
-                AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The $(use.libname) library is to be used])
+                AC_DEFINE(HAVE_$(USE.AM_LIB_MACRO), 1, [The optional $(use.libname) library is to be used])
             ],
             [])
 .       else
@@ -260,34 +250,49 @@ Header file $(use.header) was not found in default search paths])
             [AC_MSG_ERROR([cannot link with -l$(use.linkname), install $(use.libname)])])
 .       endif
 .   else
-.       if optional
-        AC_MSG_WARN([\
-.       else
-        AC_MSG_ERROR([\
-.       endif
-Cannot find $(use.libname)\
-.       if defined(use.max_version) | defined(use.next_incompatible_version)
- >= $(use.min_version)\
-.           if defined(use.max_version)
- and <= $(use.max_version)\
-.           endif
-.           if defined(use.next_incompatible_version)
- and < $(use.next_incompatible_version)\
-.           endif
-.       else
- $(use.min_version) or higher\
-.       endif
-, and no compilability tests were defined either])
+        AC_MSG_WARN([Attribute 'test' is not set on zproject dependency '$(use.project)' - please ensure it is set])
 .   endif
     ])
-.endif
+dnl END of PKG_CHECK_MODULES and/or direct tests for $(use.libname:c)
+    AS_CASE(["x${was_$(use.project:c)_check_lib_detected}"],
+        [xpkgcfg], [
+                CFLAGS="${$(use.project:c)_CFLAGS} ${CFLAGS}"
+                LIBS="${$(use.project:c)_LIBS} ${LIBS}"
+            ],
+        [xyes], [
+                CFLAGS="${$(use.project:c)_synthetic_cflags} ${CFLAGS}"
+                LDFLAGS="${$(use.project:c)_synthetic_libs} ${LDFLAGS}"
+                LIBS="${$(use.project:c)_synthetic_libs} ${LIBS}"
+
+                AC_SUBST([$(use.project:c)_CFLAGS],[${$(use.project:c)_synthetic_cflags}])
+                AC_SUBST([$(use.project:c)_LIBS],[${$(use.project:c)_synthetic_libs}])
+            ],
+        [xno], [
+.   if optional
+            AC_MSG_WARN([\
+.   else
+            AC_MSG_ERROR([\
+.   endif
+Cannot find $(use.libname)\
+.   if defined(use.max_version) | defined(use.next_incompatible_version)
+ >= $(use.min_version)\
+.       if defined(use.max_version)
+ and <= $(use.max_version)\
+.       endif
+.       if defined(use.next_incompatible_version)
+ and < $(use.next_incompatible_version)\
+.       endif
+.   else
+ $(use.min_version) or higher\
+.   endif
+.       if !(defined(use.test) | use.libname ?<> "")
+, and no compilability tests were defined either\
+.       endif
+])
+    ])
 ])
 dnl END of enabled attempts to search for $(use.libname:c)
 
-if test "x$was_$(use.project:c)_check_lib_detected" = "xno"; then
-    CFLAGS="${$(use.project:c)_CFLAGS} ${CFLAGS}"
-    LIBS="${$(use.project:c)_LIBS} ${LIBS}"
-fi
 . else
 .# TODO: Extend with support for 'optional'
 .# TODO: Extend with support for '--with-...=path/to/prog' and '--without-...'

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -217,8 +217,22 @@ PKG_CHECK_MODULES([$(use.project:c)], [$(use.libname) >= $(use.min_version)\
                 $(use.project:c)_synthetic_cflags="-I${with_$(use.libname:c)}/include"
                 $(use.project:c)_synthetic_libs="-L${with_$(use.libname:c)}/lib -l$(use.linkname)"
             else
-                AC_MSG_ERROR([${with_$(use.libname)}/include/$(use.header) not found. Please check $(use.libname) prefix])
+.   if optional
+            AC_MSG_WARN([\
+.   else
+            AC_MSG_ERROR([\
+.   endif
+Header file ${with_$(use.libname)}/include/$(use.header) was not found. Please check $(use.libname) prefix])
             fi
+        else
+            AC_CHECK_HEADER([$(use.header)], [],
+.   if optional
+            AC_MSG_WARN([\
+.   else
+            AC_MSG_ERROR([\
+.   endif
+Header file $(use.header) was not found in default search paths])
+                )
         fi
 .       if !defined(use.test)
 .           abort "test is not set on project " + use.project + " please ensure it is set"

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -147,7 +147,7 @@ fi
 # Will be used to add flags to pkg-config useful when apps want to statically link
 PKGCFG_LIBS_PRIVATE=""
 
-.# Archive user supplied flags
+# Archive user supplied flags
 PREVIOUS_CFLAGS="${CFLAGS}"
 PREVIOUS_LIBS="${LIBS}"
 

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -163,4 +163,25 @@
         <use project = "malamute"/>
     </use>
 
+    <!-- OS packagers make life hard by renaming the package, binaries and
+         even library SONAMEs - so we have to guess a bit; note that for
+         practical purposes, lua-5.2 suffices as lua-5.1 (if fixes happen
+         to be needed, they are trivial and googlable) -->
+    <use project = "lua-5.1" libname = "lua" prefix="lua"
+        optional = "0" am_lib_macro = "LUA_5_1"
+        min_major = "5" min_minor = "1" min_patch = "0"
+        debian_name="liblua5.1-0-dev" redhat_name="lua-devel"
+        test = "lua_close">
+            <linkname>lua5.2</linkname>
+            <linkname>lua52</linkname>
+            <linkname>lua5.1</linkname>
+            <linkname>lua51</linkname>
+            <linkname>lua</linkname>
+            <pkgconfig>lua5.2</pkgconfig>
+            <pkgconfig>lua52</pkgconfig>
+            <pkgconfig>lua5.1</pkgconfig>
+            <pkgconfig>lua51</pkgconfig>
+            <pkgconfig>lua</pkgconfig>
+    </use>
+
 </known_projects>

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -29,10 +29,39 @@ function resolve_project_dependency (use)
         my.use.redhat_name ?= known.spec_name?
         my.use.redhat_name ?= known.redhat_name?
 
+        my.use.min_major   ?= known.min_major?
+        my.use.min_minor   ?= known.min_minor?
+        my.use.min_patch   ?= known.min_patch?
+        my.use.min_version ?= known.min_version?
+
+        my.use.max_major   ?= known.max_major?
+        my.use.max_minor   ?= known.max_minor?
+        my.use.max_patch   ?= known.max_patch?
+        my.use.max_version ?= known.max_version?
+
+        my.use.next_incompatible_major   ?= known.next_incompatible_major?
+        my.use.next_incompatible_minor   ?= known.next_incompatible_minor?
+        my.use.next_incompatible_patch   ?= known.next_incompatible_patch?
+        my.use.next_incompatible_version ?= known.next_incompatible_version?
+
         # Copy known implied dependencies into this dependency
         for known.use as implied_use
             if !count (my.use.use, use.project = implied_use.project)
                 move implied_use to my.use as use
+            endif
+        endfor
+
+        # Copy known alternate pkg-config metadata and library link-names
+        # to help search for the dependencies
+        for known.pkgconfig as implied_pkgconfig
+            if !count (my.use.pkgconfig, pkgconfig = implied_pkgconfig)
+                move implied_pkgconfig to my.use as pkgconfig
+            endif
+        endfor
+
+        for known.linkname as implied_linkname
+            if !count (my.use.linkname, linkname = implied_linkname)
+                move implied_linkname to my.use as linkname
             endif
         endfor
     endfor

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -21,6 +21,7 @@ function resolve_project_dependency (use)
         my.use.prefix      ?= known.prefix?
         my.use.linkname    ?= known.linkname?
         my.use.libname     ?= known.libname?
+        my.use.pkgconfig   ?= known.pkgconfig?
         my.use.release     ?= known.release?
         my.use.debian_name ?= known.debian_name?
         # The spec_name is only transitional - I assume it wasn't widely used
@@ -41,6 +42,7 @@ function resolve_project_dependency (use)
     my.use.linkname ?= my.use.prefix
     my.use.header ?= my.use.prefix + ".h"
     my.use.libname ?= my.use.project
+    my.use.pkgconfig ?= my.use.libname
     my.use.am_lib_macro ?= my.use.libname
     my.use.optional ?= 0
     my.use.min_major ?= 0

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -64,7 +64,9 @@ function resolve_project_dependency (use)
 
     # Calculate all non-model values from model values (defaults
     # to "0.0.0" if not set in project.xml:
-    my.use.min_version = "$(min_major).$(min_minor).$(min_patch)"
+    if !defined(my.use.min_version)
+        my.use.min_version = "$(min_major).$(min_minor).$(min_patch)"
+    endif
 
     # Note: Logic below would produce a bump in only one field, if one is
     # passed, e.g. when min == "3.0.2" and next_incompatible_major == "4"


### PR DESCRIPTION
Solution: start from revised code of PR #838 and add support for alternate `pkgconfig` names (which is what we actually use in the configure script queries, rather than abstract `libname`) so that different spellings of the metadata can be checked with one `<use>` statement.

Based on this, add support for easily including LUA 5.1/5.2 as a single known project (and hopefully working on all relevant platforms despite their naming differences):
````
<use project = "lua-5.1" />
````

Note: This PR currently only completes the search for several pkgconfig metadata names. Supporting code is similar (and was added) for compilation tests so they could try different `-l${linkname}` values as well, but that loop was not finished and committed yet.

Attn: @vyskocilm @karolhrdina