### PR TITLE
Problem: dependencies checked out into workspace root

### DIFF
--- a/builds/check_readme/ci_build.sh
+++ b/builds/check_readme/ci_build.sh
@@ -27,10 +27,13 @@ cd "${REPO_DIR}" || exit
 PATH="`pwd`:$PATH"
 export PATH
 
+rm -rf tmp-deps
+mkdir tmp-deps
+
 echo "=== Install gitdown"
-git clone https://github.com/zeromq/gitdown.git gitdown
 mkdir -p ~/bin
-( cd gitdown && ./install-wrapper ~/bin ) || exit $?
+( cd tmp-deps && git clone https://github.com/zeromq/gitdown.git gitdown ) \
+&& ( cd tmp-deps/gitdown && ./install-wrapper ~/bin ) || exit $?
 PATH="$PATH:~/bin"
 export PATH
 which gitdown

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -24,9 +24,14 @@ LC_ALL=C
 export LANG LC_ALL
 
 if [ -d "./tmp" ]; then
+    # Proto installation area for this project and its deps
     rm -rf ./tmp
 fi
-mkdir -p tmp
+if [ -d "./tmp-deps" ]; then
+    # Checkout/unpack and build area for dependencies
+    rm -rf ./tmp-deps
+fi
+mkdir -p tmp tmp-deps
 BUILD_PREFIX=$PWD/tmp
 
 # Use tools from prerequisites we might have built
@@ -59,8 +64,9 @@ fi
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list generator-scripting-language >/dev/null 2>&1) || \
        (command -v brew >/dev/null 2>&1 && brew ls --versions gsl >/dev/null 2>&1)); then
-    $CI_TIME git clone --quiet --depth 1 https://github.com/zeromq/gsl.git gsl
     BASE_PWD=${PWD}
+    cd tmp-deps
+    $CI_TIME git clone --quiet --depth 1 https://github.com/zeromq/gsl.git gsl
     cd gsl
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR

--- a/tstgenbld.sh
+++ b/tstgenbld.sh
@@ -76,7 +76,7 @@ echo "Projects will be built and installed to here: ${BUILD_PREFIX}"
 
 # directory where git projects will be cloned will be ${GITPROJECTS}
 GITROOT=${PWD}
-GITPROJECTS=${GITROOT}/gitprojects
+GITPROJECTS=${GITROOT}/tmp-deps
 echo "Projects will be cloned to here: ${GITPROJECTS}"
 #read -p "Press ENTER to continue: "
 

--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -149,8 +149,11 @@ export TOOLCHAIN_NAME="arm-linux-androideabi-$NDK_ABI_VER"
 export TOOLCHAIN_HOST="arm-linux-androideabi"
 export TOOLCHAIN_ARCH="arm"
 
+rm -rf /tmp/tmp-deps
+mkdir -p /tmp/tmp-deps
+
 .for use where defined (use.repository)
-export $(USE.PROJECT)_ROOT="/tmp/$(use.project)"
+export $(USE.PROJECT)_ROOT="/tmp/tmp-deps/$(use.project)"
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $$(USE.PROJECT)_ROOT
 .   else

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -706,9 +706,14 @@ LC_ALL=C
 export LANG LC_ALL
 
 if [ -d "./tmp" ]; then
+    # Proto installation area for this project and its deps
     rm -rf ./tmp
 fi
-mkdir -p tmp
+if [ -d "./tmp-deps" ]; then
+    # Checkout/unpack and build area for dependencies
+    rm -rf ./tmp-deps
+fi
+mkdir -p tmp tmp-deps
 BUILD_PREFIX=$PWD/tmp
 
 # Use tools from prerequisites we might have built
@@ -753,9 +758,10 @@ if \
        (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
 ; then
     BASE_PWD=${PWD}
+    cd tmp-deps
     wget $(use.tarball)
     tar -xzf \$(basename "$(use.tarball)")
-    cd \$(basename "$(use.tarball)" .tar.gz)
+    cd \$(basename "$(use.tarball)" .tar.gz) || exit \$?
 .   if defined (use.builddir)
     cd ./$(use.builddir)
 .   endif
@@ -799,12 +805,13 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
 .   endif
        (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1)); then
+    BASE_PWD=${PWD}
+    cd tmp-deps
 .   if defined (use.release)
     $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .   else
     $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .   endif
-    BASE_PWD=${PWD}
 .   if defined (use.builddir)
     cd $(use.project)/$(use.builddir)
 .   else

--- a/zproject_docker.gsl
+++ b/zproject_docker.gsl
@@ -27,11 +27,11 @@ RUN chmod 0440 /etc/sudoers.d/zmq
 USER zmq
 
 .for use where !optional & defined (use.tarball)
-WORKDIR /home/zmq
+WORKDIR /home/zmq/tmp-deps
 RUN wget $(use.tarball)
 RUN tar -xzf \$(basename "$(use.tarball)")
 RUN rm \$(basename "$(use.tarball)")
-WORKDIR /home/zmq/\$(basename "$(use.tarball)" .tar.gz)
+WORKDIR /home/zmq/tmp-deps/\$(basename "$(use.tarball)" .tar.gz)
 RUN ./configure --quiet --without-docs
 RUN make
 RUN sudo make install
@@ -39,9 +39,9 @@ RUN sudo ldconfig
 
 .endfor
 .for use where !optional & !defined (use.tarball)
-WORKDIR /home/zmq
+WORKDIR /home/zmq/tmp-deps
 RUN git clone --quiet $(use.repository) $(use.project)
-WORKDIR /home/zmq/$(use.project)
+WORKDIR /home/zmq/tmp-deps/$(use.project)
 RUN ./autogen.sh 2> /dev/null
 RUN ./configure --quiet --without-docs
 RUN make

--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -89,12 +89,7 @@ if !file.exists (".gitignore")
     >Testing/
     >
     ># Repositories downloaded by CI integration scripts
-.   for use where defined (use.repository) & ! defined (use.tarball)
-    >$(use.project)/
-.   endfor
-.   for use where defined (use.tarball)
-    >\$(basename "$(use.tarball)" .tar.gz)/
-.   endfor
+    >tmp-deps/
     >
     ># Travis build area
     >tmp/

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -625,10 +625,14 @@ if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CO
 fi
 
 pushd ../../..
+rm -rf tmp-deps
+mkdir -p tmp-deps
 
 # Clone and build dependencies
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
 .   for use where defined (use.tarball)
+BASE_PWD=${PWD}
+cd tmp-deps
 wget $(use.tarball)
 tar -xzf \$(basename "$(use.tarball)")
 cd \$(basename "$(use.tarball)" .tar.gz)
@@ -644,9 +648,11 @@ $CI_TIME ./configure "${CONFIG_OPTS[@]}"
 .       endif
 $CI_TIME make -j4
 $CI_TIME make install
-cd ..
+cd ${BASE_PWD}
 .   endfor
 .   for use where defined (use.repository)
+BASE_PWD=${PWD}
+cd tmp-deps
 .      if defined (use.release)
 $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .      else
@@ -684,7 +690,7 @@ $CI_TIME make install
 # Build jni dependency
 ( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig $CI_TIME ./gradlew publishToMavenLocal )
 .       endif
-cd ..
+cd ${BASE_PWD}
 
 .   endfor
 popd

--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -93,9 +93,13 @@ done
 
 BUILD_ROOT=`pwd`
 cd ../../..
+rm -rf tmp-deps
+mkdir -p tmp-deps
 
 .for project.use where !optional & defined (use.repository)
 #   Check dependent projects
+BASE_PWD=${PWD}
+cd tmp-deps
 if [ ! -d $(use.project) ]; then
     echo "I:    cloning $(use.repository) into `pwd`/$(use.project)..."
     git clone $QUIET $(use.repository)
@@ -104,6 +108,7 @@ if [ ! -f $(use.project)/builds/gyp/project.gyp ]; then
     echo "E:    `pwd`/$(use.project) out of date (builds/gyp/project.gyp missing)"
     exit
 fi
+cd ${BASE_PWD}
 
 .endfor
 

--- a/zproject_rpi.gsl
+++ b/zproject_rpi.gsl
@@ -67,7 +67,16 @@ if [ $UPDATE ]; then
 fi
 
 # Cross build for the Raspberry Pi
-mkdir -p $PWD/tmp
+if [ -d "./tmp" ]; then
+    # Proto installation area for this project and its deps
+    rm -rf ./tmp
+fi
+if [ -d "./tmp-deps" ]; then
+    # Checkout/unpack and build area for dependencies
+    rm -rf ./tmp-deps
+fi
+mkdir -p tmp tmp-deps
+
 BUILD_PREFIX=$PWD/tmp
 TOOLCHAIN_HOST="arm-linux-gnueabihf"
 TOOLCHAIN_PATH="${PWD}/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin"
@@ -110,6 +119,8 @@ CONFIG_OPTS+=("RANLIB=${RANLIB}")
 if [ ! $INCREMENTAL ]; then
     # Clone and build dependencies
 .   for use where defined (use.tarball)
+    BASE_PWD=${PWD}
+    cd tmp-deps
     if [ ! -e \$(basename "$(use.tarball)") ]; then
         $CI_TIME wget $(use.tarball)
         tar -xzf \$(basename "$(use.tarball)")
@@ -130,9 +141,12 @@ if [ ! $INCREMENTAL ]; then
         $CI_TIME make install
     ) || exit 1
     popd
+    cd ${BASE_PWD}
 
 .   endfor
 .   for use where defined (use.repository) & ! defined (use.tarball)
+    BASE_PWD=${PWD}
+    cd tmp-deps
     if [ ! -e $(use.project) ]; then
 .      if defined (use.release)
         $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
@@ -174,6 +188,7 @@ if [ ! $INCREMENTAL ]; then
         $CI_TIME make install
     ) || exit 1
     popd
+    cd ${BASE_PWD}
 
 .   endfor
 fi

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -242,9 +242,14 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     export LANG LC_ALL
 
     if [ -d "./tmp" ]; then
+        # Proto installation area for this project and its deps
         rm -rf ./tmp
     fi
-    mkdir -p tmp
+    if [ -d "./tmp-deps" ]; then
+        # Checkout/unpack and build area for dependencies
+        rm -rf ./tmp-deps
+    fi
+    mkdir -p tmp tmp-deps
     BUILD_PREFIX=$PWD/tmp
 
     PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'`"
@@ -409,17 +414,19 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         BASE_PWD=${PWD}
 .           if defined (use.tarball)
         echo "`date`: INFO: Building prerequisite '$(use.project)' from tarball..." >&2
+        cd ./tmp-deps
         $CI_TIME wget $(use.tarball)
         tar -xzf \$(basename "$(use.tarball)")
-        cd \$(basename "$(use.tarball)" .tar.gz)
+        cd \$(basename "$(use.tarball)" .tar.gz) || exit \$?
 .           elsif defined (use.repository)
         echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
+        cd ./tmp-deps
 .               if defined (use.release)
         $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .               else
         $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .               endif
-        cd $(use.project)
+        cd ./$(use.project)
 .           endif
 .           if defined (use.builddir)
         cd ./$(use.builddir)
@@ -572,7 +579,9 @@ set -ex
 [ -n "${REPO_DIR-}" ] || exit 1
 
 # Verify all required dependencies with repos can be checked out
-cd "$REPO_DIR/.."
+rm -rf "$REPO_DIR/../tmp-deps"
+mkdir -p "$REPO_DIR/../tmp-deps"
+cd "$REPO_DIR/../tmp-deps"
 .for project.use where !optional & defined (use.repository)
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
@@ -584,7 +593,7 @@ cd -
 
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list zproject >/dev/null 2>&1) || \\
        (command -v brew >/dev/null 2>&1 && brew ls --versions zproject >/dev/null 2>&1)); then
-    cd "$REPO_DIR/.."
+    cd "$REPO_DIR/../tmp-deps"
     git clone --quiet --depth 1 https://github.com/zeromq/zproject zproject
     cd zproject
     PATH="`pwd`:$PATH"
@@ -592,7 +601,7 @@ fi
 
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list generator-scripting-language >/dev/null 2>&1) || \\
        (command -v brew >/dev/null 2>&1 && brew ls --versions gsl >/dev/null 2>&1)); then
-    cd "$REPO_DIR/.."
+    cd "$REPO_DIR/../tmp-deps"
     git clone https://github.com/zeromq/gsl.git gsl
     cd gsl/src
     make


### PR DESCRIPTION
Solution: avoid potential conflicts and simpify gitignore maintenance by dedicating a tmp-deps subdirectory for the checkout and build of dependency components.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: I tested this with a few projects that have Travis for autotools, and ported the fix but not tested for CMake and for bindings. One example is at https://github.com/42ity/fty-example/pull/24/files