### PR TITLE
Problem: you cannot mix two ffi instances in one call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ foreach(TEST_CLASS ${TEST_CLASSES})
     add_test(
         NAME ${TEST_CLASS}
         COMMAND zproject_selftest --continue --verbose --test ${TEST_CLASS}
+        WORKING_DIRECTORY ${SOURCE_DIR}
     )
     set_tests_properties(
         ${TEST_CLASS}

--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -234,6 +234,16 @@ function generate_binding
     ># Custom setup for $(project.name)
     >$(file.slurp('src/python_cffi.inc')?'')
     >
+    >#Import definitions from dependent projects
+    for project.use
+        if file.exists ('../$(use.project:c)/bindings/python_cffi/$(use.project:c)_cffi/cdefs.py')
+    >$(use.project:c)_slurp = """$(file.slurp('../$(use.project:c)/bindings/python_cffi/$(use.project:c)_cffi/cdefs.py'))"""
+    >gl = {}
+    >exec ($(use.project:c)_slurp, gl)
+    >$(project.name:c)_cdefs.extend (gl ["$(use.project:c)_cdefs"])
+    >
+        endif
+    endfor
     >
     >$(project.name:c)_cdefs.append ('''
     for project->python_types.type as t
@@ -285,8 +295,22 @@ function generate_binding
     >
     >    python setup.py build
     >
-    >Note you need to have setuptools and cffi packages installed.
+    >Note you need to have setuptools and cffi packages installed. As well as a checkout of all dependencies
+    >at the same level as this project, because all dependant defs.py will be included in project cdefs.py.
     >
+    >#Using more cffi modules together
+    >While zproject and CLASS encourages you to split your dependencies to smaller libraries, this does
+    >not work well for cffi. zproject generated backends have own private cffi instance, which can't
+    >be easily combined with others in one function call.
+    >
+    >See ML thread about topic https://groups.google.com/forum/#!topic/python-cffi/JtAKU-g9Exg
+    >
+    >The solution is to include all the definitions of dependant modules, so we will have an access
+    >to underlying functions directly from top level module. It is a sort of static linking, but
+    >the only way to ensure the cffi bindings will work accross multiple C libraries. And this is the
+    >reason you need to have a checkout at the same level as the project.
+    >
+    >The advantage is there are no python dependencies between modules.
 endfunction
 
     if count (class, defined (class.api) & class.private = "0")


### PR DESCRIPTION
Solution: let the upper module contains the definitions of all dependant ones.

TL;DR;
The original error code was

    TypeError: initializer for ctype 'struct _mlm_client_t *' appears indeed to
    be 'struct _mlm_client_t *', but the types are different (check that you are
    not e.g. mixing up d ifferent ffi instances)

The point is that every $(project) defines own ffi instance, which sadly can't
be mixed in one function call.

    client = mlm_cffi.lib.mlm_client_new ()
    msg = zm_proto_cffi.lib.zm_proto_new ()
    zm_proto_cffi.lib.zm_proto_recv (msg, client)

zm_proto_recv works with two declarations of mlm_client_t and thus fails. The
problem is that every cffi module must be self-contained, so all types must be
resolved. Proposed solution is kind of static linking, but it have two advantages

1. following code works

    client = zm_proto.lib.mlm_client_new ()
    msg = zm_proto_cffi.lib.zm_proto_new ()
    zm_proto_cffi.lib.zm_proto_recv (msg, client)

2. there is no need to add python dependencies to python2-zm-proto-cffi package