### PR TITLE
problem: makefile missing bindings directory inclusion for dist

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1398,6 +1398,9 @@ EXTRA_DIST += \\
 endif
 
 EXTRA_DIST += \\
+.if file.exists ("bindings")
+    bindings \\
+.endif
 .for extra
     src/$(extra.name) \\
 .endfor


### PR DESCRIPTION
solution: add a check for the bindings directory and include it if it exists (i think it exists always? but not sure)

this way make dist will include the bindings as part of the official distribution, rather than having to grap the source from GH (or other).

this may enable things like '--enable-binding=python|java|etc' which would install the relevant bindings too (future PRs).