### PR TITLE
Fix packaging of libs if we deliver mains

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -20,7 +20,6 @@ Build-Depends: debhelper (>= 9),
     asciidoc-base | asciidoc, xmlto,
     dh-autoreconf
 
-
 Package: zproject
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},

--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -46,7 +46,6 @@ Requires: generator-scripting-language
 %description
 zproject project.
 
-
 %prep
 
 %setup -q

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -119,6 +119,8 @@ endif
 project->license. ?= "Copyright (c) the Authors"
 
 project.has_main = (count (main) > 0)
+project.has_bin = (count (bin) > 0)
+project.has_classes = (count (class) > 0)
 project.exports_classes = (count (class, !defined (class.private)) > 0)
 project.generated_warning_header ?= "\
 ################################################################################

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -111,7 +111,7 @@ Description: $(project.name) development tools
  $(project.description)
 .endif
 
-.if project.has_main | count(project.bin) > 0
+.if project.has_main | project.has_bin
 Package: $(string.replace (project.name, "_|-"):lower)
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
@@ -138,7 +138,7 @@ Architecture: any
 Section: debug
 Priority: optional
 Depends:
-.if project.has_main | count(project.bin) > 0
+.if project.has_main | project.has_bin
     $(string.replace (project.name, "_|-"):lower) (= ${binary:Version}),
 .elsif project.exports_classes
 .if defined (project->abi)
@@ -311,7 +311,7 @@ override_dh_auto_configure:
 		--with autoreconf
 .chmod_x ("packaging/debian/rules")
 .discover_manpages(project)
-.if project.has_main | count(project.bin) > 0
+.if project.has_main | project.has_bin
 .   output ("packaging/debian/$(string.replace (project.name, "_|-"):lower).manpages")
 .   for project.main where scope = "public" & project.has_main & man1 ?<> ""
 debian/tmp/usr/share/man/man1/$(main.name).1

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -70,9 +70,15 @@ Build-Depends: debhelper (>= 9),
 .- NOTE: after support for Debian 7 and Ubuntu 12.04 is dropped, <!nodoc> can be added to each of the following
     asciidoc-base | asciidoc, xmlto,
     dh-autoreconf
-
-.if project.exports_classes
+.if project.exports_classes | ( project.has_classes & project.has_main )
+.# NOTE: Now for at least some compilers the symbol visibility seems to
+.# be managed in the shared library files, not the "exportedness" - so
+.# the delivered compiled binary files can use and do require those libs
+.# packaged even if all classes are marked private - should have at least
+.# one though. Also note that "bin" files are not necessarily compiled,
+.# e.g. helper scripts, so are not covered in this clause.
 .if defined (project->abi)
+
 Package: $(string.replace (project.libname, "_|-"))$(project->abi.current - project->abi.age)
 .else
 Package: $(string.replace (project.libname, "_|-"))0
@@ -82,6 +88,10 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: $(project.name) shared library
  This package contains shared library for $(project.name):
  $(project.description)
+.endif
+.if project.exports_classes
+.# NOTE: The development libs/headers make sense if any class was not
+.# marked private - different from just the lib package above.
 
 Package: $(string.replace (project.libname, "_|-"))-dev
 Architecture: any
@@ -110,8 +120,8 @@ Description: $(project.name) development tools
  This package contains development files for $(project.name):
  $(project.description)
 .endif
-
 .if project.has_main | project.has_bin
+
 Package: $(string.replace (project.name, "_|-"):lower)
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},

--- a/zproject_obs.gsl
+++ b/zproject_obs.gsl
@@ -62,7 +62,7 @@ register_target ("obs", "service for Open Build Service")
     <param name="files">*/packaging/debian/copyright</param>
     <param name="outfilename">debian.copyright</param>
   </service>
-.   if project.has_main | count(project.bin) > 0
+.   if project.has_main | project.has_bin
   <service name="extract_file">
     <param name="archive">*.tar</param>
     <param name="files">*/packaging/debian/$(string.replace (project.name, "_|-"):lower).install</param>

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -110,7 +110,7 @@ BuildRequires:  python3-setuptools
 %endif
 .endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-.if project.has_main | count(project.bin) > 0
+.if project.has_main | project.has_bin
 .for project.use where use.type ?= "runtime"
 .if defined(use.redhat_name)
 .   if !(use.redhat_name = '')
@@ -298,7 +298,7 @@ export PKG_CONFIG_PATH=`pwd`
 python3 setup.py install --root=%{buildroot} --skip-build --prefix %{_prefix}
 %endif
 .endif
-.if has_main | count(project.bin) > 0
+.if has_main | project.has_bin
 %files
 %defattr(-,root,root)
 .if file.exists ('README.md')

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -128,13 +128,19 @@ Requires: $(string.replace (use.project, "_|-"))
 
 %description
 $(project.name) $(project.description).
-
 .if defined (project->abi)
 .   my.abi_ver = project->abi.current - project->abi.age
 .else
 .   my.abi_ver = 0
 .endif
-.if project.exports_classes
+.if project.exports_classes | ( project.has_classes & project.has_main )
+.# NOTE: Now for at least some compilers the symbol visibility seems to
+.# be managed in the shared library files, not the "exportedness" - so
+.# the delivered compiled binary files can use and do require those libs
+.# packaged even if all classes are marked private - should have at least
+.# one though. Also note that "bin" files are not necessarily compiled,
+.# e.g. helper scripts, so are not covered in this clause.
+
 %package -n $(project.libname)$(my.abi_ver)
 Group:          System/Libraries
 Summary:        $(project.description) shared library
@@ -151,6 +157,10 @@ This package contains shared library for $(project.name): $(project.description)
 %doc COPYING
 .endif
 %{_libdir}/$(project.libname).so.*
+.endif
+.if project.exports_classes
+.# NOTE: The development libs/headers make sense if any class was not
+.# marked private - different from just the lib package above.
 
 %package devel
 Summary:        $(project.description)


### PR DESCRIPTION
Use-case for the problem: a project declares several `class` tags but all of them are `private="1"`, and a `main` with the binary (daemon) which is of practical interest to consumers. In practice, current zproject only packaged libraries if there is at least one non-private class. As a result, the installed binary does not have the libs it was linked against, and could not run.

Note that for some time now, at least on some platforms, the difference of public/private is not "exportedness" and so accessibility of library symbols, but their visibility/scope (so "private class" libs are usable if a binary knows what to ask for).

This PR adds packaging of libraries if either there are public classes, or (newly) if there are some classes and mains.

Note that `bin` tags are not consulted here, they can mean e.g. helper scripts for whom libraries are irrelevant.