### PR TITLE
from ctypes.util import find_library

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -204,6 +204,7 @@ function generate_binding
     >from __future__ import print_function
     >import os
     >import sys
+    >from ctypes.util import find_library
     >
     >import cffi
     >ffi = cffi.FFI()


### PR DESCRIPTION
__Problem:__ If we are going to call `find_library()`on line 224 then we must define it first or a NameError could be raised at runtime.

__Solution:__ `from ctypes.util import find_library`  https://docs.python.org/3/library/ctypes.html#finding-shared-libraries