### PR TITLE
Problem: JNI singleton methods aren't static

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -772,7 +772,7 @@ implements AutoCloseable\
         self = pointer;
     }
 .       else
-    public $(->return.jni_java_type:) $(jni_name:) ($(jni_method_signature:)) {
+    public $(static) $(->return.jni_java_type:) $(jni_name:) ($(jni_method_signature:)) {
         return new $(->return.type:pascal) (__$(name:camel) ($(jni_shim_invocation_java:)));
     }
 .       endif

--- a/zproject_java_lib.gsl
+++ b/zproject_java_lib.gsl
@@ -145,12 +145,14 @@ function resolve_method (method)
 
     my.method.jni_method_signature = ""
     if my.method.singleton = 1
+        my.method.static = "static"
         my.method.jni_shim_signature_java = ""
         my.method.jni_shim_signature_c = ""
         my.method.jni_shim_invocation_java = ""
         my.method.jni_native_invocation_c = ""
         comma = ""
     else
+        my.method.static = ""
         my.method.jni_shim_signature_java = "long self"
         my.method.jni_shim_signature_c = "jlong self"
         my.method.jni_shim_invocation_java = "self"


### PR DESCRIPTION
Solution: Make the template functionality match the basic idea from
the python bindings.

This addresses https://github.com/zeromq/zproject/issues/909