### PR TITLE
Problem: CCACHE_DIR scripting can be improved

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -205,12 +205,12 @@ default|default-Werror|default-with-docs|valgrind)
     if which ccache && ls -la /usr/lib/ccache ; then
         HAVE_CCACHE=yes
     fi
+    mkdir -p "${CCACHE_DIR}" || HAVE_CCACHE=no
 
     if [ "$HAVE_CCACHE" = yes ] && [ -d "$CCACHE_DIR" ]; then
         echo "CCache stats before build:"
         ccache -s || true
     fi
-    mkdir -p "${HOME}/.ccache"
 
     CONFIG_OPTS=()
     COMMON_CFLAGS=""


### PR DESCRIPTION
zproject_travis.gsl : inability to make the CCACHE_DIR precludes its usability. Also avoid naming this path in two different ways that can diverge in the future.