### PR TITLE
Problem: header files listed twice confuse "install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ zproject's `project.xml` contains an extensive description of the available conf
     description := A short description for your project (optional)
     email := The email address where to reach you (optional)
     repository := git repository holding project (optional)
-    unique_class_name := "0"|"1" (optional, defaults to 1) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
+    unique_class_name := "0"|"1" (optional, defaults to 0) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable explicitly (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ zproject's `project.xml` contains an extensive description of the available conf
     description := A short description for your project (optional)
     email := The email address where to reach you (optional)
     repository := git repository holding project (optional)
+    unique_class_name := "0"|"1" (optional, defaults to 1) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/project.xml
+++ b/project.xml
@@ -35,7 +35,7 @@
     description := A short description for your project (optional)
     email := The email address where to reach you (optional)
     repository := git repository holding project (optional)
-    unique_class_name := "0"|"1" (optional, defaults to 1) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
+    unique_class_name := "0"|"1" (optional, defaults to 0) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable explicitly (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/project.xml
+++ b/project.xml
@@ -35,6 +35,7 @@
     description := A short description for your project (optional)
     email := The email address where to reach you (optional)
     repository := git repository holding project (optional)
+    unique_class_name := "0"|"1" (optional, defaults to 1) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -161,6 +161,10 @@ if count (actor) > 0 & project.has_czmq = 0
     abort "E: Cannot use actors without czmq dependency"
 endif
 
+if !defined(project.unique_class_name)
+    project.unique_class_name = 1
+endif
+
 for actor
     actor.selftest ?= 1
     new class to project
@@ -171,7 +175,11 @@ for actor
     endnew
     resolve_scope (actor)
     if actor.name ?= project.name
-        abort "E: actors should be named differently from the project itself"
+        if project.unique_class_name ?= 1
+            abort "E: actors should be named differently from the project itself"
+        else
+            echo "WARNING: actors should be named differently from the project itself"
+        endif
     endif
 endfor
 
@@ -179,7 +187,11 @@ for class
     resolve_scope (class)
     class.selftest ?= 1
     if class.name ?= project.name
-        abort "E: classes should be named differently from the project itself"
+        if project.unique_class_name ?= 1
+            abort "E: classes should be named differently from the project itself"
+        else
+            echo "WARNING: classes should be named differently from the project itself"
+        endif
     endif
 endfor
 

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -170,11 +170,17 @@ for actor
         class.selftest = actor.selftest
     endnew
     resolve_scope (actor)
+    if actor.name ?= project.name
+        abort "E: actors should be named differently from the project itself"
+    endif
 endfor
 
 for class
     resolve_scope (class)
     class.selftest ?= 1
+    if class.name ?= project.name
+        abort "E: classes should be named differently from the project itself"
+    endif
 endfor
 
 for constant

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -176,9 +176,9 @@ for actor
     resolve_scope (actor)
     if actor.name ?= project.name
         if project.unique_class_name ?= 1
-            abort "E: actors should be named differently from the project itself"
+            abort "E: actors should be named differently from the project itself; set project.unique_class_name=0 to let generate this project, or better yet - fix it"
         else
-            echo "WARNING: actors should be named differently from the project itself"
+            echo "WARNING: actors should be named differently from the project itself; set project.unique_class_name=0 to let generate this project, or better yet - fix it"
         endif
     endif
 endfor
@@ -188,9 +188,9 @@ for class
     class.selftest ?= 1
     if class.name ?= project.name
         if project.unique_class_name ?= 1
-            abort "E: classes should be named differently from the project itself"
+            abort "E: classes should be named differently from the project itself; set project.unique_class_name=0 to let generate this project, or better yet - fix it"
         else
-            echo "WARNING: classes should be named differently from the project itself"
+            echo "WARNING: classes should be named differently from the project itself; set project.unique_class_name=0 to let generate this project, or better yet - fix it"
         endif
     endif
 endfor

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -162,7 +162,13 @@ if count (actor) > 0 & project.has_czmq = 0
 endif
 
 if !defined(project.unique_class_name)
-    project.unique_class_name = 1
+    # TODO: A sane default would be "1" to enforce this check
+    # However some projects are known to really use classes named
+    # same as project and do somehow survive, so enforcing this
+    # check right now would break them. So we'll issue warnings
+    # for now and enable it in a year or so :)
+    #project.unique_class_name = 1
+    project.unique_class_name = 0
 endif
 
 for actor


### PR DESCRIPTION
Solution: verify that classes and actors are not named same as the project, their headers should differ too
Note: gsl abort() currently seems flawed in not returning a non-zero exit code, but that is a separate issue

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: the initial issue was that we saw duplicate header filenames listed in `include/Makefile.am` for common list and draft additions. Digging into the issue produced this fix.