### PR TITLE
Revert "Problem: some generated sources place internal headers into src/"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,8 +10,7 @@ AM_CFLAGS = \
 
 
 AM_CPPFLAGS = \
-    -I$(srcdir)/include -I$(srcdir)/src \
-    -I$(builddir)/include -I$(builddir)/src
+    -I$(srcdir)/include
 
 project_libs =
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -948,8 +948,7 @@ AM_CPPFLAGS = \\
 .if project.use_cxx
     -D__STDC_FORMAT_MACROS \\
 .endif
-    -I\$(srcdir)/include -I\$(srcdir)/src \\
-    -I\$(builddir)/include -I\$(builddir)/src
+    -I\$(srcdir)/include
 
 .libs = ""
 .for use where use.libname ?<> ""


### PR DESCRIPTION
Reverts zeromq/zproject#861

Problem statement by @jimklimov is **not a problem**:
1. Internal headers *should* be placed into src/
2. As @bluca mentioned in the [comment](https://github.com/zeromq/zproject/pull/861#issuecomment-282019544), internal headers *should not* be placed into /include,  but that is **NOT** happening. There is nothing to be fixed!
3. No matter what, a cleanly generated project (i.e. no manual wiring) will never fail `make distcheck`.

The real problem @jimklimov was trying to fix with this PR was that one of our repos was failing `make distcheck` on his system. The reason why this repo failed is not because of zproject but because someone made manual changes to the wiring/includes. 

@jimklimov: If you provide a project.xml that would, after generation (without faulty manual additions), fail make distcheck on any system i am more then willing to re-visit this topic.