### PR TITLE
Add VERSION property and fix SOVERSION value

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -240,9 +240,19 @@ set_target_properties($(project.linkname)
 )
 set_target_properties ($(project.linkname)
 .if defined (project->abi)
-    PROPERTIES SOVERSION "$(project->abi.current - project->abi.age).$(project->abi.age).$(project->abi.revision)"
+    PROPERTIES SOVERSION "$(project->abi.current - project->abi.age)"
 .else
-    PROPERTIES SOVERSION "0.0.0"
+    PROPERTIES SOVERSION "0"
+.endif
+)
+target_link_libraries($(project.linkname)
+    ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES}
+)
+set_target_properties ($(project.linkname)
+.if defined (project->version)
+    PROPERTIES VERSION "$(project->version.major).$(project->version.minor).$(project->version.patch)"
+.else
+    PROPERTIES VERSION "0.0.0"
 .endif
 )
 target_link_libraries($(project.linkname)


### PR DESCRIPTION
Related to #907 

From different sources it seems that SOVERSION should be only one number(abi?) and VERSION should be major.minor.patch

http://pusling.com/blog/?p=352
https://cmake.org/pipermail/cmake/2012-September/051902.html
https://gitlab.cern.ch/dss/eos/commit/18ff0746ff4bc1263648fe3fdda79075ce262093