### PR TITLE
Problem: Jenkinsfile cppcheck takes too long

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,9 @@ pipeline {
         stage ('cppcheck') {
                     when { expression { return ( params.DO_CPPCHECK ) } }
                     steps {
+                        dir("tmp") {
+                            deleteDir()
+                        }
                         sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
                         archiveArtifacts artifacts: '**/cppcheck.xml'
                         sh 'rm -f cppcheck.xml'

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -209,6 +209,9 @@ pipeline {
                     when { expression { return ( params.DO_CPPCHECK ) } }
 .       jenkins_agent (project, 0)
                     steps {
+                        dir("tmp") {
+                            deleteDir()
+                        }
                         sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
                         archiveArtifacts artifacts: '**/cppcheck.xml'
                         sh 'rm -f cppcheck.xml'


### PR DESCRIPTION
Solution: zproject_jenkins.gsl / Jenkinsfile : clean up tmp/ before cppcheck