### PR TITLE
Problem: recent changes add blank lines

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -102,8 +102,8 @@ $(project.GENERATED_WARNING_HEADER:)
 #   include <stdbool.h>
 #endif
 // czmq_prelude.h bits
-.endif
 
+.endif
 #if defined (__WINDOWS__)
 #   if defined $(PROJECT.PREFIX)_STATIC
 #       define $(PROJECT.PREFIX)_EXPORT
@@ -555,9 +555,9 @@ safe_malloc (size_t size, const char *file, unsigned line)
 #else
 #   define zmalloc(size) safe_malloc((size), __FILE__, __LINE__)
 #endif
-#endif
-.endif
+#endif // __CZMQ_PRELUDE_H_INCLUDED__
 
+.endif
 .for class where scope = "public"
 .   visibility = "$(PROJECT.PREFIX)_PRIVATE"
 .   for class.method where private

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -77,8 +77,8 @@ Build-Depends: debhelper (>= 9),
 .# packaged even if all classes are marked private - should have at least
 .# one though. Also note that "bin" files are not necessarily compiled,
 .# e.g. helper scripts, so are not covered in this clause.
-.if defined (project->abi)
 
+.if defined (project->abi)
 Package: $(string.replace (project.libname, "_|-"))$(project->abi.current - project->abi.age)
 .else
 Package: $(string.replace (project.libname, "_|-"))0


### PR DESCRIPTION
Solution: shuffle the pretty blanks to be inside conditionally generated blocks, minimize changes in regenerated projects

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>