### PR TITLE
Problem: building manpages for mains in nested dirs 

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -42,9 +42,9 @@ SUFFIXES=.txt .adoc .xml .xml7 .1 .3 .7
 	asciidoc -d manpage -b docbook -f $(srcdir)/asciidoc.conf \
         -azproject_version=@PACKAGE_VERSION@ -o$@ $<
 .xml.1:
-	xmlto man $<
+	xmlto -o $(@D) man $<
 .xml.3:
-	xmlto man $<
+	xmlto -o $(@D) man $<
 
 # Special handling for project overview whose basename may collide
 # with a main or class name
@@ -52,7 +52,7 @@ SUFFIXES=.txt .adoc .xml .xml7 .1 .3 .7
 	asciidoc -d manpage -b docbook -f $(srcdir)/asciidoc.conf \
         -azproject_version=@PACKAGE_VERSION@ -o$@ $<
 .xml7.7:
-	xmlto man $<
+	xmlto -o $(@D) man $<
 
 # List of *.txt and *.doc files generated during build from comments
 # in project program source files and further processed into manpages.
@@ -64,6 +64,9 @@ GENERATED_DOCS =
 .txt.doc:
 	@true
 
+### Note: for mains, we keep the source name rather than flattened name:c
+### so that the manpages for binary programs match their name, at expense
+### of perhaps being built in a subdirectory under doc/.
 
 clean-local:
 	rm -f *.1 *.3 *.7 $(GENERATED_DOCS)

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -2434,6 +2434,9 @@ generate_manpage ($name, $outp, $rootsrcdir);
 .      man3 += " $(name:c).3"
 .   endfor
 .   man1 = ""
+.### Note: here we keep the name rather than name:c so that the
+.### manpages for binary programs match their name, at expense
+.### of perhaps being built in a subdirectory.
 .   for my.project.main where scope = "public"
 .      man1 += " $(name).1"
 .   endfor
@@ -2482,9 +2485,9 @@ SUFFIXES=.txt .adoc .xml .xml7 .1 .3 .7
 \tasciidoc -d manpage -b docbook -f $\(srcdir)/asciidoc.conf \\
         -a$(project.name)_version=@PACKAGE_VERSION@ -o$@ $<
 \.xml.1:
-\txmlto man $<
+\txmlto -o $\(@D) man $<
 \.xml.3:
-\txmlto man $<
+\txmlto -o $\(@D) man $<
 
 # Special handling for project overview whose basename may collide
 # with a main or class name
@@ -2492,7 +2495,7 @@ SUFFIXES=.txt .adoc .xml .xml7 .1 .3 .7
 \tasciidoc -d manpage -b docbook -f $\(srcdir)/asciidoc.conf \\
         -a$(project.name)_version=@PACKAGE_VERSION@ -o$@ $<
 \.xml7.7:
-\txmlto man $<
+\txmlto -o $\(@D) man $<
 
 # List of *.txt and *.doc files generated during build from comments
 # in project program source files and further processed into manpages.
@@ -2514,6 +2517,9 @@ $(name:c).txt: $\(top_srcdir)/src/$(name:$(project.filename_prettyprint)).c
 \t"$\(srcdir)/mkman" "$(name:$(project.filename_prettyprint))" "$\(builddir)/$(name:c).txt" "$\(srcdir)/.."
 
 .endfor
+### Note: for mains, we keep the source name rather than flattened name:c
+### so that the manpages for binary programs match their name, at expense
+### of perhaps being built in a subdirectory under doc/.
 .for project.main where scope = "public"
 GENERATED_DOCS += $(name).txt $(name).doc
 .   if file.exists ("src/$(name:$(project.filename_prettyprint)).$(project.source_ext)")
@@ -2521,6 +2527,7 @@ $(name).txt: $\(top_srcdir)/src/$(name:$(project.filename_prettyprint)).$(projec
 .   else
 $(name).txt: $\(top_srcdir)/src/$(name:$(project.filename_prettyprint)).c
 .   endif
+\tmkdir -p "$\(builddir)/$\(@D)"
 \t"$\(srcdir)/mkman" "$(name:$(project.filename_prettyprint))" "$\(builddir)/$(name).txt" "$\(srcdir)/.."
 
 .endfor


### PR DESCRIPTION
Solution:

* ensure making the directory for generated txt/doc files for mains
* tell `xmlto` to output generated files into target (not current) dir
* Regenerate zproject
    
Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>
