### PR TITLE
Problem: generated .travis.yml repeats too much

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -94,7 +94,6 @@ addons:
       <<: *pkg_src_zeromq_ubuntu12
     packages: &pkg_deps_common
     - *pkg_deps_devtools
-    - *pkg_deps_doctools
     - *pkg_deps_prereqs
 
 matrix:
@@ -118,6 +117,15 @@ matrix:
           <<: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_common
+  - env: BUILD_TYPE=default-with-docs
+    os: linux
+    addons:
+      apt:
+        sources:
+          <<: *pkg_src_zeromq_ubuntu12
+        packages:
+        - *pkg_deps_common
+        - *pkg_deps_doctools
 
 before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install binutils ; fi
@@ -169,7 +177,7 @@ case "$CI_TRACE" in
 esac
 
 case "$BUILD_TYPE" in
-default|default-Werror|valgrind)
+default|default-Werror|default-with-docs|valgrind)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -255,7 +263,6 @@ default|default-Werror|valgrind)
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
-    CONFIG_OPTS+=("--with-docs=no")
     if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
         CONFIG_OPTS+=("--quiet")
     fi
@@ -314,6 +321,9 @@ default|default-Werror|valgrind)
     if [ -n "$ADDRESS_SANITIZER" ] && [ "$ADDRESS_SANITIZER" == "enabled" ]; then
         CONFIG_OPTS+=("--enable-address-sanitizer=yes")
     fi
+
+    CONFIG_OPTS_COMMON=$CONFIG_OPTS
+    CONFIG_OPTS+=("--with-docs=no")
 
     # Clone and build dependencies, if not yet installed to Travis env as DEBs
     # or MacOS packages; other OSes are not currently supported by Travis cloud
@@ -398,6 +408,10 @@ default|default-Werror|valgrind)
     echo "`date`: INFO: Starting build of currently tested project with DRAFT APIs..."
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
+    if [ "$BUILD_TYPE" = "default-with-docs" ]; then
+        CONFIG_OPTS=$CONFIG_OPTS_COMMON
+        CONFIG_OPTS+=("--with-docs=yes")
+    fi
     # Only use --enable-Werror on projects that are expected to have it
     # (and it is not our duty to check prerequisite projects anyway)
     CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -58,62 +58,7 @@ env:
 #   - BUILD_TYPE=android
 #   - BUILD_TYPE=check-py
 
-matrix:
-  include:
-  - env: BUILD_TYPE=valgrind
-    os: linux
-    dist: trusty
-    addons:
-      apt:
-        sources:
-        - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
-          key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
-        packages:
-        - valgrind
-.      for use
-.         if defined (use.debian_name)
-.             if !(use.debian_name = '')
-        - $(use.debian_name)
-.             else
-.                 echo "WARNING: debian_name=='' for $(use.project) - not added to .travis.yml"
-.             endif
-.         elsif defined (use.libname)
-        - $(string.replace (use.libname, "_|-"):lower)-dev
-.         else
-        - $(string.replace (use.project, "_|-"))-dev
-.         endif
-.      endfor
-  - env: BUILD_TYPE=default ADDRESS_SANITIZER=enabled
-    os: linux
-    dist: trusty
-    addons:
-      apt:
-        sources:
-        - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
-          key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
-        packages:
-.      for use
-.         if defined (use.debian_name)
-.             if !(use.debian_name = '')
-        - $(use.debian_name)
-.             else
-.                 echo "WARNING: debian_name=='' for $(use.project) - not added to .travis.yml"
-.             endif
-.         elsif defined (use.libname)
-        - $(string.replace (use.libname, "_|-"):lower)-dev
-.         else
-        - $(string.replace (use.project, "_|-"))-dev
-.         endif
-.      endfor
-
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/ ./'
-      key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/Release.key'
-    packages:
-    - asciidoc
-    - xmlto
+pkg_deps_prereqs: &pkg_deps_prereqs
 .      for use
 .         if defined (use.debian_name)
 .             if !(use.debian_name = '')
@@ -127,6 +72,52 @@ addons:
     - $(string.replace (use.project, "_|-"))-dev
 .         endif
 .      endfor
+
+pkg_deps_doctools: &pkg_deps_doctools
+    - asciidoc
+    - xmlto
+
+pkg_deps_doctools: &pkg_deps_devtools
+    - git
+
+pkg_src_zeromq_ubuntu12: &pkg_src_zeromq_ubuntu12
+- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/ ./'
+  key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/Release.key'
+
+pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
+- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
+  key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
+
+addons:
+  apt:
+    sources:
+      <<: *pkg_src_zeromq_ubuntu12
+    packages: &pkg_deps_common
+    - *pkg_deps_devtools
+    - *pkg_deps_doctools
+    - *pkg_deps_prereqs
+
+matrix:
+  include:
+  - env: BUILD_TYPE=valgrind
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          <<: *pkg_src_zeromq_ubuntu14
+        packages:
+        - valgrind
+        - *pkg_deps_common
+  - env: BUILD_TYPE=default ADDRESS_SANITIZER=enabled
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          <<: *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -168,7 +168,8 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
-if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ "$BUILD_TYPE" == "valgrind" ]; then
+case "$BUILD_TYPE" in
+default|default-Werror|valgrind)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -462,12 +463,14 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         echo "CCache stats after build:"
         ccache -s
     fi
-
-elif [ "$BUILD_TYPE" == "bindings" ]; then
+    ;;
+bindings)
     pushd "./bindings/${BINDING}" && ./ci_build.sh
-else
+    ;;
+*)
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="\$(dirs -l +1)" ./ci_build.sh
-fi
+    ;;
+esac
 .close
 .chmod_x ("ci_build.sh")
 .directory.create ("builds/check_zproject")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -120,8 +120,8 @@ matrix:
         - *pkg_deps_common
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi
-- if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "valgrind" ] ; then brew install valgrind ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install binutils ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew install valgrind ; fi
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -98,6 +98,14 @@ addons:
 
 matrix:
   include:
+  - env: BUILD_TYPE=default-with-docs
+    os: linux
+    addons:
+      apt:
+        sources: *pkg_src_zeromq_ubuntu12
+        packages:
+        - *pkg_deps_common
+        - *pkg_deps_doctools
   - env: BUILD_TYPE=valgrind
     os: linux
     dist: trusty
@@ -115,14 +123,6 @@ matrix:
         sources: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_common
-  - env: BUILD_TYPE=default-with-docs
-    os: linux
-    addons:
-      apt:
-        sources: *pkg_src_zeromq_ubuntu12
-        packages:
-        - *pkg_deps_common
-        - *pkg_deps_doctools
 
 before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install binutils ; fi

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -89,6 +89,8 @@ pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
 
 # Note: refer to ubuntu14 if you use dist==Trusty
+# Also note that as of early 2017, either dist==trusty or services==docker
+# is needed for C++11 support; docker envs are usually faster to start up
 addons:
   apt:
     sources: *pkg_src_zeromq_ubuntu12

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -88,10 +88,10 @@ pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
 - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
 
+# Note: refer to ubuntu14 if you use dist==Trusty
 addons:
   apt:
-    sources:
-      <<: *pkg_src_zeromq_ubuntu12
+    sources: *pkg_src_zeromq_ubuntu12
     packages: &pkg_deps_common
     - *pkg_deps_devtools
     - *pkg_deps_prereqs
@@ -103,8 +103,7 @@ matrix:
     dist: trusty
     addons:
       apt:
-        sources:
-          <<: *pkg_src_zeromq_ubuntu14
+        sources: *pkg_src_zeromq_ubuntu14
         packages:
         - valgrind
         - *pkg_deps_common
@@ -113,16 +112,14 @@ matrix:
     dist: trusty
     addons:
       apt:
-        sources:
-          <<: *pkg_src_zeromq_ubuntu14
+        sources: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_common
   - env: BUILD_TYPE=default-with-docs
     os: linux
     addons:
       apt:
-        sources:
-          <<: *pkg_src_zeromq_ubuntu12
+        sources: *pkg_src_zeromq_ubuntu12
         packages:
         - *pkg_deps_common
         - *pkg_deps_doctools

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -20,14 +20,28 @@ register_target ("travis", "Travis CI scripts")
 # This is a skeleton created by zproject.
 # You can add hand-written code here.
 
-language: c
+language:
+- c
 
-cache: ccache
+cache:
+- ccache
 
 os:
 - linux
 
+# Note: some packages or dependencies may require extended permissions
+# which take longer to set up and boot. If your project does not build
+# in the default container with sudo==false, consider requiring a docker
+# image and/or a newer Ubuntu Trusty baseline VM, by uncommenting below.
+# See the current docs on http://travis-ci.org for up-to-date options.
 sudo: false
+#sudo: required
+
+#dist:
+#- trusty
+
+#services:
+#- docker
 
 # Set CI_TIME=true to enable build-step profiling in Travis
 # Set CI_TRACE=true to enable shell script tracing in Travis


### PR DESCRIPTION
Solution: DRY is good. Don't WET yourself (especially if manually). Use YAML references to define and maintain just once the list of dependency packages and their repos (e.g. OBSed ones from zeromq ecosystem).

Also made default builds docless (so no overhead of installing doc generation packages as well as running them), while a build with docs is handled separately - and earlier in the matrix chain, so overall the build does not wait for it alone to finish.

Example victim file: https://github.com/jimklimov/fty-proto/blob/test-yaml-refs/.travis.yml