### PR TITLE
Problem: double definitions when using zproto

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -431,7 +431,10 @@ $(project.GENERATED_WARNING_HEADER:)
 
 //  Opaque class structures to allow forward references
 .for class where scope = "private"
+#ifndef $(CLASS.C_NAME)_T_DEFINED
 typedef struct _$(class.c_name)_t $(class.c_name)_t;
+#define $(CLASS.C_NAME)_T_DEFINED
+#endif
 .endfor
 
 //  Internal API


### PR DESCRIPTION
Solution: use ifdef guards around forward declarations in the common
header for private classes typedefs like zproto does, to avoid build
errors