### PR TITLE
Problem: Improvements in PR#864 did not generate files from templates

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -794,10 +794,38 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
     [AC_CONFIG_FILES([
 .   for project.main where ( defined(main.service) & main.service > 0 )
 .       if ( main.service ?= 1 | main.service ?= 3 )
+.           if file.exists("src/$(main.name).service.in")
                  src/$(main.name).service
+.           endif
+.           if file.exists("src/$(main.name).timer.in")
+                 src/$(main.name).timer
+.           endif
 .       endif
 .       if ( main.service ?= 2 | main.service ?= 3 )
+.           if file.exists("src/$(main.name)@.service.in")
                  src/$(main.name)@.service
+.           endif
+.           if file.exists("src/$(main.name)@.timer.in")
+                 src/$(main.name)@.timer
+.          endif
+.       endif
+.   endfor
+.   for project.bin where ( defined(bin.service) & bin.service > 0 )
+.       if ( bin.service ?= 1 | bin.service ?= 3 )
+.           if file.exists("src/$(bin.name).service.in")
+                 src/$(bin.name).service
+.           endif
+.           if file.exists("src/$(bin.name).timer.in")
+                 src/$(bin.name).timer
+.           endif
+.       endif
+.       if ( bin.service ?= 2 | bin.service ?= 3 )
+.           if file.exists("src/$(bin.name)@.service.in")
+                 src/$(bin.name)@.service
+.           endif
+.           if file.exists("src/$(bin.name)@.timer.in")
+                 src/$(bin.name)@.timer
+.           endif
 .       endif
 .   endfor
     ])],
@@ -909,6 +937,9 @@ $(extra.name)
 .for project.main where ( defined(main.service) & main.service > 0 & ( !defined(main.no_config) | main.no_config ?= 0 ) )
 $(main.name).cfg
 .endfor
+.for project.bin where ( defined(bin.service) & bin.service > 0 & ( !defined(bin.no_config) | bin.no_config ?= 0 ) )
+$(bin.name).cfg
+.endfor
 
 .if systemd ?= 1
 # + systemd service unit for daemons (if any):
@@ -918,6 +949,26 @@ $(main.name).service
 .       endif
 .       if ( main.service ?= 2 | main.service ?= 3 )
 $(main.name)@.service
+.       endif
+.       if file.exists("src/$(main.name).timer.in")
+$(main.name).timer
+.       endif
+.       if file.exists("src/$(main.name)@.timer.in")
+$(main.name)@.timer
+.       endif
+.   endfor
+.   for project.bin where ( defined(bin.service) & bin.service > 0 )
+.       if ( bin.service ?= 1 | bin.service ?= 3 )
+$(bin.name).service
+.       endif
+.       if ( bin.service ?= 2 | bin.service ?= 3 )
+$(bin.name)@.service
+.       endif
+.       if file.exists("src/$(bin.name).timer.in")
+$(bin.name).timer
+.       endif
+.       if file.exists("src/$(bin.name)@.timer.in")
+$(bin.name)@.timer
 .       endif
 .   endfor
 .endif

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -223,6 +223,12 @@ lib/systemd/system/$(main.name).service
 .       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
 lib/systemd/system/$(main.name)@.service
 .       endif
+.       if file.exists("src/$(main.name).timer") | file.exists("src/$(main.name).timer.in") | ( main.service ?= 1 | main.service ?= 3 )
+/usr/lib/systemd/system/$(main.name).timer
+.       endif
+.       if file.exists("src/$(main.name)@.timer") | file.exists("src/$(main.name)@.timer.in") | ( main.service ?= 2 | main.service ?= 3 )
+/usr/lib/systemd/system/$(main.name)@.timer
+.       endif
 .   endfor
 .   for project.bin where ( defined(bin.service) & bin.service > 0 )
 .       if file.exists("src/$(bin.name).service") | file.exists("src/$(bin.name).service.in") | ( bin.service ?= 1 | bin.service ?= 3 )

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -216,6 +216,12 @@ find %{buildroot} -name '*.la' | xargs rm -f
 .       if file.exists("src/$(main.name)@.service") | file.exists("src/$(main.name)@.service.in") | ( main.service ?= 2 | main.service ?= 3 )
 /usr/lib/systemd/system/$(main.name)@.service
 .       endif
+.       if file.exists("src/$(main.name).timer") | file.exists("src/$(main.name).timer.in") | ( main.service ?= 1 | main.service ?= 3 )
+/usr/lib/systemd/system/$(main.name).timer
+.       endif
+.       if file.exists("src/$(main.name)@.timer") | file.exists("src/$(main.name)@.timer.in") | ( main.service ?= 2 | main.service ?= 3 )
+/usr/lib/systemd/system/$(main.name)@.timer
+.       endif
 .etc_exists = 1
 .endfor
 .for project.bin where ( defined(bin.service) & bin.service > 0 )


### PR DESCRIPTION
Solutions:
* generate configure.ac snippets for systemd service and timer .in templates, where available;
* add gitignores for such generated files;
* support systemd timer units (if sources are present) not only for BINs but also MAINs to be on par (redhat, debian)

Follow-up for PR #864 ...