### PR TITLE
Fix Cygwin autotools build 'visibility attribute not supported' error

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -97,6 +97,9 @@ $(project.GENERATED_WARNING_HEADER:)
 #       define $(PROJECT.PREFIX)_EXPORT __declspec(dllimport)
 #   endif
 #   define $(PROJECT.PREFIX)_PRIVATE
+#elif defined (__CYGWIN__)
+#   define $(PROJECT.PREFIX)_EXPORT
+#   define $(PROJECT.PREFIX)_PRIVATE
 #else
 #   define $(PROJECT.PREFIX)_EXPORT
 #   if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER


### PR DESCRIPTION
Visibility attribute "hidden" is not supported by Windows executables.

Signed-off-by: Pedro Luis Castedo Cepeda <pedroluis.castedo@upm.es>