### PR TITLE
problem : self tests must be run with assert macro enabled, but on some

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -331,6 +331,12 @@ stable\
             return 1;
         }
     }
+
+    #ifdef NDEBUG
+        printf(" !!! 'assert' macro is disabled, remove NDEBUG from your compilation definitions.\n");
+        printf(" tests will be meaningless.\n");
+    #endif //
+
     if (test) {
         printf ("Running $(project.name) test '%s'...\\n", test->testname);
         test->test (verbose);
@@ -559,7 +565,7 @@ $(VISIBILITY) $(c_method_signature (method):)\
 for class
     skeleton_class_header ()
     skeleton_class_source ()
-    
+
     if !defined (class.api)
         resolve_c_class (class)
     endif


### PR DESCRIPTION
platforms the macro is disabled by default (windows/release for example)

solution: warn the user, when the assert macro is disabled, that the tests
will be meaningless