### PR TITLE
Problem: python_cffi bindings not python3 compatible

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -212,7 +212,7 @@ function generate_binding
     directory.create ("bindings/python_cffi/$(project.name:c)_cffi")
     output "bindings/python_cffi/$(project.name:c)_cffi/__init__.py"
     >$(project.GENERATED_WARNING_HEADER:)
-    >import utils
+    >from . import utils
     for class where defined (class.api) & class.private = "0"
     >from .$(class.python_name:) import *
     endfor
@@ -445,7 +445,7 @@ function generate_classes ()
     for class where defined (class.api) & class.private = "0"
         output "bindings/python_cffi/$(project.name:c)_cffi/$(class.python_name:).py"
         >$(project.GENERATED_WARNING_HEADER:)
-        >import utils
+        >from . import utils
         >from . import destructors
         >lib$(project.name:c)_destructors = destructors.lib
         >


### PR DESCRIPTION
Solution: change absolute utils import to relative (works in 2.7 and 3+)