### PR TITLE
Problem: CMake Windows test runs are broken

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -296,10 +296,6 @@ target_link_libraries(
 .endfor
     ${OPTIONAL_LIBRARIES}
 )
-set_target_properties(
-    $(main.name)
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
-)
 .   if main.scope = "public"
 install(TARGETS $(main.name)
     RUNTIME DESTINATION bin


### PR DESCRIPTION
Solution: do not use specific locations for executables.
Cherry-picked from https://github.com/zeromq/czmq/pull/1601