### PR TITLE
Problem: zprojectized components sometimes time out in Jenkins

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -257,8 +257,9 @@
          The use_test_timeout option sets up the default timeout for test
          steps (further configurable at run-time as a build argument).
          Generally unit tests should not take pathologically long, so the
-         default of 10 minutes should commonly suffice even for distchecks.
-         If your selftests are known to take a lot of time, set this option.
+         default of 30 minutes should commonly suffice even for distchecks.
+         If your selftests are known to take a lot of time, perhaps due to
+         using an occasionally overloaded Jenkins CI farm, set this option.
 
          A use_test_retry option allows to retry each failing test step
          for the specified amount of attempts; it is deemed good if the
@@ -301,7 +302,7 @@
         <option name = "dist_docs" value = "1" />
         <option name = "require_gitignore" value = "0" />
         <option name = "use_deleteDir_rm_first" value = "1" />
-        <option name = "use_test_timeout" value = "30" />
+        <option name = "use_test_timeout" value = "60" />
         <option name = "use_test_retry" value = "3" />
         <option name = "test_check" value = "0" />
         <option name = "test_memcheck" value = "0" />

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -229,7 +229,7 @@ pipeline {
             name: 'CLANG_FORMAT')
         string (
 .  if ( !(defined(project.jenkins_use_test_timeout)) | project.jenkins_use_test_timeout ?= "" )
-            defaultValue: "10",
+            defaultValue: "30",
 .  else
             defaultValue: "$(project.jenkins_use_test_timeout)",
 .  endif


### PR DESCRIPTION
Solution: bump default timeout to 30 minutes, to cater for slower/overloaded Jenkins CI servers (and match Travis CI defaults)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>