### PR TITLE
Problem: Travis always tests code as "c"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ src/zproject_selftest
 *.app
 core
 
- # Distcheck workspace and archives
+# Distcheck workspace and archives
 zproject-*/
 zproject-*.tar.gz
 zproject-*.zip
@@ -104,7 +104,7 @@ src/app/gen/
 src/app/obj/
 src/app/local.properties
 
-# Android -dependencies
+# Android - dependencies
 src/app/jni/output
 
 # Python build directory
@@ -125,6 +125,9 @@ bindings/qt/selftest/selftest
 *.swp
 *.bak
 .test*
+
+# Netbeans directory
+nbproject/
 
 # editor backups
 *~

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -145,6 +145,9 @@ if !file.exists (".gitignore")
     >*.bak
     >.test*
     >
+    ># Netbeans directory
+    >nbproject/
+    >
     ># editor backups
     >*~
 else

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -123,7 +123,7 @@ if !file.exists (".gitignore")
     >src/app/obj/
     >src/app/local.properties
     >
-    ># Android -dependencies
+    ># Android - dependencies
     >src/app/jni/output
     >
     ># Python build directory

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -21,7 +21,11 @@ register_target ("travis", "Travis CI scripts")
 # You can add hand-written code here.
 
 language:
+.if project.use_cxx
+- cpp
+.else
 - c
+.endif
 
 cache:
 - ccache


### PR DESCRIPTION
Solution: if a project.use_cxx is true, tell travis to test as "cpp"
Note: the difference seems cosmetic at the moment, the same GCC toolkits are installed. But still, this is cleaner :)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>