### PR TITLE
Problem: ZMQ-style compact streq() replaced by strcmp()==0 monstrosity

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -215,9 +215,6 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #include "$(project.prefix)_classes.$(project.header_ext)"
 
-#include <stdio.h>
-#include <string.h>
-
 typedef struct {
     const char *testname;           // test name, can be called from command line this way
     void (*test) (bool);            // function to run the test (or NULL for private tests)
@@ -273,7 +270,7 @@ test_available (const char *testname)
 {
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (strcmp (testname, item->testname) == 0)
+        if (streq (testname, item->testname))
             return item;
     }
     return NULL;
@@ -289,7 +286,7 @@ test_runall (bool verbose)
     test_item_t *item;
     printf ("Running $(project.name) selftests...\\n");
     for (item = all_tests; item->testname; item++) {
-        if (strcmp (item->testname, "private_classes") == 0)
+        if (streq (item->testname, "private_classes"))
             continue;
         if (!item->subtest)
             item->test (verbose);
@@ -321,7 +318,7 @@ test_number (void)
     int n = 0;
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (! strcmp (item->testname, "private_classes") == 0)
+        if (! streq (item->testname, "private_classes"))
             n++;
     }
     printf ("%d\\n", n);
@@ -334,8 +331,8 @@ main (int argc, char **argv)
     test_item_t *test = 0;
     int argn;
     for (argn = 1; argn < argc; argn++) {
-        if (strcmp (argv [argn], "--help") == 0
-        ||  strcmp (argv [argn], "-h") == 0) {
+        if (streq (argv [argn], "--help")
+        ||  streq (argv [argn], "-h")) {
             puts ("$(project.prefix)_selftest.c [options] ...");
             puts ("  --verbose / -v         verbose test output");
             puts ("  --number / -n          report number of tests");
@@ -344,24 +341,24 @@ main (int argc, char **argv)
             puts ("  --continue / -c        continue on exception (on Windows)");
             return 0;
         }
-        if (strcmp (argv [argn], "--verbose") == 0
-        ||  strcmp (argv [argn], "-v") == 0)
+        if (streq (argv [argn], "--verbose")
+        ||  streq (argv [argn], "-v"))
             verbose = true;
         else
-        if (strcmp (argv [argn], "--number") == 0
-        ||  strcmp (argv [argn], "-n") == 0) {
+        if (streq (argv [argn], "--number")
+        ||  streq (argv [argn], "-n")) {
             test_number ();
             return 0;
         }
         else
-        if (strcmp (argv [argn], "--list") == 0
-        ||  strcmp (argv [argn], "-l") == 0) {
+        if (streq (argv [argn], "--list")
+        ||  streq (argv [argn], "-l")) {
             test_list ();
             return 0;
         }
         else
-        if (strcmp (argv [argn], "--test") == 0
-        ||  strcmp (argv [argn], "-t") == 0) {
+        if (streq (argv [argn], "--test")
+        ||  streq (argv [argn], "-t")) {
             argn++;
             if (argn >= argc) {
                 fprintf (stderr, "--test needs an argument\\n");
@@ -374,8 +371,8 @@ main (int argc, char **argv)
             }
         }
         else
-        if (strcmp (argv [argn], "--continue") == 0
-        ||  strcmp (argv [argn], "-c") == 0) {
+        if (streq (argv [argn], "--continue")
+        ||  streq (argv [argn], "-c")) {
 #ifdef _MSC_VER
             //  When receiving an abort signal, only print to stderr (no dialog)
             _set_abort_behavior (0, _WRITE_ABORT_MSG);

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -215,6 +215,17 @@ $(project.GENERATED_WARNING_HEADER:)
 
 #include "$(project.prefix)_classes.$(project.header_ext)"
 
+#ifndef streq
+/*
+ *  Allow projects without czmq dependency:
+ *  The generated code expects that czmq pulls in a few headers and macro
+ *  definitions. This is a minimal fix for the generated selftest file in
+ *  C++ mode.
+ */
+#include <string.h>
+#define streq(s1,s2)    (!strcmp ((s1), (s2)))
+#endif
+
 typedef struct {
     const char *testname;           // test name, can be called from command line this way
     void (*test) (bool);            // function to run the test (or NULL for private tests)

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -321,7 +321,7 @@ test_number (void)
     int n = 0;
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (strcmp (item->testname, "private_classes") == 0)
+        if (! strcmp (item->testname, "private_classes") == 0)
             n++;
     }
     printf ("%d\\n", n);


### PR DESCRIPTION
Solution: Restore the pre-Feb2018 coding pattern (ease regeneration of less dynamic projects) and retain the benefits of that patch (do not require builds with czmq headers).
    
Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

CCing @bluca @michal42 whose work is reverted here (note especially Luca's patch - was the original cause a syntax curiosity of MacOS compilers, or a logical error in the string comparison)?