### PR TITLE
Problem: Zsys.java contains manually renamed method

### DIFF
--- a/zproject_java_lib.gsl
+++ b/zproject_java_lib.gsl
@@ -134,6 +134,7 @@ function resolve_method (method)
     |  my.method.name = "finalize" \
     |  my.method.name = "getClass" \
     |  my.method.name = "hashCode" \
+    |  my.method.name = "interface" \
     |  my.method.name = "toString" \
     |  my.method.name = "notify" \
     |  my.method.name = "notifyAll" \


### PR DESCRIPTION
Solution: add interface to list of Java keywords, which are handled by zproject generator