### PR TITLE
Py3: Use feature detection, not version detection

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -485,31 +485,20 @@ function generate_classes ()
 
     output "bindings/python_cffi/$(project.name:c)_cffi/utils.py"
     >$(project.GENERATED_WARNING_HEADER:)
-    >import sys
-    >
-    >
-    >PY2 = sys.version_info[0] == 2
-    >PY3 = sys.version_info[0] == 3
-    >
-    >
-    >if PY3:
-    >    text_type = str
-    >    binary_type = bytes
-    >else:
-    >    text_type = unicode
+    >try:
+    >    text_type = unicode  # Python 2
     >    binary_type = str
+    >except NameError:
+    >    text_type = str      # Python 3
+    >    binary_type = bytes
     >
     >
     >def to_bytes(s):
-    >    if isinstance(s, binary_type):
-    >        return s
-    >    return text_type(s).encode("utf-8")
+    >    return s if isinstance(s, binary_type) else text_type(s).encode("utf-8")
     >
     >
     >def to_unicode(s):
-    >    if isinstance(s, text_type):
-    >        return s
-    >    return binary_type(s).decode("utf-8")
+    >    return s if isinstance(s, text_type) else binary_type(s).decode("utf-8")
     >$(project.GENERATED_WARNING_HEADER:)
     close
 endfunction


### PR DESCRIPTION
__Problem:__ The current compatibility code breaks Python 3 porting guidelines by using version detection instead of feature detection.  It would for instance, would fail under Python 4 and above by treating them as if they were Python 2..

__Solution:__ Follow the Python 3 porting guide best practice: __Use feature detection instead of version detection__.

https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection