### PR TITLE
Problem: first run of a newly discovered MBP does not see build args

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
         stage ('compile') {
             parallel {
                 stage ('build with DRAFT') {
-                    when { environment name:'DO_BUILD_WITH_DRAFT_API', value:'true' }
+                    when { expression { return ( params.DO_BUILD_WITH_DRAFT_API ) } }
                     steps {
                       dir("tmp/build-withDRAFT") {
                         deleteDir()
@@ -87,7 +87,7 @@ pipeline {
                     }
                 }
                 stage ('build without DRAFT') {
-                    when { environment name:'DO_BUILD_WITHOUT_DRAFT_API', value:'true' }
+                    when { expression { return ( params.DO_BUILD_WITHOUT_DRAFT_API ) } }
                     steps {
                       dir("tmp/build-withoutDRAFT") {
                         deleteDir()
@@ -100,7 +100,7 @@ pipeline {
                     }
                 }
                 stage ('build with DOCS') {
-                    when { environment name:'DO_BUILD_DOCS', value:'true' }
+                    when { expression { return ( params.DO_BUILD_DOCS ) } }
                     steps {
                       dir("tmp/build-DOCS") {
                         deleteDir()

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -162,7 +162,7 @@ pipeline {
         stage ('compile') {
             parallel {
                 stage ('build with DRAFT') {
-                    when { environment name:'DO_BUILD_WITH_DRAFT_API', value:'true' }
+                    when { expression { return ( params.DO_BUILD_WITH_DRAFT_API ) } }
 .       jenkins_agent (project, 0)
                     steps {
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -180,7 +180,7 @@ pipeline {
                     }
                 }
                 stage ('build without DRAFT') {
-                    when { environment name:'DO_BUILD_WITHOUT_DRAFT_API', value:'true' }
+                    when { expression { return ( params.DO_BUILD_WITHOUT_DRAFT_API ) } }
 .       jenkins_agent (project, 0)
                     steps {
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -198,7 +198,7 @@ pipeline {
                     }
                 }
                 stage ('build with DOCS') {
-                    when { environment name:'DO_BUILD_DOCS', value:'true' }
+                    when { expression { return ( params.DO_BUILD_DOCS ) } }
 .       jenkins_agent (project, 0)
                     steps {
 .       if !(isSingle_jenkins_agent (project, 0))


### PR DESCRIPTION
Solution: groovy build args are available, matching envvars are not populated on the first 1-2 runs of a MultiBranch Pipeline, a known deficiency in Jenkins. So instead of when{env...} we should check when{expression...}

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>