### PR TITLE
Problem: debian packages do not build in parallel

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -47,4 +47,5 @@ override_dh_auto_configure:
 
 %:
 	dh $@ \
+		--parallel \
 		--with autoreconf

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -303,6 +303,7 @@ override_dh_auto_configure:
 .if python_cffi ?= 1
 		\$(WITH_PYTHON) \\
 .endif
+		--parallel \\
 		--with autoreconf
 .chmod_x ("packaging/debian/rules")
 .discover_manpages(project)


### PR DESCRIPTION
Solution: it does not suffice to just `export DEB_BUILD_OPTIONS=parallel=8` or `MAKEFLAGS=-j8` or call `dpkg-buildpackage -j8` ... the `dh` command in the `debian.rules` file must have the `--parallel` flag as well - according to my experiment and to https://www.linuxquestions.org/questions/linux-software-2/parallel-jobs-with-dpkg-buildpackage-4175502264/

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>