### PR TITLE
include private selftest source in vs project file

### DIFF
--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -323,6 +323,11 @@ $(project.GENERATED_WARNING_HEADER:)
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
 .endfor
+.if count (class)
+    <ClCompile Include="..\\..\\..\\..\\src\\$(project.prefix)_private_selftest.$(project.source_ext)">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+.endif
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\\..\\resource.rc" />
@@ -350,6 +355,11 @@ $(project.GENERATED_WARNING_HEADER:)
       <Filter>src</Filter>
     </ClCompile>
 .endfor
+.if count (class)
+    <ClCompile Include="..\\..\\..\\..\\src\\$(project.prefix)_private_selftest.$(project.source_ext)">
+      <Filter>src</Filter>
+    </ClCompile>
+.endif
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\\..\\..\\..\\include\\$(project.prefix)_library.$(project.header_ext)">


### PR DESCRIPTION
When compiling the visual studio solution with visual studion vs20xx,
the compiler complains about the missing symbol *_private_selftest
(i.e. for czmq project, czmq_private_selftest).
Other generated build systems do contain the source of the
private_selftest function (for draft builds).
This commit adds the private_selftest source file to the visual studio
project file. Please note that the generator for the visual studion 2008
already does include the private_selftest source file into the generated
project file.