### PR TITLE
Problem: some (non-zmq) dependencies need customized CONFIG_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ Model is described in `zproject_known_projects.xml` file:
             optional = "1"              default = "0"
             debian_name = "libzmq5-dev" default = lib<name>-dev
             redhat_name = "zeromq-devel" default = <name>-devel
+                <add_config_opts>--with-dep1=nuance</add_config_opts>
+                <add_config_opts>--enable-feature2</add_config_opts>
         </use>
     -->
 

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -582,7 +582,16 @@ if \
         $CI_TIME autoconf || \\
         $CI_TIME autoreconf -fiv
     fi
+.   if count(use.add_config_opts) > 0
+    ( # Custom additional options for $(use.project)
+.       for use.add_config_opts as add_cfgopt
+      CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+      $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    )
+.   else
     $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.   endif
     $CI_TIME make -j4
     $CI_TIME make install
     cd "${BASE_PWD}"
@@ -625,7 +634,16 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)
         $CI_TIME autoconf || \\
         $CI_TIME autoreconf -fiv
     fi
+.   if count(use.add_config_opts) > 0
+    ( # Custom additional options for $(use.project)
+.       for use.add_config_opts as add_cfgopt
+      CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+      $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    )
+.   else
     $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.   endif
     $CI_TIME make -j4
     $CI_TIME make install
     cd "${BASE_PWD}"
@@ -635,6 +653,12 @@ fi
 # Build and check this project
 cd ../..
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
+.if count(add_config_opts) > 0
+# Custom additional options for this project
+.   for add_config_opts as add_cfgopt
+CONFIG_OPTS+=("$(add_cfgopt)")
+.   endfor
+.endif
 CCACHE_BASEDIR=${PWD}
 export CCACHE_BASEDIR
 PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig $CI_TIME cmake "${CMAKE_OPTS[@]}" .

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -632,7 +632,16 @@ pushd ../../..
 wget $(use.tarball)
 tar -xzf \$(basename "$(use.tarball)")
 cd \$(basename "$(use.tarball)" .tar.gz)
+.       if count(use.add_config_opts) > 0
+( # Custom additional options for $(use.project)
+.           for use.add_config_opts as add_cfgopt
+  CONFIG_OPTS+=("$(add_cfgopt)")
+.           endfor
+  $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+)
+.       else
 $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.       endif
 $CI_TIME make -j4
 $CI_TIME make install
 cd ..
@@ -659,7 +668,16 @@ if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./c
     $CI_TIME autoconf || \\
     $CI_TIME autoreconf -fiv
 fi
+.       if count(use.add_config_opts) > 0
+( # Custom additional options for $(use.project)
+.           for use.add_config_opts as add_cfgopt
+  CONFIG_OPTS+=("$(add_cfgopt)")
+.           endfor
+  $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+)
+.       else
 $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.       endif
 $CI_TIME make -j4
 $CI_TIME make install
 .       if count (project->dependencies.class, class.project = use.project) > 0
@@ -673,6 +691,12 @@ popd
 pushd ../..
 
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
+.       if count(add_config_opts) > 0
+# Custom additional options for this project
+.           for add_config_opts as add_cfgopt
+CONFIG_OPTS+=("$(add_cfgopt)")
+.           endfor
+.       endif
 $CI_TIME ./autogen.sh 2> /dev/null
 $CI_TIME ./configure "${CONFIG_OPTS[@]}"
 $CI_TIME make -j4

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -28,6 +28,8 @@
             optional = "1"              default = "0"
             debian_name = "libzmq5-dev" default = lib<name>-dev
             redhat_name = "zeromq-devel" default = <name>-devel
+                <add_config_opts>--with-dep1=nuance</add_config_opts>
+                <add_config_opts>--enable-feature2</add_config_opts>
         </use>
     -->
 

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -64,6 +64,13 @@ function resolve_project_dependency (use)
                 move implied_linkname to my.use as linkname
             endif
         endfor
+
+        # Copy known additional CONFIG_OPTS
+        for known.add_config_opts as implied_add_config_opts
+            if !count (my.use.add_config_opts, add_config_opts = implied_add_config_opts)
+                move implied_add_config_opts to my.use as add_config_opts
+            endif
+        endfor
     endfor
 
     # Use reasonable fallback values to fill in any remaining gaps

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -116,7 +116,16 @@ if [ ! $INCREMENTAL ]; then
     fi
     pushd \$(basename "$(use.tarball)" .tar.gz)
     (
+.           if count(use.add_config_opts) > 0
+        ( # Custom additional options for $(use.project)
+.               for use.add_config_opts as add_cfgopt
+            CONFIG_OPTS+=("$(add_cfgopt)")
+.               endfor
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        )
+.           else
         $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.           endif
         $CI_TIME make -j4
         $CI_TIME make install
     ) || exit 1
@@ -151,7 +160,16 @@ if [ ! $INCREMENTAL ]; then
             $CI_TIME autoconf || \\
             $CI_TIME autoreconf -fiv
         fi
+.           if count(use.add_config_opts) > 0
+        ( # Custom additional options for $(use.project)
+.               for use.add_config_opts as add_cfgopt
+            CONFIG_OPTS+=("$(add_cfgopt)")
+.               endfor
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        )
+.           else
         $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.           endif
         $CI_TIME make -j4
         $CI_TIME make install
     ) || exit 1
@@ -163,6 +181,12 @@ fi
 # Cross build this project
 pushd ../..
 (
+.   if count(add_config_opts) > 0
+    # Custom additional options for this project
+.       for add_config_opts as add_cfgopt
+    CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+.   endif
     $CI_TIME ./autogen.sh 2> /dev/null
     $CI_TIME ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     $CI_TIME make -j4

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -331,7 +331,16 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
             $CI_TIME autoconf || \\
             $CI_TIME autoreconf -fiv
         fi
+.           if count(use.add_config_opts) > 0
+        ( # Custom additional options for $(use.project)
+.               for use.add_config_opts as add_cfgopt
+            CONFIG_OPTS+=("$(add_cfgopt)")
+.               endfor
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        )
+.           else
         $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.           endif
         $CI_TIME make -j4
         $CI_TIME make install
         cd "${BASE_PWD}"
@@ -347,6 +356,12 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     # Only use --enable-Werror on projects that are expected to have it
     # (and it is not our duty to check prerequisite projects anyway)
     CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")
+.   if count(add_config_opts) > 0
+    # Custom additional options for this project
+.       for add_config_opts as add_cfgopt
+    CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+.   endif
     $CI_TIME ./autogen.sh 2> /dev/null
     $CI_TIME ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     if [ "$BUILD_TYPE" == "valgrind" ] ; then


### PR DESCRIPTION
Solution: add support for an optional list of <add_config_opts> tags in <use> dependencies... and also in the <project> itself for completeness.

Example usage:

````
    <use project = "libnutclient" test = "nut::TcpClient::TcpClient" header="nutclient.h"
        prefix="nutclient"
        repository = "https://github.com/networkupstools/nut">
            <add_config_opts>--with-doc=skip</add_config_opts>
            <add_config_opts>--with-dev=yes</add_config_opts>
    </use>
````
