### PR TITLE
Problem: failed Jenkins builds unconditionally eat disk space

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,6 +116,10 @@ pipeline {
             defaultValue: true,
             description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done successfully?',
             name: 'DO_CLEANUP_AFTER_JOB')
+        booleanParam (
+            defaultValue: false,
+            description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done unsuccessfully (failed)? Note this would not allow postmortems on CI server, but would conserve its disk space.',
+            name: 'DO_CLEANUP_AFTER_FAILED_JOB')
     }
     triggers {
         pollSCM 'H/5 * * * *'
@@ -553,6 +557,14 @@ pipeline {
             sleep 1
             //slackSend (color: "#AA0000", message: "Build ${env.BUILD_NUMBER} of ${env.JOB_NAME} ${currentBuild.result} (<${env.BUILD_URL}|Open>)")
             //emailext (to: "qa@example.com", subject: "Build ${env.JOB_NAME} failed!", body: "Build ${env.BUILD_NUMBER} of ${env.JOB_NAME} ${currentBuild.result}\nSee ${env.BUILD_URL}")
+
+            dir("tmp") {
+                if ( params.DO_CLEANUP_AFTER_FAILED_JOB ) {
+                    deleteDir()
+                } else {
+                    sh """ echo "NOTE: BUILD AREA OF WORKSPACE `pwd` REMAINS FOR POST-MORTEMS ON `hostname` AND CONSUMES `du -hs . | awk '{print $1}'` !" """
+                }
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -457,6 +457,8 @@ zproject's `project.xml` contains an extensive description of the available conf
          of stage, and/or cleans the build workspace after the whole job
          succeeded, respectively. If not set, cleanup is enabled for both
          and in either case the active options are among build parameters.
+         In opposite fashion, a do_cleanup_after_failed_build is disabled
+         by default to allow post-mortem inspection of errors on CI server.
          You might want to keep the built sources to analyze the behavior
          of your build recipes in a particular environment, thought at a
          risk of using excessive disk space there. In case of failure the

--- a/project.xml
+++ b/project.xml
@@ -281,6 +281,8 @@
          of stage, and/or cleans the build workspace after the whole job
          succeeded, respectively. If not set, cleanup is enabled for both
          and in either case the active options are among build parameters.
+         In opposite fashion, a do_cleanup_after_failed_build is disabled
+         by default to allow post-mortem inspection of errors on CI server.
          You might want to keep the built sources to analyze the behavior
          of your build recipes in a particular environment, thought at a
          risk of using excessive disk space there. In case of failure the

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -261,6 +261,16 @@ pipeline {
 .    endif
             description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done successfully?',
             name: 'DO_CLEANUP_AFTER_JOB')
+        booleanParam (
+.    if ( !(defined(project.jenkins_do_cleanup_after_failed_job)) | (project.jenkins_do_cleanup_after_failed_job ?= 0) )
+. # if nothing was set, don't cleanup by default to allow postmortems on CI server
+            defaultValue: false,
+.    else
+. # explicitly enabled for a particular project
+            defaultValue: true,
+.    endif
+            description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done unsuccessfully (failed)? Note this would not allow postmortems on CI server, but would conserve its disk space.',
+            name: 'DO_CLEANUP_AFTER_FAILED_JOB')
     }
 .  if !(defined(project.jenkins_triggers_pollSCM))
     triggers {
@@ -956,6 +966,17 @@ pipeline {
             sleep 1
             //slackSend (color: "#AA0000", message: "Build \$\{env.BUILD_NUMBER} of \$\{env.JOB_NAME} \$\{currentBuild.result} (<\$\{env.BUILD_URL}|Open>)")
             //emailext (to: "qa@example.com", subject: "Build \$\{env.JOB_NAME} failed!", body: "Build \$\{env.BUILD_NUMBER} of \$\{env.JOB_NAME} \$\{currentBuild.result}\\nSee \$\{env.BUILD_URL}")
+
+            dir("tmp") {
+                if ( params.DO_CLEANUP_AFTER_FAILED_JOB ) {
+.           if project.jenkins_use_deleteDir_rm_first ?= 1
+                    sh '_PWD="`pwd`" ; cd /tmp ; rm -rf "$_PWD" || true ; mkdir -p "$_PWD"'
+.           endif
+                    deleteDir()
+                } else {
+                    sh """ echo "NOTE: BUILD AREA OF WORKSPACE `pwd` REMAINS FOR POST-MORTEMS ON `hostname` AND CONSUMES `du -hs . | awk '{print $1}'` !" """
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Solution: add a do_cleanup_after_failed_build option (via project.xml and interactive build args)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>