### PR TITLE
Problem: Jenkinsfile tests stable build even when there is none

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,8 @@ pipeline {
             description: 'If the deployment is done, should THIS job wait for it to complete and include its success or failure as the build result (true), or should it schedule the job and exit quickly to free up the executor (false)',
             name: 'DEPLOY_REPORT_RESULT')
         booleanParam (
-            defaultValue: true,
-            description: 'Attempt build without DRAFT API in this run?',
+            defaultValue: false,
+            description: 'Attempt stable build without DRAFT API in this run?',
             name: 'DO_BUILD_WITHOUT_DRAFT_API')
         booleanParam (
             defaultValue: true,

--- a/README.md
+++ b/README.md
@@ -366,7 +366,9 @@ zproject's `project.xml` contains an extensive description of the available conf
          checkboxes clicked, e.g. while developing a missing feature.
          If not explicitly set to 0, these options are assumed to be
          "true", as normally a project should be capable of all these
-         aspects.
+         aspects. Note however that a project with no classes marked
+         "stable" would by default not test non-DRAFT builds as the
+         configure.ac script would have no support for those anyway.
          The require_gitignore option (enabled by default) also causes
          the test to fail, rather than warn, if untracked or changed
          files are found as a result of some build or test stage.

--- a/project.xml
+++ b/project.xml
@@ -191,7 +191,9 @@
          checkboxes clicked, e.g. while developing a missing feature.
          If not explicitly set to 0, these options are assumed to be
          "true", as normally a project should be capable of all these
-         aspects.
+         aspects. Note however that a project with no classes marked
+         "stable" would by default not test non-DRAFT builds as the
+         configure.ac script would have no support for those anyway.
          The require_gitignore option (enabled by default) also causes
          the test to fail, rather than warn, if untracked or changed
          files are found as a result of some build or test stage.

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -96,12 +96,15 @@ pipeline {
             description: 'If the deployment is done, should THIS job wait for it to complete and include its success or failure as the build result (true), or should it schedule the job and exit quickly to free up the executor (false)',
             name: 'DEPLOY_REPORT_RESULT')
         booleanParam (
-.  if project.jenkins_build_without_draft_api ?= 0
+.  if ( ( project.jenkins_build_without_draft_api ?= 0 ) | !(project.stable) )
+.# NOTE: If "!project.stable" then there is no support for --enable-drafts in
+.# the generated configure.ac script, drafts are always on. So we can skip the
+.# non-draft test for young experimental projects.
             defaultValue: false,
 .  else
             defaultValue: true,
 .  endif
-            description: 'Attempt build without DRAFT API in this run?',
+            description: 'Attempt stable build without DRAFT API in this run?',
             name: 'DO_BUILD_WITHOUT_DRAFT_API')
         booleanParam (
 .  if project.jenkins_build_with_draft_api ?= 0


### PR DESCRIPTION
Solution: If the project is not marked stable, default to not testing non-DRAFT stages. There is no support in build recipes for the --enable-drafts option in this case anyway.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>