### PR TITLE
Problem: python cffi: generated methods for strings are not Pythonic

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -128,7 +128,22 @@ function resolve_class (class)
 endfunction
 
 function python_c_method_call (class, method)
-    my.out = "utils.lib.$(my.class.c_name)_$(my.method.c_name)("
+
+    my.out = ""
+#   handle zproto's set strings methods
+    if  (count (my.method.argument)) = 2 \
+       & !my.method.singleton \
+       & count (my.method.argument, argument.c_type?="zlist_t **")
+            echo "$(my.method.c_name): $(argument.c_type?"")"
+            my.out += "foo = utils.to_strings (argv_p)\n"
+            my.out += "        if foo is not None:\n"
+            my.out += "            foo_p = utils.ffi.new(\"struct _zlist_t *[1]\")\n"
+            my.out += "            foo_p [0] = foo\n"
+            my.out += "            utils.lib.dproto_set_argv(self._p, foo_p)\n"
+            my.out += "\n        "
+    endif
+
+    my.out += "utils.lib.$(my.class.c_name)_$(my.method.c_name)("
     for my.method.argument by argument.order
         if first() & my.method.is_constructor
             next
@@ -468,10 +483,10 @@ function generate_classes ()
             >        """
             >        $(method.description:no,block)
             >        """
-            if count (method.return)
-                >        return $(python_c_method_call (class, method))
-            else
+            if count (method.return, return.c_type="void")
                 >        $(python_c_method_call (class, method))
+            else
+                >        return $(python_c_method_call (class, method))
             endif
             >
         endfor
@@ -512,6 +527,16 @@ function generate_classes ()
     >
     >def to_unicode(s):
     >    return s if isinstance(s, text_type) else binary_type(s).decode("utf-8")
+    >
+    >
+    >def to_strings (s):
+    >    """Convert Python native list types to zlist_t of strings"""
+    >    if issubclass (s.__class__, (list, set, frozenset, tuple)):
+    >        foo = lib.zlist_new ()
+    >        for item in s:
+    >            lib.zlist_append (foo, to_bytes (item))
+    >        return foo
+    >    return None
     >$(project.GENERATED_WARNING_HEADER:)
     close
 endfunction


### PR DESCRIPTION
Solution: handle native python types for a function with two arguments (self
and zlist_t **) as zproto's strings. This allows usage of native python types.

cc: @sappo please review the approach carefully. I am not sure I got intended semantics of *generated* Python bindings well. With this patch I can simply pass high level python structures to zproto's strings field.