### PR TITLE
Better python setup.py generation

### DIFF
--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -239,20 +239,28 @@ function method_definition (method)
 endfunction
 
 function generate_setup_py
-    output "setup.py"
-    >from distutils.core import setup
+    output "bindings/python/setup.py"
+    >$(project.GENERATED_WARNING_HEADER:)
+    >from setuptools import setup
     >
-    >setup(name='$(project.name:c)',
-    if defined (project.description)
-    >	  description="""$(project.description:no)""",
-    endif
-    >	  version='0.1',
+    >setup(
+    >    name = "$(project.name:c)",
+    >    version = "$(project->version.major).$(project->version.minor).$(project->version.patch)",
+    >    license = "$(project.license)",
+    >    description = """Python bindings of: $(project.description)""",
     if defined (project.repository)
-    >	  url='$(project.repository)',
+    >    url = "$(project.repository)",
     endif
-    >	  packages=['$(project.name:c)'],
-    >	  package_dir={'': 'bindings/python'},
+    >    packages = ["$(project.name:c)"],
+    >    install_requires = [
+   for project.use
+       if count (project->dependencies.class, class.project = use.project) > 0
+    >        "$(use.project)",
+       endif
+   endfor
+    >    ],
     >)
+    >$(project.GENERATED_WARNING_HEADER:)
 endfunction
 
 function generate_binding


### PR DESCRIPTION
Generate the setup.py in the binding/python (each project should remove setup.py at the root)
Add dependencies, licencse, version (like for cffi)