### PR TITLE
Problem: python cffi: garbage in zlist_t

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -533,6 +533,7 @@ function generate_classes ()
     >    """Convert Python native list types to zlist_t of strings"""
     >    if issubclass (s.__class__, (list, set, frozenset, tuple)):
     >        foo = lib.zlist_new ()
+    >        lib.zlist_autofree (foo)
     >        for item in s:
     >            lib.zlist_append (foo, to_bytes (item))
     >        return foo


### PR DESCRIPTION
Solution: set zlist_autofree, so zlist OWNs its content and Python garbage
collector does not destroy C lists.