### PR TITLE
Problems: Selftest can fail due to dirty previous runs

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -65,7 +65,10 @@ dist_bin_SCRIPTS = \
 SELFTEST_DIR_RO = src/selftest-ro
 SELFTEST_DIR_RW = src/selftest-rw
 
+# This is recreated on every invocation (as a selftest dependency),
+# so tests run in a clean environment
 $(abs_top_builddir)/$(SELFTEST_DIR_RW):
+	rm -rf "$@"
 	mkdir -p "$@"
 
 $(abs_top_builddir)/$(SELFTEST_DIR_RO): $(abs_top_srcdir)/$(SELFTEST_DIR_RO)
@@ -100,11 +103,22 @@ clean-local-selftest-rw:
 		fi; \
 	fi
 
+check-empty-selftest-rw:
+	if test -e $(abs_top_builddir)/$(SELFTEST_DIR_RW) ; then \
+		if test `find "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" | wc -l` -lt 1 ; then \
+			echo "FATAL: selftest did not tidy up the data it wrote" >&2 ; \
+			find "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" ; \
+			exit 2; \
+		else true ; fi; \
+	else true ; fi
+
 check-local: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute $(builddir)/src/zproject_selftest
+	$(MAKE) check-empty-selftest-rw
 
 check-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute $(builddir)/src/zproject_selftest -v
+	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for memory leaks
 memcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
@@ -112,20 +126,43 @@ memcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
 		$(builddir)/src/zproject_selftest
+	$(MAKE) check-empty-selftest-rw
+
+memcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
+		--leak-check=full --show-reachable=yes --error-exitcode=1 \
+		--suppressions=$(srcdir)/src/.valgrind.supp \
+		$(builddir)/src/zproject_selftest -v
+	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
 		$(builddir)/src/zproject_selftest
+	$(MAKE) check-empty-selftest-rw
+
+callcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
+		$(builddir)/src/zproject_selftest -v
+	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under gdb for debugging
 debug: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute gdb -q \
 		$(builddir)/src/zproject_selftest
+	$(MAKE) check-empty-selftest-rw
+
+debug-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+	$(LIBTOOL) --mode=execute gdb -q \
+		$(builddir)/src/zproject_selftest -v
+	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary with verbose switch for tracing
 animate: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute $(builddir)/src/zproject_selftest -v
+	$(MAKE) check-empty-selftest-rw
+
+animate-verbose: animate
 
 if WITH_GCOV
 coverage: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1732,11 +1732,22 @@ clean-local-selftest-rw:
 \t\tfi; \\
 \tfi
 
+check-empty-selftest-rw:
+\tif test -e $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) ; then \\
+\t\tif test `find "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" | wc -l` -lt 1 ; then \\
+\t\t\techo "FATAL: selftest did not tidy up the data it wrote" >&2 ; \\
+\t\t\tfind "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
+\t\t\texit 2; \\
+\t\telse true ; fi; \\
+\telse true ; fi
+
 check-local: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest
+\t$\(MAKE) check-empty-selftest-rw
 
 check-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest -v
+\t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for memory leaks
 memcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
@@ -1744,34 +1755,41 @@ memcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW
 \t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
+\t$\(MAKE) check-empty-selftest-rw
 
 memcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 \t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
+\t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
+\t$\(MAKE) check-empty-selftest-rw
 
 callcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
+\t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under gdb for debugging
 debug: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute gdb -q \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
+\t$\(MAKE) check-empty-selftest-rw
 
 debug-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute gdb -q \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
+\t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary with verbose switch for tracing
 animate: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest -v
+\t$\(MAKE) check-empty-selftest-rw
 
 animate-verbose: animate
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1745,19 +1745,35 @@ memcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 
+memcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+\t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
+\t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
+\t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
+\t\t$\(builddir)/src/$(project.prefix)_selftest -v
+
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
+
+callcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+\t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
+\t\t$\(builddir)/src/$(project.prefix)_selftest -v
 
 # Run the selftest binary under gdb for debugging
 debug: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute gdb -q \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 
+debug-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+\t$\(LIBTOOL) --mode=execute gdb -q \\
+\t\t$\(builddir)/src/$(project.prefix)_selftest -v
+
 # Run the selftest binary with verbose switch for tracing
 animate: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest -v
+
+animate-verbose: animate
 
 if WITH_GCOV
 coverage: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1694,7 +1694,10 @@ code:
 SELFTEST_DIR_RO = src/selftest-ro
 SELFTEST_DIR_RW = src/selftest-rw
 
+# This is recreated on every invocation (as a selftest dependency),
+# so tests run in a clean environment
 $\(abs_top_builddir)/$\(SELFTEST_DIR_RW):
+\trm -rf "\$@"
 \tmkdir -p "\$@"
 
 $\(abs_top_builddir)/$\(SELFTEST_DIR_RO): $\(abs_top_srcdir)/$\(SELFTEST_DIR_RO)

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -433,7 +433,9 @@ default|default-Werror|default-with-docs|valgrind)
     $CI_TIME ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
     if [ "$BUILD_TYPE" == "valgrind" ] ; then
         # Build and check this project
-        $CI_TIME make VERBOSE=1 memcheck
+        $CI_TIME make VERBOSE=1 memcheck && exit
+        echo "Re-running failed ($?) memcheck with greater verbosity" >&2
+        $CI_TIME make VERBOSE=1 memcheck-verbose
         exit $?
     fi
     $CI_TIME make VERBOSE=1 all


### PR DESCRIPTION
Solutions: several improvements for `selftest-rw` directory support, and to re-run memcheck verbosely if it originally failed in travis.