### PR TITLE
Problem: NodeJS generation fails due to undefined dereference

### DIFF
--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -701,7 +701,7 @@ Methods:
 
 ```
 .       if count (method.return)
-.           if $(->return.is_object)
+.           if method.return.is_object ?= 1 & $(->return.is_object)
 $(->return.type:Pascal) \
 .           else
 $(->return.type:) \


### PR DESCRIPTION
Solution: use ?= comparator to account for the case where the
variable is not defined before dereferencing it