### PR TITLE
Support providing dist tarballs to Jenkinsfile publish helper

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,19 +95,6 @@ pipeline {
 // Note: your Jenkins setup may benefit from similar setup on side of agents:
 //        PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/bin:/bin:${PATH}"
     stages {
-        stage ('cppcheck') {
-                    when { expression { return ( params.DO_CPPCHECK ) } }
-                    steps {
-                        dir("tmp") {
-                            sh 'if [ -s Makefile ]; then make -k distclean || true ; fi'
-                            sh 'chmod -R u+w .'
-                            deleteDir()
-                        }
-                        sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
-                        archiveArtifacts artifacts: '**/cppcheck.xml'
-                        sh 'rm -f cppcheck.xml'
-                    }
-        }
         stage ('prepare') {
                     steps {
                         dir("tmp") {
@@ -179,6 +166,23 @@ pipeline {
         }
         stage ('check') {
             parallel {
+                stage ('cppcheck') {
+                    when { expression { return ( params.DO_CPPCHECK ) } }
+                    steps {
+                        dir("tmp/test-cppcheck") {
+                            deleteDir()
+                            unstash 'prepped'
+                            sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
+                            archiveArtifacts artifacts: '**/cppcheck.xml'
+                            sh 'rm -f cppcheck.xml'
+                            script {
+                                if ( params.DO_CLEANUP_AFTER_BUILD ) {
+                                    deleteDir()
+                                }
+                            }
+                        }
+                    }
+                }
                 stage ('check with DRAFT') {
                     when { expression { return ( params.DO_BUILD_WITH_DRAFT_API && params.DO_TEST_CHECK ) } }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,10 @@ pipeline {
             description: 'Attempt a build with docs in this run? (Note: corresponding tools are required in the build environment)',
             name: 'DO_BUILD_DOCS')
         booleanParam (
+            defaultValue: false,
+            description: 'Publish as an archive a "dist" tarball from a build with docs in this run? (Note: corresponding tools are required in the build environment; enabling this enforces DO_BUILD_DOCS too)',
+            name: 'DO_DIST_DOCS')
+        booleanParam (
             defaultValue: true,
             description: 'Attempt "make check" in this run?',
             name: 'DO_TEST_CHECK')
@@ -145,12 +149,19 @@ pipeline {
                     }
                 }
                 stage ('build with DOCS') {
-                    when { expression { return ( params.DO_BUILD_DOCS ) } }
+                    when { expression { return ( params.DO_BUILD_DOCS || params.DO_DIST_DOCS ) } }
                     steps {
                       dir("tmp/build-DOCS") {
                         deleteDir()
                         unstash 'prepped'
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=yes --with-docs=yes'
+                        script {
+                            if ( params.DO_DIST_DOCS ) {
+                                sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make dist-gzip || exit ; DISTFILE="`ls -1tc *.tar.gz | head -1`" && [ -n "$DISTFILE" ] && [ -s "$DISTFILE" ] || exit ; mv -f "$DISTFILE" __dist.tar.gz'
+                                archiveArtifacts artifacts: '__dist.tar.gz'
+                                sh "rm -f __dist.tar.gz"
+                            }
+                        }
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make -k -j4 || make'
                         sh 'echo "Are GitIgnores good after make with docs? (should have no output below)"; git status -s || if [ "${params.REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; exit 1; fi'
                         stash (name: 'built-docs', includes: '**/*', excludes: '**/cppcheck.xml')
@@ -362,10 +373,13 @@ pipeline {
                         if ( env.BRANCH_NAME =~ myDEPLOY_BRANCH_PATTERN ) {
                             def GIT_URL = sh(returnStdout: true, script: """git remote -v | egrep '^origin' | awk '{print \$2}' | head -1""").trim()
                             def GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --verify HEAD').trim()
+                            def DIST_ARCHIVE = ""
+                            if ( params.DO_DIST_DOCS ) { DIST_ARCHIVE = env.BUILD_URL + "artifact/__dist.tar.gz" }
                             build job: "${myDEPLOY_JOB_NAME}", parameters: [
                                 string(name: 'DEPLOY_GIT_URL', value: "${GIT_URL}"),
                                 string(name: 'DEPLOY_GIT_BRANCH', value: env.BRANCH_NAME),
-                                string(name: 'DEPLOY_GIT_COMMIT', value: "${GIT_COMMIT}")
+                                string(name: 'DEPLOY_GIT_COMMIT', value: "${GIT_COMMIT}"),
+                                string(name: 'DEPLOY_DIST_ARCHIVE', value: "${DIST_ARCHIVE}")
                                 ], quietPeriod: 0, wait: myDEPLOY_REPORT_RESULT, propagate: myDEPLOY_REPORT_RESULT
                         } else {
                             echo "Not deploying because branch '${env.BRANCH_NAME}' did not match filter '${myDEPLOY_BRANCH_PATTERN}'"

--- a/Jenkinsfile-deploy.example
+++ b/Jenkinsfile-deploy.example
@@ -126,7 +126,9 @@ pipeline {
 // Certainly, customize the code below to match your tools and their params
         stage ('Deploy') {
             steps {
-                sh """
+                script {
+                    manager.addShortText("Pushing: " + ( (params.DEPLOY_GIT_URL).substring( (params.DEPLOY_GIT_URL).lastIndexOf("/") + 1 ).replace(".git", "") ) + " / " + params.DEPLOY_GIT_BRANCH + " @ " + ( (params.DEPLOY_GIT_COMMIT).take(7) ) )
+                    def statusCode = sh returnStatus:true, script: """
 DEPLOY_GIT_URL="${params["DEPLOY_GIT_URL"]}"
 DEPLOY_GIT_BRANCH="${params["DEPLOY_GIT_BRANCH"]}"
 DEPLOY_GIT_COMMIT="${params["DEPLOY_GIT_COMMIT"]}"
@@ -134,6 +136,13 @@ export DEPLOY_GIT_URL DEPLOY_GIT_BRANCH DEPLOY_GIT_COMMIT
 cd project && \
 ../ci/update-deployment.sh
 """
+                    if ( statusCode == 42 ) {
+                        manager.addShortText("Sanity: update-deployment.sh refused the git URL/branch: " + params.DEPLOY_GIT_URL + " / " + params.DEPLOY_GIT_BRANCH)
+                        currentBuild.result = 'ABORTED'
+                        manager.buildUnstable()
+                        error("Sanity: update-deployment.sh refused the git URL/branch; it looks like an automatic build of a master/release branch in a developer's repo: " + params.DEPLOY_GIT_URL + " / " + params.DEPLOY_GIT_BRANCH)
+                    }
+                }
             }
         }
     }

--- a/Jenkinsfile-deploy.example
+++ b/Jenkinsfile-deploy.example
@@ -32,6 +32,10 @@ pipeline {
             description: 'The commit ID of the sources to check out (may be not current HEAD of that repo/branch)',
             name: 'DEPLOY_GIT_COMMIT')
         string (
+            defaultValue: '',
+            description: 'URL to a "dist" archive prepared by the build (e.g. with pregenerated docs and config script) which will be fetched, and used instead of (or combined with) git-archive checkout contents during further packaging; note all the DEPLOY_GIT_* arguments are still required if this feature is used.',
+            name: 'DEPLOY_DIST_ARCHIVE')
+        string (
             defaultValue: 'https://github.com/myorg/myjenkinsscripts.git',
             description: 'GIT Repo with CI scripts and tools',
             name: 'CI_REPO_FORK')
@@ -127,12 +131,13 @@ pipeline {
         stage ('Deploy') {
             steps {
                 script {
-                    manager.addShortText("Pushing: " + ( (params.DEPLOY_GIT_URL).substring( (params.DEPLOY_GIT_URL).lastIndexOf("/") + 1 ).replace(".git", "") ) + " / " + params.DEPLOY_GIT_BRANCH + " @ " + ( (params.DEPLOY_GIT_COMMIT).take(7) ) )
+                    manager.addShortText("Pushing: " + ( (params.DEPLOY_GIT_URL).substring( (params.DEPLOY_GIT_URL).lastIndexOf("/") + 1 ).replace(".git", "") ) + " / " + params.DEPLOY_GIT_BRANCH + " @ " + ( (params.DEPLOY_GIT_COMMIT).take(7) ) + ( (params.DEPLOY_DIST_ARCHIVE == "") ? "(no dist tarballs)" : (" using " + params.DEPLOY_DIST_ARCHIVE)  ) )
                     def statusCode = sh returnStatus:true, script: """
 DEPLOY_GIT_URL="${params["DEPLOY_GIT_URL"]}"
 DEPLOY_GIT_BRANCH="${params["DEPLOY_GIT_BRANCH"]}"
 DEPLOY_GIT_COMMIT="${params["DEPLOY_GIT_COMMIT"]}"
-export DEPLOY_GIT_URL DEPLOY_GIT_BRANCH DEPLOY_GIT_COMMIT
+DEPLOY_DIST_ARCHIVE="${params["DEPLOY_DIST_ARCHIVE"]}"
+export DEPLOY_GIT_URL DEPLOY_GIT_BRANCH DEPLOY_GIT_COMMIT DEPLOY_DIST_ARCHIVE
 cd project && \
 ../ci/update-deployment.sh
 """

--- a/Jenkinsfile-deploy.example
+++ b/Jenkinsfile-deploy.example
@@ -141,6 +141,11 @@ cd project && \
                         currentBuild.result = 'ABORTED'
                         manager.buildUnstable()
                         error("Sanity: update-deployment.sh refused the git URL/branch; it looks like an automatic build of a master/release branch in a developer's repo: " + params.DEPLOY_GIT_URL + " / " + params.DEPLOY_GIT_BRANCH)
+                    } else {
+                        if ( statusCode != 0 ) {
+                            currentBuild.result = 'FAILURE'
+                            manager.buildAborted()
+                        }
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -405,6 +405,9 @@ zproject's `project.xml` contains an extensive description of the available conf
          which may be not installed on a particular deployment, so by
          default this option is disabled if not set explicitly. Same idea
          goes for build_docs as it requires asciidoc and xmlto toolkits.
+         A further dist_docs enables preparation of a "dist" tarball from
+         the workspace configured with docs, so you can forward it to the
+         publishing helper job and avoid rebuilding manpages for packaging.
 
          The triggers_pollSCM option sets up the pipeline-generated job
          for regular polling of the original SCM repository, using the
@@ -444,6 +447,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         <option name = "build_without_draft_api" value = "0" />
         <option name = "build_with_draft_api" value = "0" />
         <option name = "build_docs" value = "1" />
+        <option name = "dist_docs" value = "1" />
         <option name = "require_gitignore" value = "0" />
         <option name = "use_deleteDir_rm_first" value = "1" />
         <option name = "use_test_timeout" value = "30" />

--- a/project.xml
+++ b/project.xml
@@ -230,6 +230,9 @@
          which may be not installed on a particular deployment, so by
          default this option is disabled if not set explicitly. Same idea
          goes for build_docs as it requires asciidoc and xmlto toolkits.
+         A further dist_docs enables preparation of a "dist" tarball from
+         the workspace configured with docs, so you can forward it to the
+         publishing helper job and avoid rebuilding manpages for packaging.
 
          The triggers_pollSCM option sets up the pipeline-generated job
          for regular polling of the original SCM repository, using the
@@ -269,6 +272,7 @@
         <option name = "build_without_draft_api" value = "0" />
         <option name = "build_with_draft_api" value = "0" />
         <option name = "build_docs" value = "1" />
+        <option name = "dist_docs" value = "1" />
         <option name = "require_gitignore" value = "0" />
         <option name = "use_deleteDir_rm_first" value = "1" />
         <option name = "use_test_timeout" value = "30" />

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -130,6 +130,15 @@ pipeline {
             description: 'Attempt a build with docs in this run? (Note: corresponding tools are required in the build environment)',
             name: 'DO_BUILD_DOCS')
         booleanParam (
+.  if ( !(defined(project.jenkins_dist_docs)) | (project.jenkins_dist_docs ?= 0) )
+. # asciidoc and xmlto are external tools that may be not installed in general case
+            defaultValue: false,
+.  else
+            defaultValue: true,
+.  endif
+            description: 'Publish as an archive a "dist" tarball from a build with docs in this run? (Note: corresponding tools are required in the build environment; enabling this enforces DO_BUILD_DOCS too)',
+            name: 'DO_DIST_DOCS')
+        booleanParam (
 .  if project.jenkins_test_check ?= 0
             defaultValue: false,
 .  else
@@ -295,7 +304,7 @@ pipeline {
                     }
                 }
                 stage ('build with DOCS') {
-                    when { expression { return ( params.DO_BUILD_DOCS ) } }
+                    when { expression { return ( params.DO_BUILD_DOCS || params.DO_DIST_DOCS ) } }
 .       jenkins_agent (project, 0)
                     steps {
 .       if !(isSingle_jenkins_agent (project, 0))
@@ -307,6 +316,13 @@ pipeline {
 .       endif
                         unstash 'prepped'
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=yes --with-docs=yes'
+                        script {
+                            if ( params.DO_DIST_DOCS ) {
+                                sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make dist-gzip || exit ; DISTFILE="`ls -1tc *.tar.gz | head -1`" && [ -n "\$DISTFILE" ] && [ -s "\$DISTFILE" ] || exit ; mv -f "\$DISTFILE" __dist.tar.gz'
+                                archiveArtifacts artifacts: '__dist.tar.gz'
+                                sh "rm -f __dist.tar.gz"
+                            }
+                        }
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make -k -j4 || make'
                         sh 'echo "Are GitIgnores good after make with docs? (should have no output below)"; git status -s || if [ "${params.REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; exit 1; fi'
                         stash (name: 'built-docs', includes: '**/*', excludes: '**/cppcheck.xml')
@@ -703,10 +719,13 @@ pipeline {
                         if ( env.BRANCH_NAME =~ myDEPLOY_BRANCH_PATTERN ) {
                             def GIT_URL = sh(returnStdout: true, script: """git remote -v | egrep '^origin' | awk '{print \\$2}' | head -1""").trim()
                             def GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --verify HEAD').trim()
+                            def DIST_ARCHIVE = ""
+                            if ( params.DO_DIST_DOCS ) { DIST_ARCHIVE = env.BUILD_URL + "artifact/__dist.tar.gz" }
                             build job: "\$\{myDEPLOY_JOB_NAME}", parameters: [
                                 string(name: 'DEPLOY_GIT_URL', value: "\$\{GIT_URL}"),
                                 string(name: 'DEPLOY_GIT_BRANCH', value: env.BRANCH_NAME),
-                                string(name: 'DEPLOY_GIT_COMMIT', value: "\$\{GIT_COMMIT}")
+                                string(name: 'DEPLOY_GIT_COMMIT', value: "\$\{GIT_COMMIT}"),
+                                string(name: 'DEPLOY_DIST_ARCHIVE', value: "\$\{DIST_ARCHIVE}")
                                 ], quietPeriod: 0, wait: myDEPLOY_REPORT_RESULT, propagate: myDEPLOY_REPORT_RESULT
                         } else {
                             echo "Not deploying because branch '\$\{env.BRANCH_NAME}' did not match filter '\$\{myDEPLOY_BRANCH_PATTERN}'"

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -219,23 +219,6 @@ pipeline {
 // Note: your Jenkins setup may benefit from similar setup on side of agents:
 //        PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/bin:/bin:\$\{PATH}"
     stages {
-        stage ('cppcheck') {
-                    when { expression { return ( params.DO_CPPCHECK ) } }
-.       jenkins_agent (project, 0)
-                    steps {
-                        dir("tmp") {
-                            sh 'if [ -s Makefile ]; then make -k distclean || true ; fi'
-                            sh 'chmod -R u+w .'
-.       if project.jenkins_use_deleteDir_rm_first ?= 1
-                            sh '_PWD="`pwd`" ; cd /tmp ; rm -rf "$_PWD" || true ; mkdir -p "$_PWD"'
-.       endif
-                            deleteDir()
-                        }
-                        sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
-                        archiveArtifacts artifacts: '**/cppcheck.xml'
-                        sh 'rm -f cppcheck.xml'
-                    }
-        }
         stage ('prepare') {
 .       jenkins_agent (project, 0)
                     steps {
@@ -356,6 +339,32 @@ pipeline {
         stage ('check') {
             parallel {
 .       endif
+                stage ('cppcheck') {
+                    when { expression { return ( params.DO_CPPCHECK ) } }
+.       jenkins_agent (project, 0)
+                    steps {
+                        dir("tmp/test-cppcheck") {
+.       if project.jenkins_use_deleteDir_rm_first ?= 1
+                            sh '_PWD="`pwd`" ; cd /tmp ; rm -rf "$_PWD" || true ; mkdir -p "$_PWD"'
+.       endif
+                            deleteDir()
+                            unstash 'prepped'
+                            sh 'cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 . 2>cppcheck.xml'
+                            archiveArtifacts artifacts: '**/cppcheck.xml'
+                            sh 'rm -f cppcheck.xml'
+.       if !(isSingle_jenkins_agent (project, 0))
+                            script {
+                                if ( params.DO_CLEANUP_AFTER_BUILD ) {
+.           if project.jenkins_use_deleteDir_rm_first ?= 1
+                                    sh '_PWD="`pwd`" ; cd /tmp ; rm -rf "$_PWD" || true ; mkdir -p "$_PWD"'
+.           endif
+                                    deleteDir()
+                                }
+                            }
+.       endif
+                        }
+                    }
+                }
                 stage ('check with DRAFT') {
                     when { expression { return ( params.DO_BUILD_WITH_DRAFT_API && params.DO_TEST_CHECK ) } }
 .       jenkins_agent (project, 0)


### PR DESCRIPTION
Primary use-case is speed up of packaging, using a tarball with pre-created doc files along with the git archive. Either way, this detail is implemented (or not) on the Jenkins side by a particular deployment admin.

Also do cppcheck in parallel to other tests, there is now little reason to start with it (and its long lag, for big codebases).