### PR TITLE
fix configuration names in build.bat

### DIFF
--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -702,23 +702,23 @@ CALL %environment% x86 >> %log%
 @if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x86
 
-ECHO Configuration=DynDebug
-msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=DebugDLL
+msbuild /m /v:n /p:Configuration=DebugLL /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=DynRelease
-msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=ReleaseDLL
+msbuild /m /v:n /p:Configuration=ReleaseDLL /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=LtcgDebug
-msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=DebugLTCG
+msbuild /m /v:n /p:Configuration=DebugLTCG /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=LtcgRelease
-msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=ReleaseLTCG
+msbuild /m /v:n /p:Configuration=ReleaseLTCG /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=StaticDebug
-msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=DebugLIB
+msbuild /m /v:n /p:Configuration=DebugLIB /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=StaticRelease
-msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=ReleaseLIB
+msbuild /m /v:n /p:Configuration=ReleaseLIB /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
 
 :: restore original path
@@ -729,23 +729,23 @@ CALL %environment% x86_amd64 >> %log%
 @if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x64
 
-ECHO Configuration=DynDebug
-msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=DebugDLL
+msbuild /m /v:n /p:Configuration=DebugDLL /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=DynRelease
-msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=ReleaseDLL
+msbuild /m /v:n /p:Configuration=ReleaseDLL /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=LtcgDebug
-msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=DebugLTCG
+msbuild /m /v:n /p:Configuration=DebugLTCG /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=LtcgRelease
-msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=ReleaseLTCG
+msbuild /m /v:n /p:Configuration=ReleaseLTCG /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=StaticDebug
-msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=DebugLIB
+msbuild /m /v:n /p:Configuration=DebugLIB /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=StaticRelease
-msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=ReleaseLIB
+msbuild /m /v:n /p:Configuration=ReleaseLIB /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
 
 ECHO %action% complete: %packages% %solution%


### PR DESCRIPTION
Building on windows by calling build.bat fails as it tries to build
projetc configurations which do not exists in the visual studio solution
or project files. This commit changes the configuration names in the genereated
build.bat file to be in sync with the visual studio solution and project
file.