### PR TITLE
autotools: Fix Makefile warning with make check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,9 @@ AC_SUBST(PACKAGE_VERSION)
 LTVER="0:0:0"
 AC_SUBST(LTVER)
 
+# building in a subdirectory?
+AM_CONDITIONAL([USING_VPATH], [test "x${srcdir}" != "x."])
+
 # Capture c flags
 ZPROJECT_ORIG_CFLAGS="${CFLAGS:-none}"
 

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -72,12 +72,12 @@ $(abs_top_builddir)/$(SELFTEST_DIR_RW):
 	rm -rf "$@"
 	mkdir -p "$@"
 
+if USING_VPATH
 $(abs_top_builddir)/$(SELFTEST_DIR_RO): $(abs_top_srcdir)/$(SELFTEST_DIR_RO)
-	@if test "$@" != "$<" ; then \
-		echo "    COPYDIR  $(SELFTEST_DIR_RO)"; \
-		rm -rf "$@"; \
-		cp -r "$<" "$@" ; \
-		fi
+	echo "   COPYDIR  $(SELFTEST_DIR_RO)"; \
+	rm -rf "$@"; \
+	cp -r "$<" "$@"
+endif
 
 CLEANFILES += $(abs_top_builddir)/$(SELFTEST_DIR_RW)/*
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -415,6 +415,9 @@ LTVER="0:0:0"
 .endif
 AC_SUBST(LTVER)
 
+# building in a subdirectory?
+AM_CONDITIONAL([USING_VPATH], [test "x${srcdir}" != "x."])
+
 # Capture c flags
 $(PROJECT.PREFIX)_ORIG_CFLAGS="${CFLAGS:-none}"
 
@@ -1703,12 +1706,12 @@ $\(abs_top_builddir)/$\(SELFTEST_DIR_RW):
 \trm -rf "\$@"
 \tmkdir -p "\$@"
 
+if USING_VPATH
 $\(abs_top_builddir)/$\(SELFTEST_DIR_RO): $\(abs_top_srcdir)/$\(SELFTEST_DIR_RO)
-\t@if test "$@" != "$<" ; then \\
-\t\techo "  COPYDIR  $\(SELFTEST_DIR_RO)"; \\
-\t\trm -rf "$@"; \\
-\t\tcp -r "$<" "$@" ; \\
-\t\tfi
+\techo "  COPYDIR  $\(SELFTEST_DIR_RO)"; \\
+\trm -rf "$@"; \\
+\tcp -r "$<" "$@"
+endif
 
 CLEANFILES += $\(abs_top_builddir)/$\(SELFTEST_DIR_RW)/*
 


### PR DESCRIPTION
When building in the source directory, the check target prints the
following warning:

make[2]: Circular /home/michal/GIT/zproject/src/zproject_selftest <- /home/michal/GIT/zproject/src/zproject_selftest dependency dropped.

Instead of a runtime check, use an automake conditional and disable the
rule completely when building in the source directory.