### PR TITLE
autotools: Introduce VALGRIND_OPTIONS variable

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -126,6 +126,7 @@ memcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top
 	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
+		$(VALGRIND_OPTIONS) \
 		$(builddir)/src/zproject_selftest
 	$(MAKE) check-empty-selftest-rw
 
@@ -133,17 +134,20 @@ memcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $
 	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
+		$(VALGRIND_OPTIONS) \
 		$(builddir)/src/zproject_selftest -v
 	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
+		$(VALGRIND_OPTIONS) \
 		$(builddir)/src/zproject_selftest
 	$(MAKE) check-empty-selftest-rw
 
 callcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
+		$(VALGRIND_OPTIONS) \
 		$(builddir)/src/zproject_selftest -v
 	$(MAKE) check-empty-selftest-rw
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1754,6 +1754,7 @@ memcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW
 \t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 \t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
+\t\t$\(VALGRIND_OPTIONS) \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 \t$\(MAKE) check-empty-selftest-rw
 
@@ -1761,17 +1762,20 @@ memcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTES
 \t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 \t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
+\t\t$\(VALGRIND_OPTIONS) \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
 \t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
+\t\t$\(VALGRIND_OPTIONS) \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 \t$\(MAKE) check-empty-selftest-rw
 
 callcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
+\t\t$\(VALGRIND_OPTIONS) \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
 \t$\(MAKE) check-empty-selftest-rw
 

--- a/zproject_bench.gsl
+++ b/zproject_bench.gsl
@@ -189,6 +189,7 @@ bench-memcheck: \$(benchmark_progs)
 \t\t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 \t\t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
+\t\t\t$\(VALGRIND_OPTIONS) \\
 \t\t\t$\(srcdir)/\$\$f; \\
 \tdone
 
@@ -196,6 +197,7 @@ bench-memcheck: \$(benchmark_progs)
 bench-callcheck: \$(benchmark_progs)
 \tfor f in \$^; do \\
 \t\t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
+\t\t\t$\(VALGRIND_OPTIONS) \\
 \t\t\t$\(srcdir)/\$\$f; \\
 \tdone
 


### PR DESCRIPTION
For a project that links with OpenSSL, I need to add
--sigill-diagnostics=no to the valgrind command line to paper over
OpenSSL triggering and handling SIGILL on arm (more details here:
https://bugs.kde.org/show_bug.cgi?id=331178). This patch adds support
for a VALGRIND_OPTIONS make variable, which can be set in
Makemodule-local.am.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>