### PR TITLE
Problem: Jenkins builds in sub-dirs do not work when dir name changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,7 +163,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-draft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make check'
                         }
                         sh 'echo "Are GitIgnores good after make check with drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -181,7 +181,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-nondraft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make check'
                         }
                         sh 'echo "Are GitIgnores good after make check without drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -199,7 +199,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-draft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                         }
                         sh 'echo "Are GitIgnores good after make memcheck with drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -217,7 +217,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-nondraft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                         }
                         sh 'echo "Are GitIgnores good after make memcheck without drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -235,7 +235,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-draft'
                         timeout (time: 10, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make distcheck'
                         }
                         sh 'echo "Are GitIgnores good after make distcheck with drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -253,7 +253,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-nondraft'
                         timeout (time: 10, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make distcheck'
                         }
                         sh 'echo "Are GitIgnores good after make distcheck without drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -271,7 +271,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-draft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh "CCACHE_BASEDIR='`pwd`' ; export CCACHE_BASEDIR; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"
+                            sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\${LD_LIBRARY_PATH}"; export LD_LIBRARY_PATH; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"""
                         }
                         sh 'echo "Are GitIgnores good after make install with drafts? (should have no output below)"; git status -s || true'
                         script {
@@ -289,7 +289,7 @@ pipeline {
                         deleteDir()
                         unstash 'built-nondraft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh "CCACHE_BASEDIR='`pwd`' ; export CCACHE_BASEDIR; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"
+                            sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\${LD_LIBRARY_PATH}"; export LD_LIBRARY_PATH; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"""
                         }
                         sh 'echo "Are GitIgnores good after make install without drafts? (should have no output below)"; git status -s || true'
                         script {

--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -20,17 +20,38 @@ README.md: README.txt api/myclass.api project.xml zproject_known_projects.xml
 	 echo "WARNING : $@ should be updated, but gitdown is not installed on this system" >&2
 
 # For (dist)check, sabotage the script by not doing a distcheck again
+# Note that automake "if" has no "else"
+if USING_VPATH
 $(abs_builddir)/src/zproject_selftest: $(abs_srcdir)/src/zproject_selftest
 	@if [ "$@" != "$<" ]; then \
 	 ( echo "#! /bin/sh"; echo "true" ) > "$@" && \
 	   chmod +x "$@" ; fi
 
-check-local: $(abs_builddir)/src/zproject_selftest
-check-TESTS: $(abs_builddir)/src/zproject_selftest
+src/zproject_selftest: $(abs_builddir)/src/zproject_selftest
+endif
+
+if !USING_VPATH
+$(builddir)/src/zproject_selftest: $(srcdir)/src/zproject_selftest
+	@if [ "$@" != "$<" ]; then \
+	 ( echo "#! /bin/sh"; echo "true" ) > "$@" && \
+	   chmod +x "$@" ; fi
+
+src/zproject_selftest: $(builddir)/src/zproject_selftest
+endif
+
+check-local: src/zproject_selftest
+check-TESTS: src/zproject_selftest
 
 clean-local: clean-local-zproject_selftest
 .PHONY: clean-local-zproject_selftest
-clean-local-zproject_selftest:
+clean-local-zproject_selftest: clean-fake-zproject_selftest-abs clean-fake-zproject_selftest-rel
+
+clean-fake-zproject_selftest-abs:
 	if test "$(abs_builddir)" != "$(abs_srcdir)" ; then \
 		rm -f $(abs_builddir)/src/zproject_selftest || true ; \
+	fi
+
+clean-fake-zproject_selftest-rel:
+	if test "$(builddir)" != "$(srcdir)" ; then \
+		rm -f $(builddir)/src/zproject_selftest || true ; \
 	fi

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -68,18 +68,18 @@ SELFTEST_DIR_RW = src/selftest-rw
 
 # This is recreated on every invocation (as a selftest dependency),
 # so tests run in a clean environment
-$(abs_top_builddir)/$(SELFTEST_DIR_RW):
+$(top_builddir)/$(SELFTEST_DIR_RW):
 	rm -rf "$@"
 	mkdir -p "$@"
 
 if USING_VPATH
-$(abs_top_builddir)/$(SELFTEST_DIR_RO): $(abs_top_srcdir)/$(SELFTEST_DIR_RO)
+$(top_builddir)/$(SELFTEST_DIR_RO): $(top_srcdir)/$(SELFTEST_DIR_RO)
 	echo "   COPYDIR  $(SELFTEST_DIR_RO)"; \
 	rm -rf "$@"; \
 	cp -r "$<" "$@"
 endif
 
-CLEANFILES += $(abs_top_builddir)/$(SELFTEST_DIR_RW)/*
+CLEANFILES += $(top_builddir)/$(SELFTEST_DIR_RW)/*
 
 # Note that this syntax dists the whole directory - including subdirs (if any)
 EXTRA_DIST += $(SELFTEST_DIR_RO)
@@ -87,42 +87,42 @@ EXTRA_DIST += $(SELFTEST_DIR_RO)
 clean-local: clean-local-selftest-ro clean-local-selftest-rw
 .PHONY: clean-local-selftest-ro
 clean-local-selftest-ro:
-	@if test "$(abs_top_builddir)" != "$(abs_top_srcdir)" ; then \
-		if test -d "$(abs_top_builddir)/$(SELFTEST_DIR_RO)" ; then \
-			chmod -R u+w "$(abs_top_builddir)/$(SELFTEST_DIR_RO)" ; \
-			rm -rf "$(abs_top_builddir)/$(SELFTEST_DIR_RO)" ; \
+	@if test "$(top_builddir)" != "$(top_srcdir)" ; then \
+		if test -d "$(top_builddir)/$(SELFTEST_DIR_RO)" ; then \
+			chmod -R u+w "$(top_builddir)/$(SELFTEST_DIR_RO)" ; \
+			rm -rf "$(top_builddir)/$(SELFTEST_DIR_RO)" ; \
 		fi; \
 	fi
 
 # Unlike CLEANFILES setting above, this one whould also wipe created subdirs
 .PHONY: clean-local-selftest-rw
 clean-local-selftest-rw:
-	@if test "$(abs_top_builddir)" != "$(abs_top_srcdir)" ; then \
-		if test -d "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" ; then \
-			chmod -R u+w "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" ; \
-			rm -rf "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" ; \
+	@if test "$(top_builddir)" != "$(top_srcdir)" ; then \
+		if test -d "$(top_builddir)/$(SELFTEST_DIR_RW)" ; then \
+			chmod -R u+w "$(top_builddir)/$(SELFTEST_DIR_RW)" ; \
+			rm -rf "$(top_builddir)/$(SELFTEST_DIR_RW)" ; \
 		fi; \
 	fi
 
 check-empty-selftest-rw:
-	if test -e $(abs_top_builddir)/$(SELFTEST_DIR_RW) ; then \
-		if test `find "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" | wc -l` -lt 1 ; then \
+	if test -e $(top_builddir)/$(SELFTEST_DIR_RW) ; then \
+		if test `find "$(top_builddir)/$(SELFTEST_DIR_RW)" | wc -l` -lt 1 ; then \
 			echo "FATAL: selftest did not tidy up the data it wrote" >&2 ; \
-			find "$(abs_top_builddir)/$(SELFTEST_DIR_RW)" ; \
+			find "$(top_builddir)/$(SELFTEST_DIR_RW)" ; \
 			exit 2; \
 		else true ; fi; \
 	else true ; fi
 
-check-local: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+check-local: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute $(builddir)/src/zproject_selftest
 	$(MAKE) check-empty-selftest-rw
 
-check-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+check-verbose: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute $(builddir)/src/zproject_selftest -v
 	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for memory leaks
-memcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+memcheck: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
@@ -130,7 +130,7 @@ memcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top
 		$(builddir)/src/zproject_selftest
 	$(MAKE) check-empty-selftest-rw
 
-memcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+memcheck-verbose: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
@@ -139,38 +139,38 @@ memcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $
 	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for performance leaks
-callcheck: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+callcheck: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
 		$(VALGRIND_OPTIONS) \
 		$(builddir)/src/zproject_selftest
 	$(MAKE) check-empty-selftest-rw
 
-callcheck-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+callcheck-verbose: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
 		$(VALGRIND_OPTIONS) \
 		$(builddir)/src/zproject_selftest -v
 	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under gdb for debugging
-debug: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+debug: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute gdb -q \
 		$(builddir)/src/zproject_selftest
 	$(MAKE) check-empty-selftest-rw
 
-debug-verbose: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+debug-verbose: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute gdb -q \
 		$(builddir)/src/zproject_selftest -v
 	$(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary with verbose switch for tracing
-animate: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+animate: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	$(LIBTOOL) --mode=execute $(builddir)/src/zproject_selftest -v
 	$(MAKE) check-empty-selftest-rw
 
 animate-verbose: animate
 
 if WITH_GCOV
-coverage: src/zproject_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)
+coverage: src/zproject_selftest $(top_builddir)/$(SELFTEST_DIR_RW) $(top_builddir)/$(SELFTEST_DIR_RO)
 	@echo "you had called configure --with-gcov"
 	lcov --base-directory . --directory . --zerocounters -q
 	$(MAKE) check

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1702,18 +1702,18 @@ SELFTEST_DIR_RW = src/selftest-rw
 
 # This is recreated on every invocation (as a selftest dependency),
 # so tests run in a clean environment
-$\(abs_top_builddir)/$\(SELFTEST_DIR_RW):
+$\(top_builddir)/$\(SELFTEST_DIR_RW):
 \trm -rf "\$@"
 \tmkdir -p "\$@"
 
 if USING_VPATH
-$\(abs_top_builddir)/$\(SELFTEST_DIR_RO): $\(abs_top_srcdir)/$\(SELFTEST_DIR_RO)
+$\(top_builddir)/$\(SELFTEST_DIR_RO): $\(top_srcdir)/$\(SELFTEST_DIR_RO)
 \techo "  COPYDIR  $\(SELFTEST_DIR_RO)"; \\
 \trm -rf "$@"; \\
 \tcp -r "$<" "$@"
 endif
 
-CLEANFILES += $\(abs_top_builddir)/$\(SELFTEST_DIR_RW)/*
+CLEANFILES += $\(top_builddir)/$\(SELFTEST_DIR_RW)/*
 
 # Note that this syntax dists the whole directory - including subdirs (if any)
 EXTRA_DIST += $\(SELFTEST_DIR_RO)
@@ -1721,42 +1721,42 @@ EXTRA_DIST += $\(SELFTEST_DIR_RO)
 clean-local: clean-local-selftest-ro clean-local-selftest-rw
 \.PHONY: clean-local-selftest-ro
 clean-local-selftest-ro:
-\t@if test "$\(abs_top_builddir)" != "$\(abs_top_srcdir)" ; then \\
-\t\tif test -d "$\(abs_top_builddir)/$\(SELFTEST_DIR_RO)" ; then \\
-\t\t\tchmod -R u+w "$\(abs_top_builddir)/$\(SELFTEST_DIR_RO)" ; \\
-\t\t\trm -rf "$\(abs_top_builddir)/$\(SELFTEST_DIR_RO)" ; \\
+\t@if test "$\(top_builddir)" != "$\(top_srcdir)" ; then \\
+\t\tif test -d "$\(top_builddir)/$\(SELFTEST_DIR_RO)" ; then \\
+\t\t\tchmod -R u+w "$\(top_builddir)/$\(SELFTEST_DIR_RO)" ; \\
+\t\t\trm -rf "$\(top_builddir)/$\(SELFTEST_DIR_RO)" ; \\
 \t\tfi; \\
 \tfi
 
 # Unlike CLEANFILES setting above, this one whould also wipe created subdirs
 \.PHONY: clean-local-selftest-rw
 clean-local-selftest-rw:
-\t@if test "$\(abs_top_builddir)" != "$\(abs_top_srcdir)" ; then \\
-\t\tif test -d "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" ; then \\
-\t\t\tchmod -R u+w "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
-\t\t\trm -rf "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
+\t@if test "$\(top_builddir)" != "$\(top_srcdir)" ; then \\
+\t\tif test -d "$\(top_builddir)/$\(SELFTEST_DIR_RW)" ; then \\
+\t\t\tchmod -R u+w "$\(top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
+\t\t\trm -rf "$\(top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
 \t\tfi; \\
 \tfi
 
 check-empty-selftest-rw:
-\tif test -e $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) ; then \\
-\t\tif test `find "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" | wc -l` -lt 1 ; then \\
+\tif test -e $\(top_builddir)/$\(SELFTEST_DIR_RW) ; then \\
+\t\tif test `find "$\(top_builddir)/$\(SELFTEST_DIR_RW)" | wc -l` -lt 1 ; then \\
 \t\t\techo "FATAL: selftest did not tidy up the data it wrote" >&2 ; \\
-\t\t\tfind "$\(abs_top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
+\t\t\tfind "$\(top_builddir)/$\(SELFTEST_DIR_RW)" ; \\
 \t\t\texit 2; \\
 \t\telse true ; fi; \\
 \telse true ; fi
 
-check-local: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+check-local: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest
 \t$\(MAKE) check-empty-selftest-rw
 
-check-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+check-verbose: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest -v
 \t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for memory leaks
-memcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+memcheck: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 \t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
@@ -1764,7 +1764,7 @@ memcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 \t$\(MAKE) check-empty-selftest-rw
 
-memcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+memcheck-verbose: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 \t\t--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 \t\t--suppressions=$\(srcdir)/src/.valgrind.supp \\
@@ -1773,38 +1773,38 @@ memcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTES
 \t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under valgrind to check for performance leaks
-callcheck: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+callcheck: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
 \t\t$\(VALGRIND_OPTIONS) \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 \t$\(MAKE) check-empty-selftest-rw
 
-callcheck-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+callcheck-verbose: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute valgrind --tool=callgrind \\
 \t\t$\(VALGRIND_OPTIONS) \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
 \t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary under gdb for debugging
-debug: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+debug: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute gdb -q \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest
 \t$\(MAKE) check-empty-selftest-rw
 
-debug-verbose: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+debug-verbose: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute gdb -q \\
 \t\t$\(builddir)/src/$(project.prefix)_selftest -v
 \t$\(MAKE) check-empty-selftest-rw
 
 # Run the selftest binary with verbose switch for tracing
-animate: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+animate: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$\(LIBTOOL) --mode=execute $\(builddir)/src/$(project.prefix)_selftest -v
 \t$\(MAKE) check-empty-selftest-rw
 
 animate-verbose: animate
 
 if WITH_GCOV
-coverage: src/$(project.prefix)_selftest $\(abs_top_builddir)/$\(SELFTEST_DIR_RW) $\(abs_top_builddir)/$\(SELFTEST_DIR_RO)
+coverage: src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t@echo "you had called configure --with-gcov"
 \tlcov --base-directory . --directory . --zerocounters -q
 \t\$(MAKE) check

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -295,7 +295,7 @@ pipeline {
 .       endif
                         unstash 'built-draft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make check'
                         }
                         sh 'echo "Are GitIgnores good after make check with drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -318,7 +318,7 @@ pipeline {
 .       endif
                         unstash 'built-nondraft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make check'
                         }
                         sh 'echo "Are GitIgnores good after make check without drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -341,7 +341,7 @@ pipeline {
 .       endif
                         unstash 'built-draft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                         }
                         sh 'echo "Are GitIgnores good after make memcheck with drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -364,7 +364,7 @@ pipeline {
 .       endif
                         unstash 'built-nondraft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                         }
                         sh 'echo "Are GitIgnores good after make memcheck without drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -387,7 +387,7 @@ pipeline {
 .       endif
                         unstash 'built-draft'
                         timeout (time: 10, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make distcheck'
                         }
                         sh 'echo "Are GitIgnores good after make distcheck with drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -410,7 +410,7 @@ pipeline {
 .       endif
                         unstash 'built-nondraft'
                         timeout (time: 10, unit: 'MINUTES') {
-                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck'
+                            sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make distcheck'
                         }
                         sh 'echo "Are GitIgnores good after make distcheck without drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -433,7 +433,7 @@ pipeline {
 .       endif
                         unstash 'built-draft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh "CCACHE_BASEDIR='`pwd`' ; export CCACHE_BASEDIR; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"
+                            sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\\$\{LD_LIBRARY_PATH\}"; export LD_LIBRARY_PATH; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"""
                         }
                         sh 'echo "Are GitIgnores good after make install with drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -456,7 +456,7 @@ pipeline {
 .       endif
                         unstash 'built-nondraft'
                         timeout (time: 5, unit: 'MINUTES') {
-                            sh "CCACHE_BASEDIR='`pwd`' ; export CCACHE_BASEDIR; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"
+                            sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\\$\{LD_LIBRARY_PATH\}"; export LD_LIBRARY_PATH; make DESTDIR='${params.USE_TEST_INSTALL_DESTDIR}' install"""
                         }
                         sh 'echo "Are GitIgnores good after make install without drafts? (should have no output below)"; git status -s || true'
 .       if !(isSingle_jenkins_agent (project, 0))


### PR DESCRIPTION
Solution: rely less on `abs_*` in build recipes, and hack the `LD_LIBRARY_PATH` for tests under relocated build tree. Pathname changes are a required collateral damage of faster parallel testing without conflict of the test runs.