### PR TITLE
Problem: RPM builds fail on Fedora Rawhide

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -214,7 +214,7 @@ This package contains Python 3 CFFI bindings for $(project.name)
 
 %prep
 .if python_cffi ?= 1
-#FIXME: %{error:...} did not worked for me
+#FIXME: error:... did not worked for me
 %if %{with python_cffi}
 %if %{without drafts}
 echo "FATAL: python_cffi not yet supported w/o drafts"


### PR DESCRIPTION
Solution: remove commented out spec macro. RPM builds parse commented
out lines too, so macros should not be left in comments.