### PR TITLE
Problem: string concatenation for selftest dir usage

### DIFF
--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -301,6 +301,7 @@ $(actor.name:c)_test (bool verbose)
     printf (" * $(actor.name:c): ");
     //  @selftest
     //  Simple create/destroy test
+
     // Note: If your selftest reads SCMed fixture data, please keep it in
     // src/selftest-ro; if your test creates filesystem objects, please
     // do so under src/selftest-rw. They are defined below along with a
@@ -309,6 +310,14 @@ $(actor.name:c)_test (bool verbose)
     const char *SELFTEST_DIR_RW = "src/selftest-rw";
     assert (SELFTEST_DIR_RO);
     assert (SELFTEST_DIR_RW);
+    // The following pattern is suggested for C selftest code:
+    //    char *filename = NULL;
+    //    filename = zsys_sprintf ("%s/%s", SELFTEST_DIR_RO, "mytemplate.file");
+    //    assert (filename);
+    //    ... use the filename for I/O ...
+    //    zstr_free (&filename);
+    // This way the same filename variable can be reused for many subtests.
+    //
     // Uncomment these to use C++ strings in C++ selftest code:
     //std::string str_SELFTEST_DIR_RO = std::string(SELFTEST_DIR_RO);
     //std::string str_SELFTEST_DIR_RW = std::string(SELFTEST_DIR_RW);
@@ -469,6 +478,14 @@ $(class.c_name)_test (bool verbose)
     const char *SELFTEST_DIR_RW = "src/selftest-rw";
     assert (SELFTEST_DIR_RO);
     assert (SELFTEST_DIR_RW);
+    // The following pattern is suggested for C selftest code:
+    //    char *filename = NULL;
+    //    filename = zsys_sprintf ("%s/%s", SELFTEST_DIR_RO, "mytemplate.file");
+    //    assert (filename);
+    //    ... use the filename for I/O ...
+    //    zstr_free (&filename);
+    // This way the same filename variable can be reused for many subtests.
+    //
     // Uncomment these to use C++ strings in C++ selftest code:
     //std::string str_SELFTEST_DIR_RO = std::string(SELFTEST_DIR_RO);
     //std::string str_SELFTEST_DIR_RW = std::string(SELFTEST_DIR_RW);


### PR DESCRIPTION
Solution: zproject_skeletons.gsl updated with example pattern on using SELFTEST_DIR_R[OW] to create the filename strings.