### PR TITLE
Problem: zproject doesn't tell zproto about private classes

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1208,12 +1208,16 @@ code:
 .   endif
 .   if defined (model.script)
 \tcd $\(srcdir)/src; gsl -topdir:.. -zproject:1 -script:$(script:) \
-. for model.param
+.       for model.param
 -$(param.name):$(param.value) \
-. endfor
+.       endfor
 -q $(name:c).xml
 .   else
-\tcd $\(srcdir)/src; gsl -topdir:.. -zproject:1 -q $(name).xml
+\tcd $\(srcdir)/src; gsl -topdir:.. -zproject:1 \
+.       if count(project.class, class.name = model.name)
+-private:1 \
+.       endif
+-q $(name).xml
 .   endif
 .endfor
 \tcd $\(srcdir); gsl -target:- project.xml


### PR DESCRIPTION
Solution: If there is a private class for a model add a private
switch to the models `make code` target.