### PR TITLE
Allow private/protected methods in public classes

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -438,6 +438,23 @@ typedef struct _$(class.c_name)_t $(class.c_name)_t;
 .endfor
 
 //  Internal API
+.for class where scope = "public"
+.   visibility = "$(PROJECT.PREFIX)_PRIVATE"
+.   for class.method where private
+//  $(method.description:no,block)
+.       if method->return.fresh
+//  Caller owns return value and must destroy it when done.
+.       endif
+$(VISIBILITY) $(c_method_signature (method):)\
+.       if defined(method.format_index)
+ CHECK_PRINTF ($(method.format_index));
+.       else
+;
+.       endif
+
+.   endfor
+.endfor
+
 .for class where scope = "private"
 #include "$(class.c_name).h"
 .endfor
@@ -545,7 +562,7 @@ $(VISIBILITY) void
     $(actor.name:c) (zsock_t *pipe, void *args);
 
 .   endfor
-.   for class.method where draft = my.draft
+.   for class.method where draft = my.draft & !private
 .       method_state_comment (state)
 //  $(method.description:no,block)
 .       if method->return.fresh

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -225,6 +225,7 @@ function resolve_c_method (method, default_description)
     my.method.is_constructor ?= 0
     my.method.is_destructor ?= 0
     my.method.polymorphic ?= 0
+    my.method.private ?= 0
 
     # Resolve language-specific attributes for the C language.
     my.method.c_name ?= "$(my.method.name:c)"


### PR DESCRIPTION
**Problem: Cannot define private methods in the API**
I would like to be able to define methods as private, in public classes.
The idea would be to have something package-private methods, like in Java. 

**Solution: Write private methods into project_classes.h**

The XML definition would look something like this:
```
<class name="my public class">
  <method name="public method">
    Does stuff anyone is allowed to do
   <return type="nothing"/>
  </method>
 <method name="private method" private = "1">
   Does stuff only part of the library is allowed to do
   <return type="nothing"/>
 </method>
</class
```


