### PR TITLE
Revert "Problem: project-local CMake hook are not included"

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1003,7 +1003,7 @@ EXTRA_DIST += \\
     src/$(project.prefix)_classes.h
 
 include \$(srcdir)/src/Makemodule.am
-include \$(srcdir)/src/Makemodule-local.am # Optional project-local hook
+sinclude \$(srcdir)/src/Makemodule-local.am # Optional project-local hook
 
 $(project.GENERATED_WARNING_HEADER:)
 .#


### PR DESCRIPTION
This reverts commit 9501b601b5ea6558f73d67899fc414c0a8d20b4d.

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>