### PR TITLE
Problem: class type definitions can't be used by other classes

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -418,10 +418,17 @@ $(project.GENERATED_WARNING_HEADER:)
 //  External API
 #include "../include/$(project.header:)"
 
-//  Internal API
+//  Extra headers
 .for header where scope = "private"
 #include "$(header.name).h"
 .endfor
+
+//  Opaque class structures to allow forward references
+.for class where scope = "private"
+typedef struct _$(class.c_name)_t $(class.c_name)_t;
+.endfor
+
+//  Internal API
 .for class where scope = "private"
 #include "$(class.c_name).h"
 .endfor

--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -343,10 +343,6 @@ extern "C" {
 #include "$(class.c_name)_library.h"
 
 .   endif
-.   if class.scope = "private"
-typedef struct _$(class.c_name)_t $(class.c_name)_t;
-
-.   endif
 //  @interface
 .   if class.scope = "private"
 .      visibility = "$(PROJECT.PREFIX)_PRIVATE"


### PR DESCRIPTION
Solution: move forward class type defintions from class include file to _classes.h file.