### PR TITLE
generate valid visual studio solution file 

### DIFF
--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -445,7 +445,7 @@ $(project.GENERATED_WARNING_HEADER:)
 -->
 <Project DefaultTargets="Build" ToolsVersion="$(my.level).0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A5497C4B-1CD1-4779-9458-2CF7908E7E26}</ProjectGuid>
+    <ProjectGuid>{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}</ProjectGuid>
     <ProjectName>$(main.name)</ProjectName>
     <PlatformToolset>v$(my.level)0</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
@@ -586,77 +586,79 @@ Microsoft Visual Studio Solution File, Format Version $(my.level).00
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "$(project.libname)", "$(project.libname)\\$(project.libname).vcxproj", "{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}"
 EndProject
 .for project.main
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "$(main.name)", "$(main.name)\\$(main.name).vcxproj", "{A5497C4B-1CD1-4779-9458-2CF7908E7E26}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "$(main.name)", "$(main.name)\\$(main.name).vcxproj", "{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}"
 EndProject
 .endfor
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        DynDebug|Win32 = DynDebug|Win32
-        DynDebug|x64 = DynDebug|x64
-        DynRelease|Win32 = DynRelease|Win32
-        DynRelease|x64 = DynRelease|x64
-        LtcgDebug|Win32 = LtcgDebug|Win32
-        LtcgDebug|x64 = LtcgDebug|x64
-        LtcgRelease|Win32 = LtcgRelease|Win32
-        LtcgRelease|x64 = LtcgRelease|x64
-        StaticDebug|Win32 = StaticDebug|Win32
-        StaticDebug|x64 = StaticDebug|x64
-        StaticRelease|Win32 = StaticRelease|Win32
-        StaticRelease|x64 = StaticRelease|x64
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|Win32.ActiveCfg = DebugDLL|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|Win32.Build.0 = DebugDLL|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|x64.ActiveCfg = DebugDLL|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|x64.Build.0 = DebugDLL|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|Win32.ActiveCfg = ReleaseDLL|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|Win32.Build.0 = ReleaseDLL|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|x64.ActiveCfg = ReleaseDLL|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|x64.Build.0 = ReleaseDLL|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|Win32.ActiveCfg = DebugLTCG|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|Win32.Build.0 = DebugLTCG|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|x64.ActiveCfg = DebugLTCG|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|x64.Build.0 = DebugLTCG|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|Win32.ActiveCfg = ReleaseLTCG|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|Win32.Build.0 = ReleaseLTCG|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|x64.ActiveCfg = ReleaseLTCG|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|x64.Build.0 = ReleaseLTCG|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|Win32.ActiveCfg = DebugLIB|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|Win32.Build.0 = DebugLIB|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|x64.ActiveCfg = DebugLIB|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|x64.Build.0 = DebugLIB|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|Win32.ActiveCfg = ReleaseLIB|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|Win32.Build.0 = ReleaseLIB|Win32
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|x64.ActiveCfg = ReleaseLIB|x64
-        {0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|x64.Build.0 = ReleaseLIB|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynDebug|x64.Build.0 = DebugDEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticDebug|x64.Build.0 = DebugSEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
-        {A5497C4B-1CD1-4779-9458-2CF7908E7E26}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
-    EndGlobalSection
-    GlobalSection(SolutionProperties) = preSolution
-        HideSolutionNode = FALSE
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		DynDebug|Win32 = DynDebug|Win32
+		DynDebug|x64 = DynDebug|x64
+		DynRelease|Win32 = DynRelease|Win32
+		DynRelease|x64 = DynRelease|x64
+		LtcgDebug|Win32 = LtcgDebug|Win32
+		LtcgDebug|x64 = LtcgDebug|x64
+		LtcgRelease|Win32 = LtcgRelease|Win32
+		LtcgRelease|x64 = LtcgRelease|x64
+		StaticDebug|Win32 = StaticDebug|Win32
+		StaticDebug|x64 = StaticDebug|x64
+		StaticRelease|Win32 = StaticRelease|Win32
+		StaticRelease|x64 = StaticRelease|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|Win32.ActiveCfg = DebugDLL|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|Win32.Build.0 = DebugDLL|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|x64.ActiveCfg = DebugDLL|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynDebug|x64.Build.0 = DebugDLL|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|Win32.ActiveCfg = ReleaseDLL|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|Win32.Build.0 = ReleaseDLL|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|x64.ActiveCfg = ReleaseDLL|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.DynRelease|x64.Build.0 = ReleaseDLL|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|Win32.ActiveCfg = DebugLTCG|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|Win32.Build.0 = DebugLTCG|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|x64.ActiveCfg = DebugLTCG|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgDebug|x64.Build.0 = DebugLTCG|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|Win32.ActiveCfg = ReleaseLTCG|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|Win32.Build.0 = ReleaseLTCG|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|x64.ActiveCfg = ReleaseLTCG|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.LtcgRelease|x64.Build.0 = ReleaseLTCG|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|Win32.ActiveCfg = DebugLIB|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|Win32.Build.0 = DebugLIB|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|x64.ActiveCfg = DebugLIB|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticDebug|x64.Build.0 = DebugLIB|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|Win32.ActiveCfg = ReleaseLIB|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|Win32.Build.0 = ReleaseLIB|Win32
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|x64.ActiveCfg = ReleaseLIB|x64
+		{0C4A2E28-8C9E-4B27-85D9-BB679AD84AC7}.StaticRelease|x64.Build.0 = ReleaseLIB|x64
+.for project.main
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynDebug|x64.Build.0 = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticDebug|x64.Build.0 = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-$(string.hash(main.name))}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
+.endfor
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 EndGlobal
 .output "$(my.path)/build.bat"
 @if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script

--- a/zproject_vs20xx.gsl
+++ b/zproject_vs20xx.gsl
@@ -712,23 +712,23 @@ CALL %environment% x86 >> %log%
 @if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x86
 
-ECHO Configuration=DebugDLL
-msbuild /m /v:n /p:Configuration=DebugLL /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=DynDebug
+msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=ReleaseDLL
-msbuild /m /v:n /p:Configuration=ReleaseDLL /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=DynRelease
+msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=DebugLTCG
-msbuild /m /v:n /p:Configuration=DebugLTCG /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=LtcgDebug
+msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=ReleaseLTCG
-msbuild /m /v:n /p:Configuration=ReleaseLTCG /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=LtcgRelease
+msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=DebugLIB
-msbuild /m /v:n /p:Configuration=DebugLIB /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=StaticDebug
+msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=ReleaseLIB
-msbuild /m /v:n /p:Configuration=ReleaseLIB /p:Platform=Win32 %packages% %solution% %target% >> %log%
+ECHO Configuration=StaticRelease
+msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=Win32 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
 
 :: restore original path
@@ -739,23 +739,23 @@ CALL %environment% x86_amd64 >> %log%
 @if "%ECHOON%" == "" (@echo off) else (@echo %ECHOON%)&:: set ECHOON=on if you want to debug this script
 ECHO Platform=x64
 
-ECHO Configuration=DebugDLL
-msbuild /m /v:n /p:Configuration=DebugDLL /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=DynDebug
+msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=ReleaseDLL
-msbuild /m /v:n /p:Configuration=ReleaseDLL /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=DynRelease
+msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=DebugLTCG
-msbuild /m /v:n /p:Configuration=DebugLTCG /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=LtcgDebug
+msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=ReleaseLTCG
-msbuild /m /v:n /p:Configuration=ReleaseLTCG /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=LtcgRelease
+msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=DebugLIB
-msbuild /m /v:n /p:Configuration=DebugLIB /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=StaticDebug
+msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
-ECHO Configuration=ReleaseLIB
-msbuild /m /v:n /p:Configuration=ReleaseLIB /p:Platform=x64 %packages% %solution% %target% >> %log%
+ECHO Configuration=StaticRelease
+msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=x64 %packages% %solution% %target% >> %log%
 IF errorlevel 1 GOTO error
 
 ECHO %action% complete: %packages% %solution%


### PR DESCRIPTION
when loading the generated solution file in visual studio, it gets
rewritten by visual studio, replacing solution build configurations
and platforms.
This commit tries to improve generation of visual studio files by
- generating unique subproject guids using the project name hash
- generating project configuration platforms for each subproject
- using tabs instead of spaces for indentation´

fixes #1055 