### PR TITLE
Problem: Jenkinsfile only archves one test-suite.log, and hides the fault

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,9 +206,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" check'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -233,9 +233,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" check'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -260,9 +260,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" VERBOSE=1 memcheck-verbose'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -287,9 +287,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" VERBOSE=1 memcheck-verbose'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -314,9 +314,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes --with-docs=no" ; export DISTCHECK_CONFIGURE_FLAGS; make DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" distcheck'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -341,9 +341,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no --with-docs=no" ; export DISTCHECK_CONFIGURE_FLAGS; make DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" distcheck'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -402,9 +402,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" check'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -446,9 +446,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" check'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -490,9 +490,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" VERBOSE=1 memcheck-verbose'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -534,9 +534,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make LD_LIBRARY_PATH="$LD_LIBRARY_PATH" VERBOSE=1 memcheck-verbose'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -578,9 +578,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes --with-docs=no" ; export DISTCHECK_CONFIGURE_FLAGS; make DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" distcheck'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }
@@ -622,9 +622,9 @@ pipeline {
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; LD_LIBRARY_PATH="`pwd`/src/.libs:\$LD_LIBRARY_PATH"; export LD_LIBRARY_PATH; DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no --with-docs=no" ; export DISTCHECK_CONFIGURE_FLAGS; make DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" distcheck'
                           }
                           catch (Exception e) {
-                            dir("..") {
-                                archiveArtifacts artifacts: "**/test-suite.log", allowEmpty: true
-                            }
+                            sh 'D="`pwd`"; B="`basename "$D"`" ; tar czf test-suite_"$B".tgz `find . -name '*.trs'` `find . -name '*.log'`'
+                            archiveArtifacts artifacts: "**/test-suite*.tgz", allowEmpty: true
+                            throw e
                           }
                          }
                         }


### PR DESCRIPTION
Solution: tarball the test logs (and trace-files); throw the procesed exception up the stack so error is visible (and e.g. a retry{} happens)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>