### PR TITLE
Do not use globs for systemd unit files

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ zproject's `project.xml` contains an extensive description of the available conf
     <main name = "progname">Exported public tool</main>
     <main name = "progname" private = "1">Internal tool</main>
     <main name = "progname" service = "1">Installed as system service</main>
+    <main name = "progname" service = "2">Installed as system service, multi-instance (@)</main>
+    <main name = "progname" service = "3">Installed as system service, both single and multi-instance (@)</main>
     -->
 
     <!--

--- a/project.xml
+++ b/project.xml
@@ -116,7 +116,9 @@
                  use private = "1" for internal tools
     <main name = "progname">Exported public tool</main>
     <main name = "progname" private = "1">Internal tool</main>
-    <main name = "progname" service = "1">Installed as system service</main>
+    <main name = "progname" service = "1">Installed as system service, single-instance</main>
+    <main name = "progname" service = "2">Installed as system service, multi-instance (@)</main>
+    <main name = "progname" service = "3">Installed as system service, both single and multi-instance (@)</main>
     -->
 
     <!--

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -668,7 +668,7 @@ AS_IF([test "$have_ld_version_script" = "yes"],
 .endif
 
 # enable specific system integration features
-.for project.main where main.service ?= 1
+.for project.main where ( defined(main.service) & main.service > 0 )
 .   systemd = 1
 .endfor
 .if systemd ?= 1
@@ -777,13 +777,13 @@ AC_CONFIG_FILES([Makefile
                  src/$(extra.name)
 .       endfor
 .   endfor
-.   for project.main where main.service ?= 1
+.   for project.main where ( defined(main.service) & main.service > 0 )
                  src/$(main.name).cfg
 .   endfor
                  ])
 .else
 AC_CONFIG_FILES([Makefile
-.   for project.main where main.service ?= 1
+.   for project.main where ( defined(main.service) & main.service > 0 )
                  src/$(main.name).cfg
 .   endfor
                 ])
@@ -792,8 +792,13 @@ AC_CONFIG_FILES([Makefile
 .if systemd ?= 1
 AM_COND_IF([WITH_SYSTEMD_UNITS],
     [AC_CONFIG_FILES([
-.   for project.main where main.service ?= 1
+.   for project.main where ( defined(main.service) & main.service > 0 )
+.       if ( main.service ?= 1 | main.service ?= 3 )
                  src/$(main.name).service
+.       endif
+.       if ( main.service ?= 2 | main.service ?= 3 )
+                 src/$(main.name)@.service
+.       endif
 .   endfor
     ])],
     [])
@@ -896,14 +901,19 @@ $(extra.name)
 .endif
 
 # + config files for mains (if any):
-.for project.main where main.service ?= 1
+.for project.main where ( defined(main.service) & main.service > 0 )
 $(main.name).cfg
 .endfor
 
 .if systemd ?= 1
 # + systemd service unit for daemons (if any):
-.   for project.main where main.service ?= 1
+.   for project.main where ( defined(main.service) & main.service > 0 )
+.       if ( main.service ?= 1 | main.service ?= 3 )
 $(main.name).service
+.       endif
+.       if ( main.service ?= 2 | main.service ?= 3 )
+$(main.name)@.service
+.       endif
 .   endfor
 .endif
 
@@ -1145,11 +1155,16 @@ src_$(main.name:c)_LDADD = ${program_libs}
 src_$(name:c)_SOURCES = $(main.source)
 .#
 .#  Systemd stuff
-.   if main.service ?= 1
+.   if ( defined(main.service) & main.service > 0 )
 src_$(main.name:c)_config_DATA = src/$(main.name).cfg
 src_$(main.name:c)_configdir = \$(sysconfdir)/$(project.name)
 if WITH_SYSTEMD_UNITS
+.       if ( main.service ?= 1 | main.service ?= 3 )
 systemdsystemunit_DATA += src/$(main.name).service
+.       endif
+.       if ( main.service ?= 2 | main.service ?= 3 )
+systemdsystemunit_DATA += src/$(main.name)@.service
+.       endif
 endif #WITH_SYSTEMD_UNITS
 .   endif
 endif #ENABLE_$(NAME:c)
@@ -1248,7 +1263,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .close
 .#
 .#  Generate infrastructure for services
-.for project.main where main.service ?= 1
+.for project.main where ( defined(main.service) & main.service > 0 )
 .if !file.exists ("src/$(main.name).cfg.in")
 .       output "src/$(main.name).cfg.in"
 #   $(main.name) configuration
@@ -1263,7 +1278,8 @@ server
 .else
 .   echo "NOT regenerating an existing src/$(main.name).cfg.in file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
-.if !file.exists ("src/$(main.name).service.in")
+.if ( main.service ?= 1 | main.service ?= 3 )
+.  if !file.exists ("src/$(main.name).service.in")
 .   output "src/$(main.name).service.in"
 # This is a skeleton created by zproject.
 # You can add hand-written code here.
@@ -1271,16 +1287,50 @@ server
 [Unit]
 Description=$(main.name) service
 After=network.target
+# Requires=network.target
+# Conflicts=shutdown.target
+# PartOf=$(project.name).target
 
 [Service]
 Type=simple
+# User=@uid@
 Environment="prefix=@prefix@"
 ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
+Restart=always
 
 [Install]
 WantedBy=multi-user.target
-.else
+# WantedBy=$(project.name).target
+.  else
 .   echo "NOT regenerating an existing src/$(main.name).service.in file; you might want to move yours out of the way and re-generate the project again to get updated settings"
+.  endif
+.endif
+.if ( main.service ?= 2 | main.service ?= 3 )
+.  if !file.exists ("src/$(main.name)@.service.in")
+.   output "src/$(main.name)@.service.in"
+# This is a skeleton created by zproject.
+# You can add hand-written code here.
+
+[Unit]
+Description=$(main.name) service for %I
+After=network.target
+# Requires=network.target
+# Conflicts=shutdown.target
+# PartOf=$(project.name).target
+
+[Service]
+Type=simple
+# User=@uid@
+Environment="prefix=@prefix@"
+ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name)@%i.cfg
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+# WantedBy=$(project.name).target
+.  else
+.   echo "NOT regenerating an existing src/$(main.name)@.service.in file; you might want to move yours out of the way and re-generate the project again to get updated settings"
+.  endif
 .endif
 .endfor
 .close

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -215,7 +215,12 @@ usr/bin/$(bin.name)
 .# generate service file names
 .   for project.main where main.service ?= 1
 etc/$(project.name)/$(main.name).cfg
-lib/systemd/system/$(main.name){,@*}.{service,*}
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+lib/systemd/system/$(main.name).service
+.       endif
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+lib/systemd/system/$(main.name)@.service
+.       endif
 .   endfor
 .zinstall_include ("builds/zinstall/$(project.name).install")
 .endif

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -13,7 +13,7 @@
 register_target ("debian", "packaging for Debian")
 
 .macro target_debian
-.for project.main where main.service ?= 1
+.for project.main where ( defined(main.service) & main.service > 0 )
 .   systemd = 1
 .endfor
 .directory.create ('packaging/debian')
@@ -213,12 +213,12 @@ usr/share/man/man1/$(main.name).1
 usr/bin/$(bin.name)
 .   endfor
 .# generate service file names
-.   for project.main where main.service ?= 1
+.   for project.main where ( defined(main.service) & main.service > 0 )
 etc/$(project.name)/$(main.name).cfg
-.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
 lib/systemd/system/$(main.name).service
 .       endif
-.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
 lib/systemd/system/$(main.name)@.service
 .       endif
 .   endfor

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -204,7 +204,12 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .# generate service file names
 .for project.main where main.service ?= 1
 %config(noreplace) %{_sysconfdir}/$(project.name)/$(main.name).cfg
-/usr/lib/systemd/system/$(main.name){,@*}.{service,*}
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+/usr/lib/systemd/system/$(main.name).service
+.       endif
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+/usr/lib/systemd/system/$(main.name)@.service
+.       endif
 .etc_exists = 1
 .endfor
 .if etc_exists ?= 1
@@ -216,19 +221,34 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %post
 %systemd_post\
 .   for project.main where main.service ?= 1
- $(main.name){,@*}.{service,*}\
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+ $(main.name).service\
+.       endif
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+ $(main.name)@.service\
+.       endif
 .   endfor
 
 %preun
 %systemd_preun\
 .   for project.main where main.service ?= 1
- $(main.name){,@*}.{service,*}\
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+ $(main.name).service\
+.       endif
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+ $(main.name)@.service\
+.       endif
 .   endfor
 
 %postun
 %systemd_postun_with_restart\
 .   for project.main where main.service ?= 1
- $(main.name){,@*}.{service,*}\
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+ $(main.name).service\
+.       endif
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+ $(main.name)@.service\
+.       endif
 .   endfor
 
 %endif

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -13,7 +13,7 @@
 register_target ("redhat", "Packaging for RedHat")
 
 .macro target_redhat
-.for project.main where main.service ?= 1
+.for project.main where ( defined(main.service) & main.service > 0 )
 .   systemd = 1
 .endfor
 .directory.create ('packaging/redhat')
@@ -202,12 +202,12 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %{_bindir}/$(bin.name)
 .endfor
 .# generate service file names
-.for project.main where main.service ?= 1
+.for project.main where ( defined(main.service) & main.service > 0 )
 %config(noreplace) %{_sysconfdir}/$(project.name)/$(main.name).cfg
-.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
 /usr/lib/systemd/system/$(main.name).service
 .       endif
-.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
 /usr/lib/systemd/system/$(main.name)@.service
 .       endif
 .etc_exists = 1
@@ -220,33 +220,33 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %if 0%{?suse_version} > 1315
 %post
 %systemd_post\
-.   for project.main where main.service ?= 1
-.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+.   for project.main where ( defined(main.service) & main.service > 0 )
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
  $(main.name).service\
 .       endif
-.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
  $(main.name)@.service\
 .       endif
 .   endfor
 
 %preun
 %systemd_preun\
-.   for project.main where main.service ?= 1
-.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+.   for project.main where ( defined(main.service) & main.service > 0 )
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
  $(main.name).service\
 .       endif
-.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
  $(main.name)@.service\
 .       endif
 .   endfor
 
 %postun
 %systemd_postun_with_restart\
-.   for project.main where main.service ?= 1
-.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in")
+.   for project.main where ( defined(main.service) & main.service > 0 )
+.       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
  $(main.name).service\
 .       endif
-.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in")
+.       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
  $(main.name)@.service\
 .       endif
 .   endfor


### PR DESCRIPTION
Following up on #811 - it seems that debian always and RPM sometimes do not well support globs. So another solution is proposed to better handle the single-instance and/or multi-instance service units. Non-service units are left for the future, so far no released zproject version shipped them out of the box.