### PR TITLE
Problem: successful PR builds waste space on Jenkins servers

### DIFF
--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -237,6 +237,10 @@ pipeline {
             description: 'When using temporary subdirs in build/test workspaces, wipe them after successful builds?',
             name: 'DO_CLEANUP_AFTER_BUILD')
 .  endif
+        booleanParam (
+            defaultValue: true,
+            description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done successfully?',
+            name: 'DO_CLEANUP_AFTER_JOB')
     }
 .  if !(defined(project.jenkins_triggers_pollSCM))
     triggers {
@@ -914,6 +918,14 @@ pipeline {
 
                     //slackSend (color: "#008800", message: "Build \$\{env.JOB_NAME} is back to normal.")
                     //emailext (to: "qa@example.com", subject: "Build \$\{env.JOB_NAME} is back to normal.", body: "Build \$\{env.JOB_NAME} is back to normal.")
+                }
+                if ( params.DO_CLEANUP_AFTER_JOB ) {
+                    dir("tmp") {
+.           if project.jenkins_use_deleteDir_rm_first ?= 1
+                        sh '_PWD="`pwd`" ; cd /tmp ; rm -rf "$_PWD" || true ; mkdir -p "$_PWD"'
+.           endif
+                        deleteDir()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Solution: clean up the tmp/ sub-directory after a successful job completion (allow to inspect codebase on worker if build failed) by default, can be overridden for a particular run of a build with arguments to keep even a successful workspace.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>