### PR TITLE
Problem: project-local CMake hook are not included

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1003,7 +1003,7 @@ EXTRA_DIST += \\
     src/$(project.prefix)_classes.h
 
 include \$(srcdir)/src/Makemodule.am
-sinclude \$(srcdir)/src/Makemodule-local.am # Optional project-local hook
+include \$(srcdir)/src/Makemodule-local.am # Optional project-local hook
 
 $(project.GENERATED_WARNING_HEADER:)
 .#


### PR DESCRIPTION
Solution: Fix typo error

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>