### PR TITLE
Problem: needless blank lines added to re-generated specfiles

### DIFF
--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -48,10 +48,18 @@ zproject project.
 
 
 %prep
+#FIXME: %{error:...} did not worked for me
+%if %{with python_cffi}
+%if %{without drafts}
+echo "FATAL: python_cffi not yet supported w/o drafts"
+exit 1
+%endif
+%endif
+
 %setup -q
 
 %build
-sh autogen.sh
+[ -f autogen.sh ] && sh autogen.sh
 %{configure} --enable-drafts=%{DRAFTS}
 make %{_smp_mflags}
 

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -42,16 +42,16 @@ register_target ("redhat", "packaging for RedHat")
 .   if !has_main & !project.exports_classes
 %global debug_package %{nil}
 .   endif
-
 .if python_cffi ?= 1
+
 # build with python_cffi support enabled
 %bcond_with python_cffi
 %if %{with python_cffi}
 %define py2_ver %(python2 -c "import sys; print ('%d.%d' % (sys.version_info.major, sys.version_info.minor))")
 %define py3_ver %(python3 -c "import sys; print ('%d.%d' % (sys.version_info.major, sys.version_info.minor))")
 %endif
-.endif
 
+.endif
 Name:           $(project.name)
 Version:        $(project->version.major).$(project->version.minor).$(project->version.patch)
 Release:        1
@@ -183,8 +183,8 @@ This package contains development files for $(project.name): $(project.descripti
 .      endif
 .   endfor
 .endif
-
 .if python_cffi ?= 1
+
 %if %{with python_cffi}
 %package -n python2-$(project.name)_cffi
 Group:  Python
@@ -231,8 +231,8 @@ exit 1
 %{configure} --enable-drafts=%{DRAFTS}
 .endif
 make %{_smp_mflags}
-
 .if python_cffi ?= 1
+
 %if %{with python_cffi}
 # Problem: we need pkg-config points to built and not yet installed copy of czmq
 # Solution: chicken-egg problem - let's make "fake" pkg-config file
@@ -260,8 +260,8 @@ export PKG_CONFIG_PATH=`pwd`
 python2 setup.py install --root=%{buildroot} --skip-build --prefix %{_prefix}
 python3 setup.py install --root=%{buildroot} --skip-build --prefix %{_prefix}
 %endif
-.endif
 
+.endif
 .if has_main | count(project.bin) > 0
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
Solution: rearrange GSL code to not add the lines, regenerate zproject

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Follow-up for #917, should also fix the travis builds broken by merging that PR (due to not regenerated zproject)