### PR TITLE
Problem: autoconf optional deps changed to default off

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -531,7 +531,9 @@ AC_ARG_WITH([$(use.libname)],
     [
         search_$(use.libname:c)="yes"
     ],
-    [])
+    [
+        search_$(use.libname:c)="yes"
+    ])
 AS_CASE([x"${with_$(use.libname:c)}"],
     [xyes], [search_$(use.libname:c)="yes"],
     [xno],  [search_$(use.libname:c)="no"])


### PR DESCRIPTION
Solution: restore the default to enable all optional dependencies if
they are available to avoid backward incompatible change


This caused a regression in czmq - while in the previous version running ./configure by itself enabled the optional dependencies, now it doesn't anymore