### PR TITLE
Problem: some generated sources place internal headers into src/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,8 @@ AM_CFLAGS = \
 
 
 AM_CPPFLAGS = \
-    -I$(srcdir)/include
+    -I$(srcdir)/include -I$(srcdir)/src \
+    -I$(builddir)/include -I$(builddir)/src
 
 project_libs =
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -948,7 +948,8 @@ AM_CPPFLAGS = \\
 .if project.use_cxx
     -D__STDC_FORMAT_MACROS \\
 .endif
-    -I\$(srcdir)/include
+    -I\$(srcdir)/include -I\$(srcdir)/src \\
+    -I\$(builddir)/include -I\$(builddir)/src
 
 .libs = ""
 .for use where use.libname ?<> ""


### PR DESCRIPTION
Solution: add -Isrc/ to CPPFLAGS; just in case for build-time generated headers (e.g. from templates) also add the builddir/include and builddir/src.

NOTE: This is about internal headers (implementation details of classes and APIs) as far as I've seen, so it makes little sense to expose them in include/ dir properly. But feel free to decide more authoritatively if any of those should be generated into another path; out of scope for this PR though :)