### PR TITLE
Problem: public global draft constants not added to internal build

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -581,6 +581,14 @@ $(VISIBILITY) $(c_method_signature (method):)\
 
 //  *** To avoid double-definitions, only define if building without draft ***
 #ifndef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+.for constant where scope = "public" & draft
+.   if first ()
+
+//  *** Draft global constants, defined for internal use only ***
+.   endif
+#define $(CONSTANT.NAME)\
+                            $(constant.value)  //  $(constant.?'')
+.endfor
 .for class where draft = 0
 .   for constant where draft = 1
 .      if first ()


### PR DESCRIPTION
Solution: when generating the internal classes draft definitions for
non-draft builds, also add global constants.