### PR TITLE
Problem: tmp/ stashed and unstashed in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,9 @@ pipeline {
         }
         stage ('prepare') {
                     steps {
+                        dir("tmp") {
+                            deleteDir()
+                        }
                         sh './autogen.sh'
                         stash (name: 'prepped', includes: '**/*', excludes: '**/cppcheck.xml')
                     }

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -204,6 +204,9 @@ pipeline {
         stage ('prepare') {
 .       jenkins_agent (project, 0)
                     steps {
+                        dir("tmp") {
+                            deleteDir()
+                        }
                         sh './autogen.sh'
                         stash (name: 'prepped', includes: '**/*', excludes: '**/cppcheck.xml')
                     }


### PR DESCRIPTION
Solution: wipe it (if present) before prepping

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: This nuance proved to be quite a space-hog (unconstrained disk-space leak over several rebuilds in same workspace).