### PR TITLE
Problem: generated "git clone" commands lowercase the branch ("release")

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -152,7 +152,7 @@ export TOOLCHAIN_ARCH="arm"
 .for use where defined (use.repository)
 export $(USE.PROJECT)_ROOT="/tmp/$(use.project)"
 .   if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $$(USE.PROJECT)_ROOT
+git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $$(USE.PROJECT)_ROOT
 .   else
 git clone --quiet --depth 1 $(use.repository) $$(USE.PROJECT)_ROOT
 .   endif

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -608,7 +608,7 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)
 .   endif
        (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
 .   if defined (use.release)
-    $CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+    $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .   else
     $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .   endif

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -648,7 +648,7 @@ cd ..
 .   endfor
 .   for use where defined (use.repository)
 .      if defined (use.release)
-$CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+$CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .      else
 $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .      endif

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -135,7 +135,7 @@ if [ ! $INCREMENTAL ]; then
 .   for use where defined (use.repository) & ! defined (use.tarball)
     if [ ! -e $(use.project) ]; then
 .      if defined (use.release)
-        $CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+        $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .      else
         $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .      endif

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -316,7 +316,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
 .           elsif defined (use.repository)
         echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
 .               if defined (use.release)
-        $CI_TIME git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+        $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .               else
         $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .               endif
@@ -452,7 +452,7 @@ set -ex
 cd "$REPO_DIR/.."
 .for project.use where !optional & defined (use.repository)
 .   if defined (use.release)
-git clone --quiet --depth 1 -b $(use.release) $(use.repository) $(use.project)
+git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .   else
 git clone --quiet --depth 1 $(use.repository) $(use.project)
 .   endif


### PR DESCRIPTION
Solution: use the original spelling provided by project.xml script author, because git is case-sensitive about branch names.