### PR TITLE
Problem: current integration with ASAN can break CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,20 @@ else
     AM_CONDITIONAL(WITH_GCOV, false)
 fi
 
+# Memory mis-use detection
+AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes/no],
+                  [Build with GCC Address Sanitizer instrumentation])],
+                  [ZPROJECT_ASAN="$withval"])
+
+if test "x${ZPROJECT_ASAN}" == "xyes"; then
+    CFLAGS="${CFLAGS} -fsanitize=address"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+
+    AM_CONDITIONAL(WITH_ASAN, true)
+else
+    AM_CONDITIONAL(WITH_ASAN, false)
+fi
+
 # Set pkgconfigdir
 AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
     [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -453,6 +453,20 @@ else
     AM_CONDITIONAL(WITH_GCOV, false)
 fi
 
+# Memory mis-use detection
+AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes/no],
+                  [Build with GCC Address Sanitizer instrumentation])],
+                  [$(PROJECT.PREFIX)_ASAN="$withval"])
+
+if test "x${$(PROJECT.PREFIX)_ASAN}" == "xyes"; then
+    CFLAGS="${CFLAGS} -fsanitize=address"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+
+    AM_CONDITIONAL(WITH_ASAN, true)
+else
+    AM_CONDITIONAL(WITH_ASAN, false)
+fi
+
 # Set pkgconfigdir
 AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
     [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -306,8 +306,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     fi
 
     if [ -n "$ADDRESS_SANITIZER" ] && [ "$ADDRESS_SANITIZER" == "enabled" ]; then
-        CONFIG_OPTS+=("CFLAGS=-fsanitize=address")
-        CONFIG_OPTS+=("CXXFLAGS=-fsanitize=address")
+        CONFIG_OPTS+=("--enable-address-sanitizer=yes")
     fi
 
     # Clone and build dependencies, if not yet installed to Travis env as DEBs


### PR DESCRIPTION
Solution: remake by producing a custom configure option

Follow-up on #892 

In any case, having this automated can be beneficial for not-only-travis test builds.