### PR TITLE
Problem: typo in pushed zproject_jenkins.gsl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                     }
                 }
                 stage ('build with DOCS') {
-                    when { environment name:'DO_BUILD_WITH_DOCS', value:'true' }
+                    when { environment name:'DO_BUILD_DOCS', value:'true' }
                     steps {
                       dir("tmp/build-DOCS") {
                         deleteDir()

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -198,7 +198,7 @@ pipeline {
                     }
                 }
                 stage ('build with DOCS') {
-                    when { environment name:'DO_BUILD_WITH_DOCS', value:'true' }
+                    when { environment name:'DO_BUILD_DOCS', value:'true' }
 .       jenkins_agent (project, 0)
                     steps {
 .       if !(isSingle_jenkins_agent (project, 0))


### PR DESCRIPTION
Solution: Jenkinsfile zproject_jenkins.gsl : typo fix - DO_BUILD(_WITH)_DOCS - mismatched the build arg and the tested variable name