### PR TITLE
Problem: rpm build fails

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -156,7 +156,7 @@ This package contains development files for $(project.name): $(project.descripti
 # Install api files into /usr/local/share/zproject
 %dir %{_datadir}/zproject/
 %dir %{_datadir}/zproject/$(project.name)
-%dir %{_datadir}/zproject/$(project.name)/*.api
+%{_datadir}/zproject/$(project.name)/*.api
 .      endif
 .   endfor
 .endif


### PR DESCRIPTION
Solution: do not mark api files as directories