### PR TITLE
Problem: one stage of Travis tests enforces --with-docs=yes

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -473,13 +473,13 @@ default|default-Werror|default-with-docs|valgrind)
     git reset --hard HEAD
     (
         $CI_TIME ./autogen.sh 2> /dev/null
-        $CI_TIME ./configure --enable-drafts=no "${CONFIG_OPTS[@]}" --with-docs=yes
+        $CI_TIME ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
         $CI_TIME make VERBOSE=1 all || exit $?
 .   if travis_distcheck ?= 0
         make check
 .   else
         (
-            export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]} --with-docs=yes" && \\
+            export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]}" && \\
             $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
         )
 .   endif


### PR DESCRIPTION
Solution: we have a specially defined environment and BUILD_TYPE to test docs generation; do not require it explicitly always

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>