### PR TITLE
 clang-format-check : provide an autotools-only implementation for travis users

### DIFF
--- a/builds/cmake/Modules/ClangFormat.cmake
+++ b/builds/cmake/Modules/ClangFormat.cmake
@@ -11,7 +11,7 @@ file(GLOB_RECURSE ALL_SOURCE_FILES
      ${CMAKE_SOURCE_DIR}/perf/*.h ${CMAKE_SOURCE_DIR}/perf/*.hpp
      ${CMAKE_SOURCE_DIR}/tools/*.c ${CMAKE_SOURCE_DIR}/tools/*.cc ${CMAKE_SOURCE_DIR}/tools/*.cpp
      ${CMAKE_SOURCE_DIR}/tools/*.h ${CMAKE_SOURCE_DIR}/tools/*.hpp
-     ${CMAKE_SOURCE_DIR}/include/*.h
+     ${CMAKE_SOURCE_DIR}/include/*.h ${CMAKE_SOURCE_DIR}/include/*.hpp
     )
 
 if("${CLANG_FORMAT}" STREQUAL "")

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -29,6 +29,10 @@ fi
 mkdir -p tmp
 BUILD_PREFIX=$PWD/tmp
 
+# Use tools from prerequisites we might have built
+PATH="${BUILD_PREFIX}/sbin:${BUILD_PREFIX}/bin:${PATH}"
+export PATH
+
 CONFIG_OPTS=()
 CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
 CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -224,6 +224,7 @@ ALL_SOURCE_FILES = $(wildcard \
 	$(top_srcdir)/tools/*.h \
 	$(top_srcdir)/tools/*.hpp \
 	$(top_srcdir)/include/*.h \
+	$(top_srcdir)/include/*.hpp \
  )
 
 # Check if any sources need to be fixed, report the filenames and an error code

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1925,6 +1925,7 @@ ALL_SOURCE_FILES = \$(wildcard \\
 \t\$(top_srcdir)/tools/*.h \\
 \t\$(top_srcdir)/tools/*.hpp \\
 \t\$(top_srcdir)/include/*.h \\
+\t\$(top_srcdir)/include/*.hpp \\
  )
 
 # Check if any sources need to be fixed, report the filenames and an error code

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -851,7 +851,7 @@ file(GLOB_RECURSE ALL_SOURCE_FILES
      ${CMAKE_SOURCE_DIR}/perf/*.h ${CMAKE_SOURCE_DIR}/perf/*.hpp
      ${CMAKE_SOURCE_DIR}/tools/*.c ${CMAKE_SOURCE_DIR}/tools/*.cc ${CMAKE_SOURCE_DIR}/tools/*.cpp
      ${CMAKE_SOURCE_DIR}/tools/*.h ${CMAKE_SOURCE_DIR}/tools/*.hpp
-     ${CMAKE_SOURCE_DIR}/include/*.h
+     ${CMAKE_SOURCE_DIR}/include/*.h ${CMAKE_SOURCE_DIR}/include/*.hpp
     )
 
 if("${CLANG_FORMAT}" STREQUAL "")

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -677,6 +677,10 @@ fi
 mkdir -p tmp
 BUILD_PREFIX=$PWD/tmp
 
+# Use tools from prerequisites we might have built
+PATH="${BUILD_PREFIX}/sbin:${BUILD_PREFIX}/bin:${PATH}"
+export PATH
+
 CONFIG_OPTS=()
 CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
 CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -138,6 +138,9 @@ matrix:
         packages:
         - *pkg_deps_common
   - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
+# For non-cmake users, there is an autotools solution with a bit more overhead
+# to have dependencies ready and pass configure script before making this check):
+#  - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
     os: linux
     dist: trusty
     addons:
@@ -197,7 +200,7 @@ case "$CI_TRACE" in
 esac
 
 case "$BUILD_TYPE" in
-default|default-Werror|default-with-docs|valgrind)
+default|default-Werror|default-with-docs|valgrind|clang-format-check)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -451,13 +454,25 @@ default|default-Werror|default-with-docs|valgrind)
 .   endif
     $CI_TIME ./autogen.sh 2> /dev/null
     $CI_TIME ./configure --enable-drafts=yes "${CONFIG_OPTS[@]}"
-    if [ "$BUILD_TYPE" == "valgrind" ] ; then
-        # Build and check this project
-        $CI_TIME make VERBOSE=1 memcheck && exit
-        echo "Re-running failed ($?) memcheck with greater verbosity" >&2
-        $CI_TIME make VERBOSE=1 memcheck-verbose
-        exit $?
-    fi
+    case "$BUILD_TYPE" in
+        valgrind)
+            # Build and check this project
+            $CI_TIME make VERBOSE=1 memcheck && exit
+            echo "Re-running failed ($?) memcheck with greater verbosity" >&2
+            $CI_TIME make VERBOSE=1 memcheck-verbose
+            exit $?
+            ;;
+        clang-format-check)
+            RES=0
+            $CI_TIME make VERBOSE=1 clang-format-check || {
+                RES=$?
+                echo "" >&2
+                echo "Style mismatches were found by clang-format; detailing below:" >&2
+                $CI_TIME make VERBOSE=1 clang-format-diff || RES=$?
+            }
+            exit $RES
+            ;;
+    esac
     $CI_TIME make VERBOSE=1 all
 
     echo "=== Are GitIgnores good after 'make all' with drafts?"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -208,7 +208,7 @@ default|default-Werror|default-with-docs|valgrind)
     mkdir -p tmp
     BUILD_PREFIX=$PWD/tmp
 
-    PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'2`"
+    PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'`"
     CCACHE_PATH="$PATH"
     CCACHE_DIR="${HOME}/.ccache"
     # Use tools from prerequisites we might have built

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -211,6 +211,8 @@ default|default-Werror|default-with-docs|valgrind)
     PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'2`"
     CCACHE_PATH="$PATH"
     CCACHE_DIR="${HOME}/.ccache"
+    # Use tools from prerequisites we might have built
+    PATH="${BUILD_PREFIX}/sbin:${BUILD_PREFIX}/bin:${PATH}"
     export CCACHE_PATH CCACHE_DIR PATH
     HAVE_CCACHE=no
     if which ccache && ls -la /usr/lib/ccache ; then


### PR DESCRIPTION
Not enabled by default, but can be uncommented in the generated file (for teams who do not use cmake and so have its files removed from the tree).