### PR TITLE
Problem: PR #982 removed usage pattern for SELFTEST_DIR_R[OW]

### DIFF
--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -298,7 +298,14 @@ $(actor.name:c)_actor (zsock_t *pipe, void *args)
 
 // If your selftest reads SCMed fixture data, please keep it in
 // src/selftest-ro; if your test creates filesystem objects, please
-// do so under src/selftest-rw. 
+// do so under src/selftest-rw.
+// The following pattern is suggested for C selftest code:
+//    char *filename = NULL;
+//    filename = zsys_sprintf ("%s/%s", SELFTEST_DIR_RO, "mytemplate.file");
+//    assert (filename);
+//    ... use the "filename" for I/O ...
+//    zstr_free (&filename);
+// This way the same "filename" variable can be reused for many subtests.
 #define SELFTEST_DIR_RO "src/selftest-ro"
 #define SELFTEST_DIR_RW "src/selftest-rw"
 
@@ -448,7 +455,14 @@ $(class.c_name)_destroy ($(class.c_name)_t **self_p)
 
 // If your selftest reads SCMed fixture data, please keep it in
 // src/selftest-ro; if your test creates filesystem objects, please
-// do so under src/selftest-rw. 
+// do so under src/selftest-rw.
+// The following pattern is suggested for C selftest code:
+//    char *filename = NULL;
+//    filename = zsys_sprintf ("%s/%s", SELFTEST_DIR_RO, "mytemplate.file");
+//    assert (filename);
+//    ... use the "filename" for I/O ...
+//    zstr_free (&filename);
+// This way the same "filename" variable can be reused for many subtests.
 #define SELFTEST_DIR_RO "src/selftest-ro"
 #define SELFTEST_DIR_RW "src/selftest-rw"
 


### PR DESCRIPTION
Solution: document back the copy-pasteable comment about constructing filename variables in tests

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>