### PR TITLE
Problem: python package name has underscores only since f901cb9

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -195,8 +195,8 @@ Requires:  python = %{py2_ver}
 This package contains Python CFFI bindings for $(project.name)
 
 %files -n python2-$(project.name)_cffi
-%{_libdir}/python%{py2_ver}/site-packages/$(project.name)_cffi/
-%{_libdir}/python%{py2_ver}/site-packages/$(project.name)_cffi-*-py%{py2_ver}.egg-info/
+%{_libdir}/python%{py2_ver}/site-packages/$(project.name:c)_cffi/
+%{_libdir}/python%{py2_ver}/site-packages/$(project.name:c)_cffi-*-py%{py2_ver}.egg-info/
 
 %package -n python3-$(project.name)_cffi
 Group:  Python
@@ -207,8 +207,8 @@ Requires:  python3 = %{py2_ver}
 This package contains Python 3 CFFI bindings for $(project.name)
 
 %files -n python3-$(project.name)_cffi
-%{_libdir}/python%{py3_ver}/site-packages/$(project.name)_cffi/
-%{_libdir}/python%{py3_ver}/site-packages/$(project.name)_cffi-*-py%{py3_ver}.egg-info/
+%{_libdir}/python%{py3_ver}/site-packages/$(project.name:c)_cffi/
+%{_libdir}/python%{py3_ver}/site-packages/$(project.name:c)_cffi-*-py%{py3_ver}.egg-info/
 %endif
 .endif
 


### PR DESCRIPTION
Solution: fix paths in redhat packaging

@bluca - I did not find a similar section for Debian packaging. I'll let you to handle it ;-)