### PR TITLE
Problem: debian/rules "autogened" should not call extra $(MAKE)

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -30,6 +30,9 @@ $(shell dpkg --compare-versions `dpkg-query -W -f='$${Version}\n' automake` lt 1
 	./autogen.sh
 	touch $@
 
+clean-autogened:
+	rm -f .autogened
+
 override_dh_strip:
 	dh_strip --dbg-package=zproject-dbg
 
@@ -40,8 +43,10 @@ override_dh_auto_configure: .autogened
 	dh_auto_configure -- \
 		--enable-drafts=$(DRAFTS)
 
+# Additional dependency for certain targets
+build: .autogened
+clean: clean-autogened
+
 %:
-	if test "$@" = "clean" ; then rm -f .autogened ; fi; \
-	if test "$@" = "build" ; then $(MAKE) .autogened ; else true; fi && \
 	dh $@ \
 		--with autoreconf

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -182,6 +182,9 @@ endif
 	./autogen.sh
 	touch $@
 
+clean-autogened:
+	rm -f .autogened
+
 override_dh_strip:
 	dh_strip --dbg-package=$(string.replace (project.name, "_|-"):lower)-dbg
 
@@ -195,9 +198,11 @@ override_dh_auto_configure: .autogened
 .endif
 		--enable-drafts=\$(DRAFTS)
 
+# Additional dependency for certain targets
+build: .autogened
+clean: clean-autogened
+
 %:
-	if test "$@" = "clean" ; then rm -f .autogened ; fi; \\
-	if test "$@" = "build" ; then $\(MAKE) .autogened ; else true; fi && \\
 	dh $@ \\
 .if systemd ?= 1
 		--with systemd \\


### PR DESCRIPTION
Solution: define makefile-style targets to call or clean-up the autogen script within currently processed set of recipes rather than calling a $(MAKE) with an undefined makefile name ;)

Follow-up for #883 
