### PR TITLE
Problem: implicit dependency on czmq

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -83,7 +83,7 @@ $(project.GENERATED_WARNING_HEADER:)
     $(PROJECT.PREFIX)_MAKE_VERSION($(PROJECT.PREFIX)_VERSION_MAJOR, $(PROJECT.PREFIX)_VERSION_MINOR, $(PROJECT.PREFIX)_VERSION_PATCH)
 
 // czmq_prelude.h bits
-.if project.prefix <> "czmq"
+.if project.prefix <> "czmq" & project.has_czmq <> 1
 #if !defined (__WINDOWS__)
 #   if (defined WIN32 || defined _WIN32 || defined WINDOWS || defined _WINDOWS)
 #       undef __WINDOWS__
@@ -519,8 +519,7 @@ typedef struct _$(class.c_name:)_t $(class.c_name:)_t;
 .endfor
 
 //  Internal API
-
-.if project.prefix <> "czmq"
+.if project.prefix <> "czmq" & project.has_czmq <> 1
 // common definitions and idioms from czmq_prelude.h, which are used in generated code
 #if ! defined(__CZMQ_PRELUDE_H_INCLUDED__)
 #include <stdlib.h>

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -83,12 +83,14 @@ $(project.GENERATED_WARNING_HEADER:)
     $(PROJECT.PREFIX)_MAKE_VERSION($(PROJECT.PREFIX)_VERSION_MAJOR, $(PROJECT.PREFIX)_VERSION_MINOR, $(PROJECT.PREFIX)_VERSION_PATCH)
 
 // czmq_prelude.h bits
+.if project.prefix <> "czmq"
 #if !defined (__WINDOWS__)
 #   if (defined WIN32 || defined _WIN32 || defined WINDOWS || defined _WINDOWS)
 #       undef __WINDOWS__
 #       define __WINDOWS__
 #   endif
 #endif
+.endif
 
 // Windows MSVS doesn't have stdbool
 #if (defined (_MSC_VER) && !defined (true))
@@ -518,6 +520,7 @@ typedef struct _$(class.c_name:)_t $(class.c_name:)_t;
 
 //  Internal API
 
+.if project.prefix <> "czmq"
 // common definitions and idioms from czmq_prelude.h, which are used in generated code
 #if ! defined(__CZMQ_PRELUDE_H_INCLUDED__)
 #include <stdlib.h>
@@ -554,6 +557,7 @@ safe_malloc (size_t size, const char *file, unsigned line)
 #   define zmalloc(size) safe_malloc((size), __FILE__, __LINE__)
 #endif
 #endif
+.endif
 
 .for class where scope = "public"
 .   visibility = "$(PROJECT.PREFIX)_PRIVATE"

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -82,6 +82,26 @@ $(project.GENERATED_WARNING_HEADER:)
 #define $(PROJECT.PREFIX)_VERSION \\
     $(PROJECT.PREFIX)_MAKE_VERSION($(PROJECT.PREFIX)_VERSION_MAJOR, $(PROJECT.PREFIX)_VERSION_MINOR, $(PROJECT.PREFIX)_VERSION_PATCH)
 
+// czmq_prelude.h bits
+#if !defined (__WINDOWS__)
+#   if (defined WIN32 || defined _WIN32 || defined WINDOWS || defined _WINDOWS)
+#       undef __WINDOWS__
+#       define __WINDOWS__
+#   endif
+#endif
+
+// Windows MSVS doesn't have stdbool
+#if (defined (_MSC_VER) && !defined (true))
+#   if (!defined (__cplusplus) && (!defined (true)))
+#       define true 1
+#       define false 0
+        typedef char bool;
+#   endif
+#else
+#   include <stdbool.h>
+#endif
+// czmq_prelude.h bits
+
 #if defined (__WINDOWS__)
 #   if defined $(PROJECT.PREFIX)_STATIC
 #       define $(PROJECT.PREFIX)_EXPORT
@@ -214,17 +234,6 @@ $(project.GENERATED_WARNING_HEADER:)
 */
 
 #include "$(project.prefix)_classes.$(project.header_ext)"
-
-#ifndef streq
-/*
- *  Allow projects without czmq dependency:
- *  The generated code expects that czmq pulls in a few headers and macro
- *  definitions. This is a minimal fix for the generated selftest file in
- *  C++ mode.
- */
-#include <string.h>
-#define streq(s1,s2)    (!strcmp ((s1), (s2)))
-#endif
 
 typedef struct {
     const char *testname;           // test name, can be called from command line this way
@@ -508,6 +517,44 @@ typedef struct _$(class.c_name:)_t $(class.c_name:)_t;
 .endfor
 
 //  Internal API
+
+// common definitions and idioms from czmq_prelude.h, which are used in generated code
+#if ! defined(__CZMQ_PRELUDE_H_INCLUDED__)
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#define streq(s1,s2)    (!strcmp ((s1), (s2)))
+#define strneq(s1,s2)   (strcmp ((s1), (s2)))
+//  Replacement for malloc() which asserts if we run out of heap, and
+//  which zeroes the allocated block.
+static inline void *
+safe_malloc (size_t size, const char *file, unsigned line)
+{
+//     printf ("%s:%u %08d\\n", file, line, (int) size);
+    void *mem = calloc (1, size);
+    if (mem == NULL) {
+        fprintf (stderr, "FATAL ERROR at %s:%u\\n", file, line);
+        fprintf (stderr, "OUT OF MEMORY (malloc returned NULL)\\n");
+        fflush (stderr);
+        abort ();
+    }
+    return mem;
+}
+
+//  Define _ZMALLOC_DEBUG if you need to trace memory leaks using e.g. mtrace,
+//  otherwise all allocations will claim to come from czmq_prelude.h. For best
+//  results, compile all classes so you see dangling object allocations.
+//  _ZMALLOC_PEDANTIC does the same thing, but its intention is to propagate
+//  out of memory condition back up the call stack.
+#if defined (_ZMALLOC_DEBUG) || defined (_ZMALLOC_PEDANTIC)
+#   define zmalloc(size) calloc(1,(size))
+#else
+#   define zmalloc(size) safe_malloc((size), __FILE__, __LINE__)
+#endif
+#endif
+
 .for class where scope = "public"
 .   visibility = "$(PROJECT.PREFIX)_PRIVATE"
 .   for class.method where private

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -157,6 +157,10 @@ for main
     resolve_scope (main)
 endfor
 
+if count (actor) > 0 & project.has_czmq = 0
+    abort "E: Cannot use actors without czmq dependency"
+endif
+
 for actor
     actor.selftest ?= 1
     new class to project

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -145,8 +145,12 @@ function resolve_scope (item)
     endif
 endfunction
 
+project.has_czmq = 0
 for use
     resolve_project_dependency (use)
+    if use.prefix = "czmq"
+        project.has_czmq = 1
+    endif
 endfor
 
 for main


### PR DESCRIPTION
Solution:
if project is not czmq or does not depends on it
1. move `__WINDOWS__` definition to `_library.h`
2. include basic ANSI headers mandatory for generated code in private `_classes.h`
3. include common idioms streq/strneq/zmalloc in `_classes.h`
4. fail if `actor` is specified, but `czmq` is not in the dependency list

cc: @bluca @karolhrdina @geraldguillaume
references: #1101
references: #1102
references: #1105 

This is leaner and smaller version of previous attempt. Tested manually with minimal project.xml(s) and with czmq.