### PR TITLE
Problem: types defined by extra include files can't be used in class definitions

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -419,11 +419,11 @@ $(project.GENERATED_WARNING_HEADER:)
 #include "../include/$(project.header:)"
 
 //  Internal API
-.for class where scope = "private"
-#include "$(class.c_name).h"
-.endfor
 .for header where scope = "private"
 #include "$(header.name).h"
+.endfor
+.for class where scope = "private"
+#include "$(class.c_name).h"
 .endfor
 
 //  *** To avoid double-definitions, only define if building without draft ***


### PR DESCRIPTION
Solutions: Reverse order of including files - extra first, class definitions - next.