### PR TITLE
Problem: debian copyright is always from 2015

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -2,7 +2,7 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: zproject
 
 Files: *
-Copyright: 2015- zproject Developers <zeromq-dev@lists.zeromq.org>
+Copyright: 2014- zproject Developers <zeromq-dev@lists.zeromq.org>
 License: zproject_license
  Copyright (c) the Contributors as noted in the AUTHORS file.
  This file is part of CZMQ, the high-level C binding for 0MQ:

--- a/project.xml
+++ b/project.xml
@@ -39,6 +39,7 @@
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"
     license = "MPLv2"
+    starting_year = "2014"
     url = "https://github.com/zeromq/zproject"
     repository = "https://github.com/zeromq/zproject">
 

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -187,7 +187,11 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: $(project.name)
 
 Files: *
+.if defined (project.starting_year)
+Copyright: $(project.starting_year)- $(project.name) Developers <$(project.email)>
+.else
 Copyright: 2015- $(project.name) Developers <$(project.email)>
+.endif
 License: $(project.name)_license
 .   for project.license
  $(string.replace(string.trim (license.), '\n\n|\n.\n'):block)


### PR DESCRIPTION
Solution: make the project.starting_year a configurable value

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>