### PR TITLE
Problem: python cffi incompatible with system installed czmq

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1648,7 +1648,7 @@ systemdsystemunit_DATA += src/$(bin.name)@.timer
 endif #WITH_SYSTEMD_UNITS
 .   endif
 .endfor
-# copy&paste from zproject_redhat.gsl
+.# copy&paste from zproject_redhat.gsl
 .for project.target where ( target.name = "*" | target.name = "python_cffi" > 0 )
 .   python_cffi = 1
 .endfor

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1648,11 +1648,18 @@ systemdsystemunit_DATA += src/$(bin.name)@.timer
 endif #WITH_SYSTEMD_UNITS
 .   endif
 .endfor
+# copy&paste from zproject_redhat.gsl
+.for project.target where ( target.name = "*" | target.name = "python_cffi" > 0 )
+.   python_cffi = 1
+.endfor
 .for class where defined (class.api)
 .   if first ()
 # Install api files into /usr/local/share/zproject
 apidir = @datadir@/zproject/$(project.name)
 dist_api_DATA = \\
+.       if python_cffi ?= 1
+    api/python_cffi.slurp \\
+.       endif
 .   endif
 .# Install files that the api includes
 .   for class.include

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -10,6 +10,11 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# copy&paste from zproject_redhat.gsl
+for project.target where ( target.name = "*" | target.name = "python_cffi" > 0 )
+   python_cffi = 1
+endfor
+
 # Resolve filename for each class API (undefined if the file is not found)
 for project.class
     class.private ?= "0"
@@ -30,6 +35,19 @@ for project.class
         endif
     endif
 endfor
+
+if python_cffi ?= 1
+# Resolve python_cffi slurps
+    for project.use
+        if file.exists ("../$(use.project:c)/api/python_cffi.slurp")
+            use.python_cffi_slurp = "../$(use.project:c)/api/$(use.project:c).slurp"
+        elsif file.exists ("/usr/local/share/zproject/$(use.project:c)/python_cffi.slurp")
+            use.python_cffi_slurp = "/usr/local/share/zproject/$(use.project:c)/python_cffi.slurp"
+        elsif file.exists ("/usr/share/zproject/$(use.project:c)/python_cffi.slurp")
+            use.python_cffi_slurp = "/usr/share/zproject/$(use.project:c)/python_cffi.slurp"
+        endif
+    endfor
+endif
 
 # Replace each class item with the class model from its API file (if any)
 for project.class where defined (class.api)

--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -380,9 +380,10 @@ function generate_binding
     >    ffibuilder.compile (verbose=True)
     >    ffidestructorbuilder.compile (verbose=True)
 
-    output "bindings/python_cffi/$(project.name:c)_cffi/_cdefs.inc"
+    directory.create ("api/")
+    output "api/python_cffi.slurp"
     >$(project.GENERATED_WARNING_HEADER:)
-    ># This file is intended to be included while generating cffi binding for top level library
+    ># Python cffi compatible file slurp
     >
     >$(project.name:c)_cdefs = list ()
     ># Custom setup for $(project.name)
@@ -399,11 +400,9 @@ function generate_binding
     >$(file.slurp('src/python_cffi.inc')?'')
     >
     >#Import definitions from dependent projects
-    for project.use
-        if file.exists ('../$(use.project:c)/bindings/python_cffi/$(use.project:c)_cffi/_cdefs.inc')
-            >$(file.slurp('../$(use.project:c)/bindings/python_cffi/$(use.project:c)_cffi/_cdefs.inc'))
-            >$(project.name:c)_cdefs.extend ($(use.project)_cdefs)
-        endif
+    for project.use where defined (use.python_cffi_slurp)
+        >$(file.slurp(use.python_cffi_slurp))
+        >$(project.name:c)_cdefs.extend ($(use.project)_cdefs)
     endfor
     >
     >$(project.name:c)_cdefs.append ('''

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -189,7 +189,7 @@ This package contains development files for $(project.name): $(project.descripti
 # Install api files into /usr/local/share/zproject
 %dir %{_datadir}/zproject/
 %dir %{_datadir}/zproject/$(project.name)
-%{_datadir}/zproject/$(project.name)/*.api
+%{_datadir}/zproject/$(project.name)/*
 .      endif
 .   endfor
 .endif


### PR DESCRIPTION
Solution: do not rely on random git snapshot when generating bindings.
Instead generate api/python_cffi.slurp and install it together with api
files. Then slurp the file from following locations

1. ../$project/api/ to use git snapshots
2. /usr/local/share to use result of make install
3. /usr/share tu use installed rpm or debian packages

This ensures consitency between installed czmq-devel and generated
bindings.