### PR TITLE
Clean up some more fallout from #1113

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,11 +71,13 @@ install_manifest.txt
 Testing/
 
 # Repositories downloaded by CI integration scripts
-gsl/
-gitdown/
+tmp-deps/
+###gsl/
+###gitdown/
 
-# Manually tracked: the czmq source is pulled as a test target
-czmq/
+### Manually tracked: the czmq source is pulled as a test target
+###libzmq/
+###czmq/
 
 # Travis build area
 tmp/

--- a/zproject_class_api.gsl
+++ b/zproject_class_api.gsl
@@ -41,6 +41,8 @@ if python_cffi ?= 1
     for project.use
         if file.exists ("../$(use.project:c)/api/python_cffi.slurp")
             use.python_cffi_slurp = "../$(use.project:c)/api/python_cffi.slurp"
+        elsif file.exists ("tmp-deps/$(use.project:c)/api/python_cffi.slurp")
+            use.python_cffi_slurp = "tmp-deps/$(use.project:c)/api/python_cffi.slurp"
         elsif file.exists ("/usr/local/share/zproject/$(use.project:c)/python_cffi.slurp")
             use.python_cffi_slurp = "/usr/local/share/zproject/$(use.project:c)/python_cffi.slurp"
         elsif file.exists ("/usr/share/zproject/$(use.project:c)/python_cffi.slurp")

--- a/zproject_gyp.gsl
+++ b/zproject_gyp.gsl
@@ -192,15 +192,20 @@ $(project.GENERATED_WARNING_HEADER:)
       ],
       'dependencies': [
 .   for project.use where !optional
-.       use.gypfile = "../$(use.project)/$(my.targetdir)/project.gyp"
+.       prjdir = "../$(use.project)"
+.       gypfile = "$(prjdir)/$(my.targetdir)/project.gyp"
 .       if ! file.exists (gypfile)
-.           use.gypfile_tmp = "../tmp-deps/$(use.project)/$(my.targetdir)/project.gyp"
+.           prjdir_tmp = "../tmp-deps/$(use.project)"
+.           gypfile_tmp = "$(prjdir_tmp)/$(my.targetdir)/project.gyp"
 .       endif
 .       if (file.exists (gypfile) | file.exists (gypfile_tmp))
 .# Note: Use the location expected in usual, non-CI workflows
         '../../$(gypfile):$(use.libname)',
 .       else
-.           abort "E: please checkout $(use.project) into ../tmp-deps/$(use.project) or ../$(use.project)"
+.# Note: Simply missing file with a properly checked out code is ok, it just is not there
+.           if (!file.exists (prjdir) & !file.exists (prjdir_tmp))
+.               abort "E: please checkout $(use.project) into $(prjdir_tmp) or $(prjdir)"
+.           endif
 .       endif
 .   endfor
       ],

--- a/zproject_gyp.gsl
+++ b/zproject_gyp.gsl
@@ -56,8 +56,6 @@ project.Makefile
 *.mk
 out/
 Makefile
-tmp-deps/
-.#TODO: Remove this for if tmp-deps/ works for this
 .for project.use where !optional
 $(use.project)/
 .endfor
@@ -193,13 +191,10 @@ $(project.GENERATED_WARNING_HEADER:)
       'dependencies': [
 .   for project.use where !optional
 .       use.gypfile = "../$(use.project)/$(my.targetdir)/project.gyp"
-.       if ! file.exists (gypfile)
-.           use.gypfile = "../tmp-deps/$(use.project)/$(my.targetdir)/project.gyp"
-.       endif
 .       if file.exists (gypfile)
         '../../$(gypfile):$(use.libname)',
 .       else
-.           echo "E: please checkout $(use.project) into ../tmp-deps/$(use.project) or ../$(use.project)"
+.           echo "E: please checkout $(use.project) into ../$(use.project)"
 .       endif
 .   endfor
       ],

--- a/zproject_gyp.gsl
+++ b/zproject_gyp.gsl
@@ -194,7 +194,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .       if file.exists (gypfile)
         '../../$(gypfile):$(use.libname)',
 .       else
-.           echo "E: please checkout $(use.project) into ../$(use.project)"
+.           abort "E: please checkout $(use.project) into ../$(use.project)"
 .       endif
 .   endfor
       ],

--- a/zproject_gyp.gsl
+++ b/zproject_gyp.gsl
@@ -56,6 +56,8 @@ project.Makefile
 *.mk
 out/
 Makefile
+tmp-deps/
+.#TODO: Remove this for if tmp-deps/ works for this
 .for project.use where !optional
 $(use.project)/
 .endfor
@@ -191,10 +193,14 @@ $(project.GENERATED_WARNING_HEADER:)
       'dependencies': [
 .   for project.use where !optional
 .       use.gypfile = "../$(use.project)/$(my.targetdir)/project.gyp"
-.       if file.exists (gypfile)
+.       if ! file.exists (gypfile)
+.           use.gypfile_tmp = "../tmp-deps/$(use.project)/$(my.targetdir)/project.gyp"
+.       endif
+.       if (file.exists (gypfile) | file.exists (gypfile_tmp))
+.# Note: Use the location expected in usual, non-CI workflows
         '../../$(gypfile):$(use.libname)',
 .       else
-.           abort "E: please checkout $(use.project) into ../$(use.project)"
+.           abort "E: please checkout $(use.project) into ../tmp-deps/$(use.project) or ../$(use.project)"
 .       endif
 .   endfor
       ],

--- a/zproject_java_msvc.gsl
+++ b/zproject_java_msvc.gsl
@@ -268,8 +268,14 @@ $(project.GENERATED_WARNING_HEADER:)
     <ClCompile>
       <AdditionalIncludeDirectories>..\\..\\..\\..\\..\\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$\(JAVA_HOME)\\include;$\(JAVA_HOME)\\include\\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-.for project.use where file.exists ("../$(use.project)/include")
+.for project.use
+.   if file.exists ("../$(use.project)/include")
       <AdditionalIncludeDirectories>..\\..\\..\\..\\..\\..\\$(use.project)\\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+.   else
+.       if use.optional ?= 0
+.           abort "E: please checkout $(use.project) into ../$(use.project)"
+.       endif
+.   endif
 .endfor
       <CompileAs>CompileAsC</CompileAs>
       <DisableSpecificWarnings>%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -26,6 +26,7 @@ Makefile
 logs
 *.log
 npm-debug.log*
+tmp-deps/
 .for project.use where !optional
 $(use.project)/
 .endfor
@@ -151,8 +152,12 @@ $(project.GENERATED_WARNING_HEADER:)
       'target_name': '$(project.name)',
       'sources': [
 .   for project.use where !optional
-.       if file.exists ("../$(use.project)/$(topdir)/binding.cc")
-          '../../../$(use.project)/$(topdir)/binding.cc',
+.       if file.exists ("../tmp-deps/$(use.project)/$(topdir)/binding.cc")
+          '../../../tmp-deps/$(use.project)/$(topdir)/binding.cc',
+.       else
+.           if !file.exists ("../tmp-deps/$(use.project)")
+.               abort "E: please checkout $(use.project) into ../../../tmp-deps/$(use.project)"
+.           endif
 .       endif
 .   endfor
           'binding.cc'
@@ -160,7 +165,7 @@ $(project.GENERATED_WARNING_HEADER:)
       'include_dirs': [
           "<!(node -e \\"require('nan')\\")",
 .   for project.use where !optional
-          '../../../$(use.project)/include',
+          '../../../tmp-deps/$(use.project)/include',
 .   endfor
           '../../include'
       ],
@@ -244,8 +249,12 @@ $(project.GENERATED_WARNING_HEADER:)
 #define $(PROJECT.PREFIX)_BUILD_DRAFT_API
 
 .   for project.use where !optional
-.       if file.exists ("../$(use.project)/$(topdir)/binding.h")
-#include "../../../$(use.project)/$(topdir)/binding.h"
+.       if file.exists ("../tmp-deps/$(use.project)/$(topdir)/binding.h")
+#include "../../../tmp-deps/$(use.project)/$(topdir)/binding.h"
+.       else
+.           if !file.exists ("../tmp-deps/$(use.project)")
+.               abort "E: please checkout $(use.project) into ../tmp-deps/$(use.project)"
+.           endif
 .       endif
 .   endfor
 #include "$(project.header)"

--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -103,11 +103,13 @@ BASE_PWD=${PWD}
 cd tmp-deps
 if [ ! -d $(use.project) ]; then
     echo "I:    cloning $(use.repository) into `pwd`/$(use.project)..."
-    git clone $QUIET $(use.repository)
+.# TODO: Should there be a use of "release" (git branch) like elsewhere?
+    git clone $QUIET $(use.repository) || exit
 fi
 if [ ! -f $(use.project)/builds/gyp/project.gyp ]; then
-    echo "E:    `pwd`/$(use.project) out of date (builds/gyp/project.gyp missing)"
-    exit
+.# Note: We removed tmp-deps before, so the checkout is assumed most-recent and clean
+    echo "E:    `pwd`/$(use.project) out of date (builds/gyp/project.gyp missing)" >&2
+    exit 1
 fi
 cd ${BASE_PWD}
 

--- a/zproject_nodejs.gsl
+++ b/zproject_nodejs.gsl
@@ -26,7 +26,6 @@ Makefile
 logs
 *.log
 npm-debug.log*
-tmp-deps/
 .for project.use where !optional
 $(use.project)/
 .endfor
@@ -94,24 +93,20 @@ done
 
 BUILD_ROOT=`pwd`
 cd ../../..
-rm -rf tmp-deps
-mkdir -p tmp-deps
+# Note: here we go to parent directory that contains current project,
+# so the checkout is nearby, same as expected for usual developer work
 
 .for project.use where !optional & defined (use.repository)
 #   Check dependent projects
-BASE_PWD=${PWD}
-cd tmp-deps
 if [ ! -d $(use.project) ]; then
     echo "I:    cloning $(use.repository) into `pwd`/$(use.project)..."
 .# TODO: Should there be a use of "release" (git branch) like elsewhere?
     git clone $QUIET $(use.repository) || exit
 fi
 if [ ! -f $(use.project)/builds/gyp/project.gyp ]; then
-.# Note: We removed tmp-deps before, so the checkout is assumed most-recent and clean
     echo "E:    `pwd`/$(use.project) out of date (builds/gyp/project.gyp missing)" >&2
     exit 1
 fi
-cd ${BASE_PWD}
 
 .endfor
 
@@ -154,11 +149,12 @@ $(project.GENERATED_WARNING_HEADER:)
       'target_name': '$(project.name)',
       'sources': [
 .   for project.use where !optional
-.       if file.exists ("../tmp-deps/$(use.project)/$(topdir)/binding.cc")
-          '../../../tmp-deps/$(use.project)/$(topdir)/binding.cc',
+.# Note: the file.exists() paths are relative to current project.xml during zproject regen
+.       if file.exists ("../$(use.project)/$(topdir)/binding.cc")
+          '../../../$(use.project)/$(topdir)/binding.cc',
 .       else
-.           if !file.exists ("../tmp-deps/$(use.project)")
-.               abort "E: please checkout $(use.project) into ../../../tmp-deps/$(use.project)"
+.           if !file.exists ("../$(use.project)")
+.               abort "E: please checkout $(use.project) into ../../../$(use.project)"
 .           endif
 .       endif
 .   endfor
@@ -167,7 +163,7 @@ $(project.GENERATED_WARNING_HEADER:)
       'include_dirs': [
           "<!(node -e \\"require('nan')\\")",
 .   for project.use where !optional
-          '../../../tmp-deps/$(use.project)/include',
+          '../../../$(use.project)/include',
 .   endfor
           '../../include'
       ],
@@ -251,11 +247,11 @@ $(project.GENERATED_WARNING_HEADER:)
 #define $(PROJECT.PREFIX)_BUILD_DRAFT_API
 
 .   for project.use where !optional
-.       if file.exists ("../tmp-deps/$(use.project)/$(topdir)/binding.h")
-#include "../../../tmp-deps/$(use.project)/$(topdir)/binding.h"
+.       if file.exists ("../$(use.project)/$(topdir)/binding.h")
+#include "../../../$(use.project)/$(topdir)/binding.h"
 .       else
-.           if !file.exists ("../tmp-deps/$(use.project)")
-.               abort "E: please checkout $(use.project) into ../tmp-deps/$(use.project)"
+.           if !file.exists ("../$(use.project)")
+.               abort "E: please checkout $(use.project) into ../$(use.project)"
 .           endif
 .       endif
 .   endfor

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -579,9 +579,9 @@ set -ex
 [ -n "${REPO_DIR-}" ] || exit 1
 
 # Verify all required dependencies with repos can be checked out
-rm -rf "$REPO_DIR/../tmp-deps"
-mkdir -p "$REPO_DIR/../tmp-deps"
-cd "$REPO_DIR/../tmp-deps"
+# Note: certain zproject scripts that deal with deeper dependencies expect that
+# such checkouts are directly in the same parent directory as "this" project.
+cd "$REPO_DIR/.."
 .for project.use where !optional & defined (use.repository)
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
@@ -593,7 +593,7 @@ cd -
 
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list zproject >/dev/null 2>&1) || \\
        (command -v brew >/dev/null 2>&1 && brew ls --versions zproject >/dev/null 2>&1)); then
-    cd "$REPO_DIR/../tmp-deps"
+    cd "$REPO_DIR/.."
     git clone --quiet --depth 1 https://github.com/zeromq/zproject zproject
     cd zproject
     PATH="`pwd`:$PATH"
@@ -601,7 +601,7 @@ fi
 
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list generator-scripting-language >/dev/null 2>&1) || \\
        (command -v brew >/dev/null 2>&1 && brew ls --versions gsl >/dev/null 2>&1)); then
-    cd "$REPO_DIR/../tmp-deps"
+    cd "$REPO_DIR/.."
     git clone https://github.com/zeromq/gsl.git gsl
     cd gsl/src
     make


### PR DESCRIPTION
The `check_zproject` script verifies that an expected set-up of a developer workstation includes dependency checkouts in proper locations (into same parent dir as the checked project itself). Thus, it should not use `tmp-deps/` after all.

Also, generated projects' code should not refer to `tmp-deps/` either - if the dependencies' files are to be used directly without a checkout, it may be an unfortunately intimate type of dependency, but one that should be reproducible in a casual developer's environment manually per README instructions, etc.