### PR TITLE
force c-linkage for private_selfttest function

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -172,9 +172,18 @@ typedef struct _$(class.c_name:)_t $(class.c_name:)_t;
 .endfor
 
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //  Self test for private classes
 $(PROJECT.PREFIX)_EXPORT void
     $(project.prefix)_private_selftest (bool verbose, const char *subtest);
+
+#ifdef __cplusplus
+}
+#endif
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 
 #endif


### PR DESCRIPTION
When building on windows with visual studio, source files are
compiled using the c++-compiler. So all exported symbols need
to be enclosed by an extern "C" {} to force c-linkage (which
almost all exported symbols do already).
However the private_selftest function, which gets exported in
project_library.h (i.e. czmq_library.h) when building
in draft mode, is missing an extetn "C".

This commit encloses the private_selftest function declaration in an
extern "C" block to also force c-linkage for that symbol.