### PR TITLE
Sanitize --enable-Werror support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,9 +5,6 @@
 
 ACLOCAL_AMFLAGS = -I config
 
-AM_CFLAGS = \
-    -Werror=format-security
-
 
 AM_CPPFLAGS = \
     -I$(srcdir)/include

--- a/configure.ac
+++ b/configure.ac
@@ -317,11 +317,6 @@ AC_TYPE_UINT32_T
 AC_C_VOLATILE
 AC_C_BIGENDIAN
 
-# These options are GNU compiler specific.
-if test "x$GCC" = "xyes"; then
-    CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
-fi
-
 AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$zproject_on_mingw32" = "xyes")
 AM_CONDITIONAL(ON_CYGWIN, test "x$zproject_on_cygwin" = "xyes")
@@ -365,26 +360,28 @@ fi
 
 AC_ARG_ENABLE([Werror],
     AS_HELP_STRING([--enable-Werror],
-        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified]]),
+        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified as the specific argument value]]),
     [AS_IF([test -n "$enableval"], [enable_Werror=$enableval], [enable_Werror=auto])],
     [enable_Werror=no])
 
+# These options are GNU compiler specific.
 AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
-    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
-         CFLAGS="$CFLAGS -Wall -Werror"],
+         CFLAGS="$CFLAGS -pedantic -Wall -Werror -Werror=format-security"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
          AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C: $CC])])
         ])])
-     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
-         CXXFLAGS="$CXXFLAGS -Wall -Werror"],
+         CXXFLAGS="$CXXFLAGS -pedantic -Wall -Werror -Werror=format-security"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
          AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++: $CXX])])
         ])])
-     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
-         CPPFLAGS="$CPPFLAGS -Wall -Werror"],
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+        ],
         [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
          AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
         ])])

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1014,15 +1014,6 @@ AC_TYPE_UINT32_T
 AC_C_VOLATILE
 AC_C_BIGENDIAN
 
-# These options are GNU compiler specific.
-if test "x$GCC" = "xyes"; then
-.if project.use_cxx
-    CPPFLAGS="-pedantic -Werror -Wall ${CPPFLAGS}"
-.else
-    CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
-.endif
-fi
-
 AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$$(project.name:c)_on_mingw32" = "xyes")
 AM_CONDITIONAL(ON_CYGWIN, test "x$$(project.name:c)_on_cygwin" = "xyes")
@@ -1170,26 +1161,32 @@ fi
 
 AC_ARG_ENABLE([Werror],
     AS_HELP_STRING([--enable-Werror],
-        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified]]),
+        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified as the specific argument value]]),
     [AS_IF([test -n "$enableval"], [enable_Werror=$enableval], [enable_Werror=auto])],
     [enable_Werror=no])
 
+# These options are GNU compiler specific.
 AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
-    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
-         CFLAGS="$CFLAGS -Wall -Werror"],
+         CFLAGS="$CFLAGS -pedantic -Wall -Werror -Werror=format-security"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C)])
          AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C: $CC])])
         ])])
-     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
-         CXXFLAGS="$CXXFLAGS -Wall -Werror"],
+         CXXFLAGS="$CXXFLAGS -pedantic -Wall -Werror -Werror=format-security"],
         [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU C++)])
          AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++: $CXX])])
         ])])
-     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
-         CPPFLAGS="$CPPFLAGS -Wall -Werror"],
+.if project.use_cxx
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall"
+.else
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+.endif
+        ],
         [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU CPP)])
          AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
         ])])
@@ -1471,12 +1468,8 @@ DISTCHECK_CONFIGURE_FLAGS = \\
 
 ACLOCAL_AMFLAGS = -I config
 
-AM_CFLAGS = \\
-    -Werror=format-security
-
 .if project.use_cxx
 AM_CXXFLAGS = \\
-    -Werror=format-security \\
     -std=c++11
 .endif
 

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -120,6 +120,10 @@ pipeline {
 .  endif
             description: 'Attempt build with DRAFT API in this run?',
             name: 'DO_BUILD_WITH_DRAFT_API')
+        choice (
+            choices: 'auto\\nyes\\nno',
+            description: 'Enable pedantic compiler options for common builds (auto turns into yes for GCC builds)?',
+            name: 'ENABLE_WERROR')
         booleanParam (
 .  if ( !(defined(project.jenkins_build_docs)) | (project.jenkins_build_docs ?= 0) )
 . # asciidoc and xmlto are external tools that may be not installed in general case
@@ -288,7 +292,7 @@ pipeline {
                         deleteDir()
 .       endif
                         unstash 'prepped'
-                        sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=yes --with-docs=no'
+                        sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=yes --enable-Werror="${params.ENABLE_WERROR}" --with-docs=no"""
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make -k -j4 || make'
                         sh """ echo "Are GitIgnores good after make with drafts?"; make CI_REQUIRE_GOOD_GITIGNORE="${params.CI_REQUIRE_GOOD_GITIGNORE}" check-gitignore """
                         stash (name: 'built-draft', includes: '**/*', excludes: '**/cppcheck.xml')
@@ -317,7 +321,7 @@ pipeline {
                         deleteDir()
 .       endif
                         unstash 'prepped'
-                        sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=no --with-docs=no'
+                        sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=no --enable-Werror="${params.ENABLE_WERROR}" --with-docs=no"""
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make -k -j4 || make'
                         sh """ echo "Are GitIgnores good after make without drafts?"; make CI_REQUIRE_GOOD_GITIGNORE="${params.CI_REQUIRE_GOOD_GITIGNORE}" check-gitignore """
                         stash (name: 'built-nondraft', includes: '**/*', excludes: '**/cppcheck.xml')
@@ -346,7 +350,7 @@ pipeline {
                         deleteDir()
 .       endif
                         unstash 'prepped'
-                        sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=yes --with-docs=yes'
+                        sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=yes --with-docs=yes --enable-Werror=no'
                         script {
                             if ( params.DO_DIST_DOCS ) {
                                 sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make dist-gzip || exit ; DISTFILE="`ls -1tc *.tar.gz | head -1`" && [ -n "\$DISTFILE" ] && [ -s "\$DISTFILE" ] || exit ; mv -f "\$DISTFILE" __dist.tar.gz'
@@ -409,7 +413,7 @@ pipeline {
                                     unstash 'built-docs'
                                 } else {
                                     unstash 'prepped'
-                                    sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=no --with-docs=no'
+                                    sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=no --enable-Werror="${params.ENABLE_WERROR}" --with-docs=no"""
                                 }
                             }
                             sh 'rm -f cppcheck.xml'
@@ -453,7 +457,7 @@ pipeline {
                                     unstash 'built-docs'
                                 } else {
                                     unstash 'prepped'
-                                    sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=no --with-docs=no'
+                                    sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; ./configure --enable-drafts=no --enable-Werror="${params.ENABLE_WERROR}" --with-docs=no"""
                                 }
                             }
                             sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make clang-format-check-CI'


### PR DESCRIPTION
* sanitize configure script and Makefile support for pedantic compile-time error-checking (less hardcoding, less conflict with random compilers, use the available configurability)
* allow use (or disablement) of the pedantic checks in Jenkins, similar to how Travis does both variants