### PR TITLE
Problem: debian copyright output is in wrong format

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -7,7 +7,7 @@ License: zproject_license
  Copyright (c) the Contributors as noted in the AUTHORS file.       
  This file is part of CZMQ, the high-level C binding for 0MQ:       
  http://czmq.zeromq.org.                                            
-                                                                    
+ .                                                                  
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at http://mozilla.org/MPL/2.0/.           

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -190,7 +190,7 @@ Files: *
 Copyright: 2015- $(project.name) Developers <$(project.email)>
 License: $(project.name)_license
 .   for project.license
- $(string.trim (license.):block                                         )
+ $(string.search_replace(string.trim (license.), '\n\n', '\n.\n'):block)
 .   endfor
 .output "packaging/debian/format"
 3.0 (quilt)


### PR DESCRIPTION
Solution: fix it so that empty lines in the license block are changed
to a space and a dot as per policy and regenerate