### PR TITLE
Problem: headers always dumped into main includedir

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,14 +750,15 @@ Model is described in `zproject_known_projects.xml` file:
 
 Exemple:
 ```classfilename
-<classfilename use-cxx = "true" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
+<classfilename use-cxx = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
 ```
 
 * use-cxx will force usage (or not) of c++.
-* keep-tree will keeping the include tree on the install, must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
-* pretty-print define the type of class name format change in order to generate the filename. It use the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/imatix/gsl#expressions for more information).
+* keep-tree will keep the include tree structure on the install (as opposed to flat delivery of include files basenames into the single-level target directory), must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
+* pkgincludedir option chooses whether headers of this project should be dumped into the common system includedir (legacy default), or into an includedir/projname subdirectory?. Currently only supported with autotool.
+* pretty-print define the type of class name format change in order to generate the filename. It uses the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/imatix/gsl#expressions for more information).
 * source-extension define the filename extension for source files in this project.
-* header-extension define the filename extension for source files in this project.
+* header-extension define the filename extension for header files in this project.
 
 Default value :
 * pretty-print : substitute_non_alpha_to_make_c_identifier (c option)

--- a/README.txt
+++ b/README.txt
@@ -149,9 +149,9 @@ Exemple:
 * use-cxx will force usage (or not) of c++.
 * keep-tree will keeping the include tree on the install, must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
 * pkgincludedir option chooses whether headers of this project should be dumped into the common system includedir (legacy default), or into an includedir/projname subdirectory?. Currently only supported with autotool.
-* pretty-print define the type of class name format change in order to generate the filename. It use the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/imatix/gsl#expressions for more information).
+* pretty-print define the type of class name format change in order to generate the filename. It uses the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/imatix/gsl#expressions for more information).
 * source-extension define the filename extension for source files in this project.
-* header-extension define the filename extension for source files in this project.
+* header-extension define the filename extension for header files in this project.
 
 Default value :
 * pretty-print : substitute_non_alpha_to_make_c_identifier (c option)

--- a/README.txt
+++ b/README.txt
@@ -143,11 +143,12 @@ Model is described in `zproject_known_projects.xml` file:
 
 Exemple:
 ```classfilename
-<classfilename use-cxx = "true" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
+<classfilename use-cxx = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
 ```
 
 * use-cxx will force usage (or not) of c++.
 * keep-tree will keeping the include tree on the install, must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
+* pkgincludedir option chooses whether headers of this project should be dumped into the common system includedir (legacy default), or into an includedir/projname subdirectory?. Currently only supported with autotool.
 * pretty-print define the type of class name format change in order to generate the filename. It use the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/imatix/gsl#expressions for more information).
 * source-extension define the filename extension for source files in this project.
 * header-extension define the filename extension for source files in this project.

--- a/README.txt
+++ b/README.txt
@@ -147,7 +147,7 @@ Exemple:
 ```
 
 * use-cxx will force usage (or not) of c++.
-* keep-tree will keeping the include tree on the install, must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
+* keep-tree will keep the include tree structure on the install (as opposed to flat delivery of include files basenames into the single-level target directory), must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
 * pkgincludedir option chooses whether headers of this project should be dumped into the common system includedir (legacy default), or into an includedir/projname subdirectory?. Currently only supported with autotool.
 * pretty-print define the type of class name format change in order to generate the filename. It uses the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/imatix/gsl#expressions for more information).
 * source-extension define the filename extension for source files in this project.

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -77,6 +77,14 @@ function resolve_classfilename_option()
             endif
         endif
 
+        if defined (classfilename.pkgincludedir)
+            if classfilename.pkgincludedir ?= "true"
+                project.pkgincludedir = 1
+            elsif classfilename.pkgincludedir ?= "false"
+                project.pkgincludedir = 0
+            endif
+        endif
+
         return
     endfor
 endfunction
@@ -86,6 +94,7 @@ project.header_ext = "h"
 project.source_ext = "c"
 project.use_cxx = project_use_cxx ()
 project.keep_tree = 0
+project.pkgincludedir = 0
 resolve_classfilename_option()
 project.name ?= "myproject"
 project.prefix ?= "$(project.name:c)"

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1557,9 +1557,17 @@ $(project.GENERATED_WARNING_HEADER:)
 .output "include/Makefile.am"
 $(project.GENERATED_WARNING_HEADER:)
 .if project.keep_tree
+. if project.pkgincludedir
+nobase_pkginclude_HEADERS = \\
+. else
 nobase_include_HEADERS = \\
+. endif
 .else
+. if project.pkgincludedir
+pkginclude_HEADERS = \\
+. else
 include_HEADERS = \\
+. endif
 .endif
 .if file.exists ("include/$(project.prelude)")
     $(project.prelude) \\
@@ -1578,9 +1586,17 @@ include_HEADERS = \\
 .if count (class, scope = "public" & draft)
 if ENABLE_DRAFTS
 .if project.keep_tree
+. if project.pkgincludedir
+nobase_pkginclude_HEADERS += \\
+. else
 nobase_include_HEADERS += \\
+. endif
 .else
+. if project.pkgincludedir
+pkginclude_HEADERS += \\
+. else
 include_HEADERS += \\
+. endif
 .endif
 .   for class where scope = "public" & draft
     $(name:$(project.filename_prettyprint)).$(project.header_ext)$(last ()?? "\n"? " \\")


### PR DESCRIPTION
Solution: let configure a project to install its headers into includedir/projname instead