### PR TITLE
Problem : "make check" fails

### DIFF
--- a/src/zproject_selftest
+++ b/src/zproject_selftest
@@ -63,8 +63,8 @@ fi
 
 if [ ! -s ../config.status ] && [ -s ../config.status.pre-selftest ]; then
     echo "Restore config.status in src dir" >&2
-    mv -f ../config.status.pre-selftest ../config.status
-    chmod +x ../config.status.pre-selftest
+    mv -f ../config.status.pre-selftest ../config.status \
+    && chmod +x ../config.status
 fi
 
 make

--- a/src/zproject_selftest
+++ b/src/zproject_selftest
@@ -36,6 +36,8 @@ export PATH
 
 if [ -s Makefile ]; then
     make clean -k || true
+    cp -f Makefile Makefile.pre-selftest
+    cp -f config.status config.status.pre-selftest
     make distclean -k || true
 fi
 ./autogen.sh
@@ -53,6 +55,13 @@ cp -pf "${ABS_SRC_DIR}/src/zproject_selftest" ./src/
 #./autogen.sh
 #./configure --srcdir="$ABS_SRC_DIR"
 ../configure
+
+if [ ! -s ../Makefile ] && [ -s ../Makefile.pre-selftest ]; then
+    echo "Restore Makefile in src dir" >&2
+    cp -f ../Makefile.pre-selftest ../Makefile
+    cp -f ../config.status.pre-selftest ../config.status
+    chmod +x ../config.status.pre-selftest
+fi
 
 make
 make clean -k || true

--- a/src/zproject_selftest
+++ b/src/zproject_selftest
@@ -58,8 +58,12 @@ cp -pf "${ABS_SRC_DIR}/src/zproject_selftest" ./src/
 
 if [ ! -s ../Makefile ] && [ -s ../Makefile.pre-selftest ]; then
     echo "Restore Makefile in src dir" >&2
-    cp -f ../Makefile.pre-selftest ../Makefile
-    cp -f ../config.status.pre-selftest ../config.status
+    mv -f ../Makefile.pre-selftest ../Makefile
+fi
+
+if [ ! -s ../config.status ] && [ -s ../config.status.pre-selftest ]; then
+    echo "Restore config.status in src dir" >&2
+    mv -f ../config.status.pre-selftest ../config.status
     chmod +x ../config.status.pre-selftest
 fi
 


### PR DESCRIPTION
Solution : zproject_selftest : a required distclean during "make check" removes the parent Makefile and config.status used in the test - restore them