### PR TITLE
Problem: Debian packaging misses src/Makemodule-local.am if not in SCM

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,7 +7,7 @@
 #   Script to generate all required files from fresh git checkout.
 
 if [ ! -f src/Makemodule-local.am ] ; then
-    echo "autogen.sh: generating a dummy src/Makemodule-local.am to fulfill dependencies"
+    echo "autogen.sh: generating a dummy src/Makemodule-local.am to fulfill dependencies." 1>&2
     touch src/Makemodule-local.am
 fi
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -25,16 +25,23 @@ endif
 # Workaround for automake < 1.14 bug
 $(shell dpkg --compare-versions `dpkg-query -W -f='$${Version}\n' automake` lt 1:1.14 && mkdir -p config)
 
+.autogened: autogen.sh
+	@echo "Executing autogen.sh for this project..."
+	./autogen.sh
+	touch $@
+
 override_dh_strip:
 	dh_strip --dbg-package=zproject-dbg
 
 override_dh_auto_test:
 	echo "Skipped for now"
 
-override_dh_auto_configure:
+override_dh_auto_configure: .autogened
 	dh_auto_configure -- \
 		--enable-drafts=$(DRAFTS)
 
 %:
+	if test "$@" = "clean" ; then rm -f .autogened ; fi; \
+	if test "$@" = "build" ; then $(MAKE) .autogened ; else true; fi && \
 	dh $@ \
 		--with autoreconf

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -20,7 +20,7 @@ $(project.GENERATED_WARNING_HEADER:)
 #   Script to generate all required files from fresh git checkout.
 
 if [ ! -f src/Makemodule-local.am ] ; then
-    echo "autogen.sh: generating a dummy src/Makemodule-local.am to fulfill dependencies"
+    echo "autogen.sh: generating a dummy src/Makemodule-local.am to fulfill dependencies." 1>&2
     touch src/Makemodule-local.am
 fi
 

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -177,13 +177,18 @@ endif
 # Workaround for automake < 1.14 bug
 \$(shell dpkg --compare-versions `dpkg-query -W -f='\$${Version}\\n' automake` lt 1:1.14 && mkdir -p config)
 
+\.autogened: autogen.sh
+	@echo "Executing autogen.sh for this project..."
+	./autogen.sh
+	touch $@
+
 override_dh_strip:
 	dh_strip --dbg-package=$(string.replace (project.name, "_|-"):lower)-dbg
 
 override_dh_auto_test:
 	echo "Skipped for now"
 
-override_dh_auto_configure:
+override_dh_auto_configure: .autogened
 	dh_auto_configure -- \\
 .if systemd ?= 1
 		--with-systemd-units \\
@@ -191,6 +196,8 @@ override_dh_auto_configure:
 		--enable-drafts=\$(DRAFTS)
 
 %:
+	if test "$@" = "clean" ; then rm -f .autogened ; fi; \\
+	if test "$@" = "build" ; then $\(MAKE) .autogened ; else true; fi && \\
 	dh $@ \\
 .if systemd ?= 1
 		--with systemd \\


### PR DESCRIPTION
Solution: call autogen.sh before building to generate the dummy

Follow-up to #860 et al

Improvement tested in our project - passed public Travis and private Jenkins + OBS