### PR TITLE
Problem: can't import cffi bindings in python3

### DIFF
--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -48,13 +48,6 @@ zproject project.
 
 
 %prep
-#FIXME: %{error:...} did not worked for me
-%if %{with python_cffi}
-%if %{without drafts}
-echo "FATAL: python_cffi not yet supported w/o drafts"
-exit 1
-%endif
-%endif
 
 %setup -q
 

--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -80,11 +80,11 @@ function generate_binding
     output "bindings/python_cffi/$(project.name:c)_cffi/__init__.py"
     >$(project.GENERATED_WARNING_HEADER:)
     >try:
-    >    import native
+    >    from . import native
     >    lib = native.lib
     >    ffi = native.ffi
     >except ImportError:
-    >    import dlopen
+    >    from . import dlopen
     >    lib = dlopen.lib
     >    ffi = dlopen.ffi
     >


### PR DESCRIPTION
Solution: use absolute import for dlopen/native