### PR TITLE
Problem: inconsistency between installed czmq and git snapshot

### DIFF
--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -23,6 +23,10 @@ for project.class
             class.api = "api/$(class.name:c).api"
         elsif file.exists ("api/$(class.name:c).xml")
             class.api = "api/$(class.name:c).xml"
+        elsif file.exists ("/usr/local/share/zproject/$(class.name:c).api")
+            class.api = "/usr/local/share/zproject/$(class.name:c).api"
+        elsif file.exists ("/usr/share/zproject/$(class.name:c).api")
+            class.api = "/usr/share/zproject/$(class.name:c).api"
         endif
     endif
 endfor


### PR DESCRIPTION
Solution: load API models in /usr/local and /usr. Order of preference is

    1. current dir for git snapshots
    2. /usr/local/share/ for results of make install
    3. /usr/share for installed rpm or Debian packages