### PR TITLE
Problem: in specfiles, autogen.sh is no longer required?

### DIFF
--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -59,7 +59,7 @@ exit 1
 %setup -q
 
 %build
-[ -f autogen.sh ] && sh autogen.sh
+sh autogen.sh
 %{configure} --enable-drafts=%{DRAFTS}
 make %{_smp_mflags}
 

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -224,7 +224,7 @@ exit 1
 %setup -q
 
 %build
-[ -f autogen.sh ] && sh autogen.sh
+sh autogen.sh
 .if systemd ?= 1
 %{configure} --enable-drafts=%{DRAFTS} --with-systemd-units
 .else


### PR DESCRIPTION
Solution: fix the apparent typo/experimentation that was committed

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Follow-up for #917