### PR TITLE
Problem: Jenkins tests fail with hardcoded ports in codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,13 @@ zproject's `project.xml` contains an extensive description of the available conf
          builds of this component on several agents (specified by
          label or docker) vs. a sequential build on a single agent.
 
+         Similarly, a check_sequential option can be defined so that
+         self-testing stages would run sequentially. This can be needed
+         at early stages of a project's evolution, where hardcoding is
+         prevalent so parallel runs in same operating environemnt cause
+         conflicts to each other. Ultimately a project should remove
+         this flag ;)
+
          The build_* and test_* options influence the default setting
          of corresponding build arguments for the project. You can
          still run a custom Jenkins Build with Arguments with other
@@ -410,6 +417,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         <option name = "agent_docker" value = "zeromqorg/czmq" />
         <option name = "agent_label" value = "linux || macosx || bsd || solaris || posix || windows" />
         <option name = "agent_single" value = "1" />
+        <option name = "check_sequential" value = "1" />
         <option name = "triggers_pollSCM" value = "H/5 * * * *" />
         <option name = "build_without_draft_api" value = "0" />
         <option name = "build_with_draft_api" value = "0" />

--- a/project.xml
+++ b/project.xml
@@ -188,6 +188,13 @@
          builds of this component on several agents (specified by
          label or docker) vs. a sequential build on a single agent.
 
+         Similarly, a check_sequential option can be defined so that
+         self-testing stages would run sequentially. This can be needed
+         at early stages of a project's evolution, where hardcoding is
+         prevalent so parallel runs in same operating environemnt cause
+         conflicts to each other. Ultimately a project should remove
+         this flag ;)
+
          The build_* and test_* options influence the default setting
          of corresponding build arguments for the project. You can
          still run a custom Jenkins Build with Arguments with other
@@ -235,6 +242,7 @@
         <option name = "agent_docker" value = "zeromqorg/czmq" />
         <option name = "agent_label" value = "linux || macosx || bsd || solaris || posix || windows" />
         <option name = "agent_single" value = "1" />
+        <option name = "check_sequential" value = "1" />
         <option name = "triggers_pollSCM" value = "H/5 * * * *" />
         <option name = "build_without_draft_api" value = "0" />
         <option name = "build_with_draft_api" value = "0" />

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -300,8 +300,20 @@ pipeline {
                 }
             }
         }
+.       if ( project.jenkins_check_sequential ?= 1 )
+        // Self-test stages below should be run sequentially, as decreed by
+        // project authors for the time being (e.g. port conflicts, etc.)
+        // You can uncomment the closures below experimentally, but proper
+        // fix belongs in the project.xml (e.g. use separate agents if your
+        // infrastructure is set up to only schedule one build on the agent
+        // at a time) and better yet - in the project sources, to not have
+        // the conflicts at all.
+//        stage ('check') {
+//            parallel {
+.       else
         stage ('check') {
             parallel {
+.       endif
                 stage ('check with DRAFT') {
                     when { expression { return ( params.DO_BUILD_WITH_DRAFT_API && params.DO_TEST_CHECK ) } }
 .       jenkins_agent (project, 0)
@@ -512,8 +524,14 @@ pipeline {
 .       endif
                     }
                 }
+.       if ( project.jenkins_check_sequential ?= 1 )
+        // Sequential block of self-tests end here
+//            }
+//        }
+.       else
             }
         }
+.       endif
         stage ('deploy if appropriate') {
             steps {
                 script {


### PR DESCRIPTION
Solution: Allow project authors to generate a Jenkinsfile that runs self-tests sequentially, while they think of a better fix. This takes more wallclock time, but avoids port conflicts etc. in the same environment. Note that such ability to fail can expose potential resilience problems for production builds too.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>