### PR TITLE
Problem: build of python3 bindings fails if path has ~

### DIFF
--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -252,10 +252,13 @@ make %{_smp_mflags}
 %if %{with python_cffi}
 # Problem: we need pkg-config points to built and not yet installed copy of $(project.name)
 # Solution: chicken-egg problem - let's make "fake" pkg-config file
-sed -e "s@^libdir.*@libdir=`pwd`/src/.libs@" \\
-    -e "s@^includedir.*@includedir=`pwd`/include@" \\
+sed -e "s@^libdir.*@libdir=.libs/@" \\
+    -e "s@^includedir.*@includedir=include/@" \\
     src/$(project.libname).pc > bindings/python_cffi/$(project.libname).pc
 cd bindings/python_cffi
+# This avoids problem with "weird" character quoting between shell and python3
+ln -sfr ../../include/ .
+ln -sfr ../../src/.libs/ .
 export PKG_CONFIG_PATH=`pwd`
 python2 setup.py build
 %endif
@@ -263,10 +266,13 @@ python2 setup.py build
 %if %{with python3_cffi}
 # Problem: we need pkg-config points to built and not yet installed copy of $(project.name)
 # Solution: chicken-egg problem - let's make "fake" pkg-config file
-sed -e "s@^libdir.*@libdir=`pwd`/src/.libs@" \\
-    -e "s@^includedir.*@includedir=`pwd`/include@" \\
+sed -e "s@^libdir.*@libdir=.libs/@" \\
+    -e "s@^includedir.*@includedir=include/@" \\
     src/$(project.libname).pc > bindings/python_cffi/$(project.libname).pc
 cd bindings/python_cffi
+# This avoids problem with "weird" character quoting between shell and python3
+ln -sfr ../../include/ .
+ln -sfr ../../src/.libs/ .
 export PKG_CONFIG_PATH=`pwd`
 python3 setup.py build
 %endif


### PR DESCRIPTION
Solution: gcc run from setuptools failed, however the same command
copy&pasted to shell passed. It is most likely related to bad quoting of
~ in python3 port of setuptools. So main project include path was broken
in a compiler, however shell quote (\~) was fine.

As a workaround spec file now makes symlinks for libdir and includedir,
so paths have only boring and safe ascii letters. Generated pkg-config
file now points to local links and as a result, python3 bindings are now
built in our OBS instance.