### PR TITLE
Problem: Jenkinsfile does not cppcheck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,10 @@ pipeline {
             defaultValue: false,
             description: 'Attempt "make distcheck" in this run?',
             name: 'DO_TEST_DISTCHECK')
+        booleanParam (
+            defaultValue: false,
+            description: 'Attempt "cppcheck" analysis before this run?',
+            name: 'DO_CPPCHECK')
     }
     triggers {
         pollSCM 'H/5 * * * *'
@@ -65,6 +69,13 @@ pipeline {
 // Note: your Jenkins setup may benefit from similar setup on side of agents:
 //        PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/bin:/bin:${PATH}"
     stages {
+        stage ('cppcheck') {
+                    when { expression { return ( params.DO_CPPCHECK ) } }
+                    steps {
+                        sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
+                        archiveArtifacts artifacts: '**/cppcheck.xml'
+                    }
+        }
         stage ('prepare') {
                     steps {
                         sh './autogen.sh'

--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ zproject's `project.xml` contains an extensive description of the available conf
          That job should accept parameters DEPLOY_GIT_URL (URL of repo),
          DEPLOY_GIT_BRANCH (name for decision-making), DEPLOY_GIT_COMMIT
          (actual commit to check out and shrink-wrap into packaging.
+         The test_cppcheck is different, as it calls the "cppcheck" tool
+         which may be not installed on a particular deployment, so by
+         default this option is disabled if not set explicitly.
     <target name = "jenkins">
         <option name = "file" value = "Jenkinsfile" />
         <option name = "agent_docker" value = "zeromqorg/czmq" />
@@ -386,6 +389,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         <option name = "test_check" value = "0" />
         <option name = "test_memcheck" value = "0" />
         <option name = "test_distcheck" value = "0" />
+        <option name = "test_cppcheck" value = "1" />
     </target>
     -->
     <target name = "jenkins" >
@@ -396,6 +400,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         <option name = "test_check" value = "1" />
         <option name = "test_memcheck" value = "0" />
         <option name = "test_distcheck" value = "0" />
+        <option name = "test_cppcheck" value = "0" />
     </target>
 
     <!-- In order loaded by zproject.gsl -->

--- a/project.xml
+++ b/project.xml
@@ -200,6 +200,9 @@
          That job should accept parameters DEPLOY_GIT_URL (URL of repo),
          DEPLOY_GIT_BRANCH (name for decision-making), DEPLOY_GIT_COMMIT
          (actual commit to check out and shrink-wrap into packaging.
+         The test_cppcheck is different, as it calls the "cppcheck" tool
+         which may be not installed on a particular deployment, so by
+         default this option is disabled if not set explicitly.
     <target name = "jenkins">
         <option name = "file" value = "Jenkinsfile" />
         <option name = "agent_docker" value = "zeromqorg/czmq" />
@@ -211,6 +214,7 @@
         <option name = "test_check" value = "0" />
         <option name = "test_memcheck" value = "0" />
         <option name = "test_distcheck" value = "0" />
+        <option name = "test_cppcheck" value = "1" />
     </target>
     -->
     <target name = "jenkins" >
@@ -221,6 +225,7 @@
         <option name = "test_check" value = "1" />
         <option name = "test_memcheck" value = "0" />
         <option name = "test_distcheck" value = "0" />
+        <option name = "test_cppcheck" value = "0" />
     </target>
 
     <!-- In order loaded by zproject.gsl -->

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -144,6 +144,15 @@ pipeline {
 .  endif
             description: 'Attempt "make distcheck" in this run?',
             name: 'DO_TEST_DISTCHECK')
+        booleanParam (
+.  if ( !(defined(project.jenkins_test_cppcheck)) | (project.jenkins_test_cppcheck ?= 0) )
+. # cppcheck is an external tool that may be not installed in general case
+            defaultValue: false,
+.  else
+            defaultValue: true,
+.  endif
+            description: 'Attempt "cppcheck" analysis before this run?',
+            name: 'DO_CPPCHECK')
     }
     triggers {
         pollSCM 'H/5 * * * *'
@@ -152,6 +161,14 @@ pipeline {
 // Note: your Jenkins setup may benefit from similar setup on side of agents:
 //        PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/bin:/bin:\$\{PATH}"
     stages {
+        stage ('cppcheck') {
+                    when { expression { return ( params.DO_CPPCHECK ) } }
+.       jenkins_agent (project, 0)
+                    steps {
+                        sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
+                        archiveArtifacts artifacts: '**/cppcheck.xml'
+                    }
+        }
         stage ('prepare') {
 .       jenkins_agent (project, 0)
                     steps {


### PR DESCRIPTION
Solution: Add optional support for `cppcheck` utility to validate C/C++ codebase; feature is disabled by default since this requires a third-party tool on the Jenkins worker instance.