### PR TITLE
Problem: Debian nodoc build fails due to missing manpages

### DIFF
--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -51,6 +51,11 @@
   </service>
   <service name="extract_file">
     <param name="archive">*.tar</param>
+    <param name="files">*/packaging/debian/zproject.manpages</param>
+    <param name="outfilename">debian.zproject.manpages</param>
+  </service>
+  <service name="extract_file">
+    <param name="archive">*.tar</param>
     <param name="files">*/packaging/debian/format</param>
     <param name="outfilename">debian.format</param>
   </service>

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -304,14 +304,15 @@ override_dh_auto_configure:
 .chmod_x ("packaging/debian/rules")
 .discover_manpages(project)
 .if project.has_main | count(project.bin) > 0
+.   output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).manpages")
+.   for project.main where scope = "public" & project.has_main & man1 ?<> ""
+usr/share/man/man1/$(main.name).1
+.   endfor
 .   output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).install")
 .# generate binary names
 .   for project.main where scope = "public"
 .       if project.has_main
 usr/bin/$(main.name)
-.          if man1 ?<> ""
-usr/share/man/man1/$(main.name).1
-.          endif
 .       endif
 .   endfor
 .   for project.bin
@@ -370,6 +371,7 @@ usr/lib/*/pkgconfig/$(project.libname).pc
 .   if count (class, defined (class.api))
 usr/share/zproject
 .   endif
+.   output ("packaging/debian/$(string.replace (project.libname, "_|-"))-dev.manpages")
 .   if man3 ?<> ""
 usr/share/man/man3/*
 .   endif

--- a/zproject_obs.gsl
+++ b/zproject_obs.gsl
@@ -68,6 +68,11 @@ register_target ("obs", "service for Open Build Service")
     <param name="files">*/packaging/debian/$(string.replace (project.name, "_|-"):lower).install</param>
     <param name="outfilename">debian.$(string.replace (project.name, "_|-"):lower).install</param>
   </service>
+  <service name="extract_file">
+    <param name="archive">*.tar</param>
+    <param name="files">*/packaging/debian/$(string.replace (project.name, "_|-"):lower).manpages</param>
+    <param name="outfilename">debian.$(string.replace (project.name, "_|-"):lower).manpages</param>
+  </service>
 .   endif
   <service name="extract_file">
     <param name="archive">*.tar</param>
@@ -84,6 +89,11 @@ register_target ("obs", "service for Open Build Service")
     <param name="archive">*.tar</param>
     <param name="files">*/packaging/debian/$(string.replace (project.libname, "_|-"))-dev.install</param>
     <param name="outfilename">debian.$(string.replace (project.libname, "_|-"))-dev.install</param>
+  </service>
+  <service name="extract_file">
+    <param name="archive">*.tar</param>
+    <param name="files">*/packaging/debian/$(string.replace (project.libname, "_|-"))-dev.manpages</param>
+    <param name="outfilename">debian.$(string.replace (project.libname, "_|-"))-dev.manpages</param>
   </service>
 .   endif
   <service name="extract_file">


### PR DESCRIPTION
Solution: use dh_installman for manpages instead of dh_install, so
that the build options and profiles are automatically taken into
account.

Also regenerate.