### PR TITLE
Problem: Config.cmake.in is missing from the EXTRA_DIST files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST += \
     Findgsl.cmake \
     builds/cmake/Modules/ClangFormat.cmake \
     builds/cmake/clang-format-check.sh.in \
+    builds/cmake/Config.cmake.in \
     CMakeLists.txt
 endif
 

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1515,6 +1515,7 @@ EXTRA_DIST += \\
 .endif
     builds/cmake/Modules/ClangFormat.cmake \\
     builds/cmake/clang-format-check.sh.in \\
+    builds/cmake/Config.cmake.in \\
     CMakeLists.txt
 endif
 


### PR DESCRIPTION
Solution: add the line to zproject_autotools.gsl and update the zproject

this fixes an issue introduced by #1088 and observed here: https://github.com/zeromq/czmq/pull/1927