### PR TITLE
Problem: projects stopped EXTRA_DISTing Makemodule-local.am after PR#860

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,12 @@ EXTRA_DIST += \
     CONTRIBUTING.md \
     src/zproject_classes.h
 
+# Victims of "include" are EXTRA_DISTed by autotools, however neither "-include"
+# nor "sinclude" are covered by this magic.
+if ENABLE_DIST_SRC_MAKEMODULE_LOCAL
+EXTRA_DIST += src/Makemodule-local.am
+endif
+
 include $(srcdir)/src/Makemodule.am
 sinclude $(srcdir)/src/Makemodule-local.am # Optional project-local hook
 

--- a/configure.ac
+++ b/configure.ac
@@ -337,6 +337,11 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
 AC_CONFIG_FILES([Makefile
                 ])
 
+AC_MSG_CHECKING([whether to redistribute src/Makemodule-local.am])
+AC_CHECK_FILE([$srcdir/src/Makemodule-local.am], [enable_dist_SRC_MAKEMODULE_LOCAL=yes], [enable_dist_SRC_MAKEMODULE_LOCAL=no])
+AM_CONDITIONAL([ENABLE_DIST_SRC_MAKEMODULE_LOCAL], [test "x$enable_dist_SRC_MAKEMODULE_LOCAL" = "xyes"])
+AC_MSG_RESULT([$enable_dist_SRC_MAKEMODULE_LOCAL])
+
 AC_OUTPUT
 
 # Print configure summary and list make options

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -805,7 +805,6 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
 
 .endif
 .insert_snippet ("configure.ac")
-
 AC_MSG_CHECKING([whether to redistribute src/Makemodule-local.am])
 AC_CHECK_FILE([$srcdir/src/Makemodule-local.am], [enable_dist_SRC_MAKEMODULE_LOCAL=yes], [enable_dist_SRC_MAKEMODULE_LOCAL=no])
 AM_CONDITIONAL([ENABLE_DIST_SRC_MAKEMODULE_LOCAL], [test "x$enable_dist_SRC_MAKEMODULE_LOCAL" = "xyes"])

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -805,6 +805,12 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
 
 .endif
 .insert_snippet ("configure.ac")
+
+AC_MSG_CHECKING([whether to redistribute src/Makemodule-local.am])
+AC_CHECK_FILE([$srcdir/src/Makemodule-local.am], [enable_dist_SRC_MAKEMODULE_LOCAL=yes], [enable_dist_SRC_MAKEMODULE_LOCAL=no])
+AM_CONDITIONAL([ENABLE_DIST_SRC_MAKEMODULE_LOCAL], [test "x$enable_dist_SRC_MAKEMODULE_LOCAL" = "xyes"])
+AC_MSG_RESULT([$enable_dist_SRC_MAKEMODULE_LOCAL])
+
 AC_OUTPUT
 
 # Print configure summary and list make options
@@ -1001,6 +1007,12 @@ EXTRA_DIST += \\
     CONTRIBUTING.md \\
 .endif
     src/$(project.prefix)_classes.h
+
+# Victims of "include" are EXTRA_DISTed by autotools, however neither "-include"
+# nor "sinclude" are covered by this magic.
+if ENABLE_DIST_SRC_MAKEMODULE_LOCAL
+EXTRA_DIST += src/Makemodule-local.am
+endif
 
 include \$(srcdir)/src/Makemodule.am
 sinclude \$(srcdir)/src/Makemodule-local.am # Optional project-local hook


### PR DESCRIPTION
Solution: detect it at configure time and redist optionally

Thanks to @aquette for persisting that PR #860 did introduce a bug.