### PR TITLE
Revert "Problem : a project.xml without czmq dependency is not buildable"

### DIFF
--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -177,7 +177,7 @@ struct _$(actor.name:c)_t {
 static $(actor.name:c)_t *
 $(actor.name:c)_new (zsock_t *pipe, void *args)
 {
-    $(actor.name:c)_t *self = ($(actor.name:c)_t *) malloc (sizeof ($(actor.name:c)_t));
+    $(actor.name:c)_t *self = ($(actor.name:c)_t *) zmalloc (sizeof ($(actor.name:c)_t));
     assert (self);
 
     self->pipe = pipe;
@@ -426,7 +426,7 @@ struct _$(class.c_name:)_t {
 $(class.c_name:)_t *
 $(class.c_name:)_new (void)
 {
-    $(class.c_name:)_t *self = ($(class.c_name:)_t *) malloc (sizeof ($(class.c_name:)_t));
+    $(class.c_name:)_t *self = ($(class.c_name:)_t *) zmalloc (sizeof ($(class.c_name:)_t));
     assert (self);
     //  Initialize class properties here
     return self;


### PR DESCRIPTION
1) **Provided solution does not work**

Even if we pretend for a moment, that declared "problem" is a problem, then this pull request does not provide a working solution:
https://gist.github.com/karolhrdina/b3b702d529d66502698dd509ea1906e8

This gist has two files, `project.xml` -  a minimal zproject xml without czmq dependency, `output` - output of doing gsl project.xml; ./autogen.sh && ./configure && make, which fails as seen.

2) **Provided 'Problem' statement is not a problem**

> zproject is a project that makes it cheaper to build other projects that use ZeroMQ.

^^^ is a quote from Hintjens himself in a article http://hintjens.com/blog:79 presenting zproject to the public for the first time. 
`zproject` is not supposed to work without `czmq`; This fact is obvious in every part of gsl template for CLASS or ACTOR elements; `czmq` is integral to `zproject`, since czmq is the high level C binding for libzmq. 

