### PR TITLE
Problem: make distcheck failed about missing private headers

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1449,6 +1449,9 @@ EXTRA_DIST += \\
 .for class where scope = "private"
     src/$(name:$(project.filename_prettyprint)).$(project.header_ext) \\
 .endfor
+.for header where scope = "private"
+    src/$(name:$(project.filename_prettyprint)).$(project.header_ext) \\
+.endfor
 .if file.exists ("LICENSE")
     LICENSE \\
 .endif


### PR DESCRIPTION
Problem : private headers are not listed in EXTRA_DIST, so make distcheck could not find them.
Solution: add them 
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>