### PR TITLE
problem: vagrant gsl contains out of date repo and too little memory for newer versions of zmq

### DIFF
--- a/zproject_vagrant.gsl
+++ b/zproject_vagrant.gsl
@@ -20,7 +20,6 @@ register_target ("vagrant", "packaging for Vagrant")
 # This will setup a clean Ubuntu1404 LTS env
 
 $script = <<SCRIPT
-add-apt-repository ppa:fkrull/deadsnakes-python2.7
 apt-get update
 apt-get install -y python-pip python-dev git htop virtualenvwrapper python2.7 python-virtualenv python-support cython \\
 git build-essential libtool pkg-config autotools-dev autoconf automake cmake uuid-dev libpcre3-dev valgrind \\
@@ -70,7 +69,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", inline: $script
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "2", "--ioapic", "on", "--memory", "512" ]
+    vb.customize ["modifyvm", :id, "--cpus", "2", "--ioapic", "on", "--memory", "1024" ]
   end
 
   if File.file?(VAGRANTFILE_LOCAL)


### PR DESCRIPTION
solution: removing old [python] deadsnakes apt repo, defaulting mem to 1024 from 512