### PR TITLE
Configure script: the flag type for ASAN is "enable", not "with"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
 # Code coverage
+AC_MSG_CHECKING([whether to enable GCov])
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting])],
                   [ZPROJECT_GCOV="$withval"])
@@ -64,22 +65,27 @@ if test "x${ZPROJECT_GCOV}" == "xyes"; then
         CFLAGS="${CFLAGS} ${ZPROJECT_ORIG_CFLAGS}"
     fi
     AM_CONDITIONAL(WITH_GCOV, true)
+    AC_MSG_RESULT([yes])
 else
     AM_CONDITIONAL(WITH_GCOV, false)
+    AC_MSG_RESULT([no])
 fi
 
 # Memory mis-use detection
+AC_MSG_CHECKING([whether to enable ASan])
 AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes/no],
                   [Build with GCC Address Sanitizer instrumentation])],
-                  [ZPROJECT_ASAN="$withval"])
+                  [ZPROJECT_ASAN="$enableval"])
 
 if test "x${ZPROJECT_ASAN}" == "xyes"; then
     CFLAGS="${CFLAGS} -fsanitize=address"
     CXXFLAGS="${CXXFLAGS} -fsanitize=address"
 
-    AM_CONDITIONAL(WITH_ASAN, true)
+    AM_CONDITIONAL(ENABLE_ASAN, true)
+    AC_MSG_RESULT([yes])
 else
-    AM_CONDITIONAL(WITH_ASAN, false)
+    AM_CONDITIONAL(ENABLE_ASAN, false)
+    AC_MSG_RESULT([no])
 fi
 
 # Set pkgconfigdir

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -438,6 +438,7 @@ AX_PROJECT_LOCAL_HOOK
 
 .endif
 # Code coverage
+AC_MSG_CHECKING([whether to enable GCov])
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting])],
                   [$(PROJECT.PREFIX)_GCOV="$withval"])
@@ -449,22 +450,27 @@ if test "x${$(PROJECT.PREFIX)_GCOV}" == "xyes"; then
         CFLAGS="${CFLAGS} ${$(PROJECT.PREFIX)_ORIG_CFLAGS}"
     fi
     AM_CONDITIONAL(WITH_GCOV, true)
+    AC_MSG_RESULT([yes])
 else
     AM_CONDITIONAL(WITH_GCOV, false)
+    AC_MSG_RESULT([no])
 fi
 
 # Memory mis-use detection
+AC_MSG_CHECKING([whether to enable ASan])
 AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes/no],
                   [Build with GCC Address Sanitizer instrumentation])],
-                  [$(PROJECT.PREFIX)_ASAN="$withval"])
+                  [$(PROJECT.PREFIX)_ASAN="$enableval"])
 
 if test "x${$(PROJECT.PREFIX)_ASAN}" == "xyes"; then
     CFLAGS="${CFLAGS} -fsanitize=address"
     CXXFLAGS="${CXXFLAGS} -fsanitize=address"
 
-    AM_CONDITIONAL(WITH_ASAN, true)
+    AM_CONDITIONAL(ENABLE_ASAN, true)
+    AC_MSG_RESULT([yes])
 else
-    AM_CONDITIONAL(WITH_ASAN, false)
+    AM_CONDITIONAL(ENABLE_ASAN, false)
+    AC_MSG_RESULT([no])
 fi
 
 # Set pkgconfigdir


### PR DESCRIPTION
Also add messages to make ASAN and GCOV enablement more visible

Follow-up to #892 and #893 