### PR TITLE
Add support for main "no_config" attr, and some minor fixes

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -777,13 +777,13 @@ AC_CONFIG_FILES([Makefile
                  src/$(extra.name)
 .       endfor
 .   endfor
-.   for project.main where ( defined(main.service) & main.service > 0 )
+.   for project.main where ( defined(main.service) & main.service > 0 & ( !defined(main.no_config) | main.no_config ?= 0 ) )
                  src/$(main.name).cfg
 .   endfor
                  ])
 .else
 AC_CONFIG_FILES([Makefile
-.   for project.main where ( defined(main.service) & main.service > 0 )
+.   for project.main where ( defined(main.service) & main.service > 0 & ( !defined(main.no_config) | main.no_config ?= 0 ) )
                  src/$(main.name).cfg
 .   endfor
                 ])
@@ -901,7 +901,7 @@ $(extra.name)
 .endif
 
 # + config files for mains (if any):
-.for project.main where ( defined(main.service) & main.service > 0 )
+.for project.main where ( defined(main.service) & main.service > 0 & ( !defined(main.no_config) | main.no_config ?= 0 ) )
 $(main.name).cfg
 .endfor
 
@@ -1156,7 +1156,10 @@ src_$(name:c)_SOURCES = $(main.source)
 .#
 .#  Systemd stuff
 .   if ( defined(main.service) & main.service > 0 )
-src_$(main.name:c)_config_DATA = src/$(main.name).cfg
+src_$(main.name:c)_config_DATA =
+.       if ( !defined(main.no_config) | main.no_config ?= 0 )
+src_$(main.name:c)_config_DATA += src/$(main.name).cfg
+.       endif
 src_$(main.name:c)_configdir = \$(sysconfdir)/$(project.name)
 if WITH_SYSTEMD_UNITS
 .       if ( main.service ?= 1 | main.service ?= 3 )
@@ -1264,7 +1267,8 @@ $(project.GENERATED_WARNING_HEADER:)
 .#
 .#  Generate infrastructure for services
 .for project.main where ( defined(main.service) & main.service > 0 )
-.if !file.exists ("src/$(main.name).cfg.in")
+.if !defined(main.no_config) | main.no_config ?= 0
+.  if !file.exists ("src/$(main.name).cfg.in")
 .       output "src/$(main.name).cfg.in"
 #   $(main.name) configuration
 # This is a skeleton created by zproject.
@@ -1275,8 +1279,9 @@ server
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     verbose = 0         #   Do verbose logging of activity?
-.else
+.  else
 .   echo "NOT regenerating an existing src/$(main.name).cfg.in file; you might want to move yours out of the way and re-generate the project again to get updated settings"
+.  endif
 .endif
 .if ( main.service ?= 1 | main.service ?= 3 )
 .  if !file.exists ("src/$(main.name).service.in")
@@ -1295,7 +1300,11 @@ After=network.target
 Type=simple
 # User=@uid@
 Environment="prefix=@prefix@"
+.       if ( !defined(main.no_config) | main.no_config ?= 0 )
 ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
+.       else
+ExecStart=@prefix@/bin/$(main.name)
+.       endif
 Restart=always
 
 [Install]
@@ -1322,7 +1331,11 @@ After=network.target
 Type=simple
 # User=@uid@
 Environment="prefix=@prefix@"
+.       if ( !defined(main.no_config) | main.no_config ?= 0 )
 ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name)@%i.cfg
+.       else
+ExecStart=@prefix@/bin/$(main.name) %i
+.       endif
 Restart=always
 
 [Install]

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1300,6 +1300,7 @@ After=network.target
 Type=simple
 # User=@uid@
 Environment="prefix=@prefix@"
+Environment='SYSTEMD_UNIT_FULLNAME=%n'
 .       if ( !defined(main.no_config) | main.no_config ?= 0 )
 ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name).cfg
 .       else
@@ -1331,6 +1332,7 @@ After=network.target
 Type=simple
 # User=@uid@
 Environment="prefix=@prefix@"
+Environment='SYSTEMD_UNIT_FULLNAME=%n'
 .       if ( !defined(main.no_config) | main.no_config ?= 0 )
 ExecStart=@prefix@/bin/$(main.name) @sysconfdir@/@PACKAGE@/$(main.name)@%i.cfg
 .       else

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -214,7 +214,9 @@ usr/bin/$(bin.name)
 .   endfor
 .# generate service file names
 .   for project.main where ( defined(main.service) & main.service > 0 )
+.       if !defined(main.no_config) | main.no_config ?= 0
 etc/$(project.name)/$(main.name).cfg
+.       endif
 .       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
 lib/systemd/system/$(main.name).service
 .       endif

--- a/zproject_install.gsl
+++ b/zproject_install.gsl
@@ -61,6 +61,8 @@ for project.main where defined (main->install)
             append "builds/zinstall/$(project.name).install"
 >usr/lib/tmpfiles.d/$(main.name).conf
 
+# TODO: consider equivalent of
+# `if !defined(main.no_config) | main.no_config ?= 0`
         elsif install.type = "config"
             install.name ?= main.name + ".cfg"
             append "builds/zinstall/configure.ac"

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -10,7 +10,7 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-register_target ("redhat", "Packaging for RedHat")
+register_target ("redhat", "packaging for RedHat")
 
 .macro target_redhat
 .for project.main where ( defined(main.service) & main.service > 0 )

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -203,7 +203,9 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .endfor
 .# generate service file names
 .for project.main where ( defined(main.service) & main.service > 0 )
+.       if !defined(main.no_config) | main.no_config ?= 0
 %config(noreplace) %{_sysconfdir}/$(project.name)/$(main.name).cfg
+.       endif
 .       if file.exists("src/$(main.name).service") | file.exists("src/$(main.name).service.in") | ( main.service ?= 1 | main.service ?= 3 )
 /usr/lib/systemd/system/$(main.name).service
 .       endif


### PR DESCRIPTION
Main problem: some daemons do not want the .cfg file 

Solution: add the inverse flag `no_config=1` to specify that the `$(main.name).cfg` should not be generated, built or distributed