### PR TITLE
Allow projects without czmq dependency (part 1)

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -205,6 +205,9 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #include "$(project.prefix)_classes.$(project.header_ext)"
 
+#include <stdio.h>
+#include <string.h>
+
 typedef struct {
     const char *testname;           // test name, can be called from command line this way
     void (*test) (bool);            // function to run the test (or NULL for private tests)
@@ -260,7 +263,7 @@ test_available (const char *testname)
 {
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (streq (testname, item->testname))
+        if (strcmp (testname, item->testname) == 0)
             return item;
     }
     return NULL;
@@ -276,7 +279,7 @@ test_runall (bool verbose)
     test_item_t *item;
     printf ("Running $(project.name) selftests...\\n");
     for (item = all_tests; item->testname; item++) {
-        if (streq (item->testname, "private_classes"))
+        if (strcmp (item->testname, "private_classes") == 0)
             continue;
         if (!item->subtest)
             item->test (verbose);
@@ -306,7 +309,7 @@ test_number (void)
     int n = 0;
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (! streq (item->testname, "private_classes"))
+        if (! strcmp (item->testname, "private_classes") == 0)
             n++;
     }
     printf ("%d\\n", n);
@@ -319,8 +322,8 @@ main (int argc, char **argv)
     test_item_t *test = 0;
     int argn;
     for (argn = 1; argn < argc; argn++) {
-        if (streq (argv [argn], "--help")
-        ||  streq (argv [argn], "-h")) {
+        if (strcmp (argv [argn], "--help") == 0
+        ||  strcmp (argv [argn], "-h") == 0) {
             puts ("$(project.prefix)_selftest.c [options] ...");
             puts ("  --verbose / -v         verbose test output");
             puts ("  --number / -n          report number of tests");
@@ -329,24 +332,24 @@ main (int argc, char **argv)
             puts ("  --continue / -c        continue on exception (on Windows)");
             return 0;
         }
-        if (streq (argv [argn], "--verbose")
-        ||  streq (argv [argn], "-v"))
+        if (strcmp (argv [argn], "--verbose") == 0
+        ||  strcmp (argv [argn], "-v") == 0)
             verbose = true;
         else
-        if (streq (argv [argn], "--number")
-        ||  streq (argv [argn], "-n")) {
+        if (strcmp (argv [argn], "--number") == 0
+        ||  strcmp (argv [argn], "-n") == 0) {
             test_number ();
             return 0;
         }
         else
-        if (streq (argv [argn], "--list")
-        ||  streq (argv [argn], "-l")) {
+        if (strcmp (argv [argn], "--list") == 0
+        ||  strcmp (argv [argn], "-l") == 0) {
             test_list ();
             return 0;
         }
         else
-        if (streq (argv [argn], "--test")
-        ||  streq (argv [argn], "-t")) {
+        if (strcmp (argv [argn], "--test") == 0
+        ||  strcmp (argv [argn], "-t") == 0) {
             argn++;
             if (argn >= argc) {
                 fprintf (stderr, "--test needs an argument\\n");
@@ -359,8 +362,8 @@ main (int argc, char **argv)
             }
         }
         else
-        if (streq (argv [argn], "--continue")
-        ||  streq (argv [argn], "-c")) {
+        if (strcmp (argv [argn], "--continue") == 0
+        ||  strcmp (argv [argn], "-c") == 0) {
 #ifdef _MSC_VER
             //  When receiving an abort signal, only print to stderr (no dialog)
             _set_abort_behavior (0, _WRITE_ABORT_MSG);


### PR DESCRIPTION
The generated code expects that czmq pulls in a few headers and macro
definitions. This is a minimal fix for the generated selftest file in
C++ mode.