### PR TITLE
Problem: slow Jenkins environments have same commit built many times

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,20 @@ zproject's `project.xml` contains an extensive description of the available conf
          empty string disables polling, so you'd only run the job manually.
          Note that the most frequent working setting is "H/2", NOT a "H/1".
 
+         On the Jenkins setup used by generated projects, sometimes it was
+         re-scheduling the same commits over and over and even overlapping.
+         Usually this was linked to some lagginess of the build system or
+         its internet connection, but the result was a growing queue of
+         same (and redundant) builds. To remedy this, projects can set a
+         few experimental options now (and regenerate their Jenkinsfile):
+         * use_earlymilestone -- uses a milestone to cancel builds that
+            got to it later than the running one
+         * use_build_nonconcurrent -- sets a disableConcurrentBuilds option
+         * use_checkout_explicit -- sets a skipDefaultCheckout option and
+            defines a step to check out code explicitly; it is believed
+            this may better succeed in recording which commits are already
+            being processed by the server
+
          The use_test_timeout option sets up the default timeout for test
          steps (further configurable at run-time as a build argument).
          Generally unit tests should not take pathologically long, so the

--- a/project.xml
+++ b/project.xml
@@ -255,6 +255,20 @@
          empty string disables polling, so you'd only run the job manually.
          Note that the most frequent working setting is "H/2", NOT a "H/1".
 
+         On the Jenkins setup used by generated projects, sometimes it was
+         re-scheduling the same commits over and over and even overlapping.
+         Usually this was linked to some lagginess of the build system or
+         its internet connection, but the result was a growing queue of
+         same (and redundant) builds. To remedy this, projects can set a
+         few experimental options now (and regenerate their Jenkinsfile):
+         * use_earlymilestone -- uses a milestone to cancel builds that
+            got to it later than the running one
+         * use_build_nonconcurrent -- sets a disableConcurrentBuilds option
+         * use_checkout_explicit -- sets a skipDefaultCheckout option and
+            defines a step to check out code explicitly; it is believed
+            this may better succeed in recording which commits are already
+            being processed by the server
+
          The use_test_timeout option sets up the default timeout for test
          steps (further configurable at run-time as a build argument).
          Generally unit tests should not take pathologically long, so the

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -289,7 +289,7 @@ pipeline {
 // Note: your Jenkins setup may benefit from similar setup on side of agents:
 //        PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/bin:/bin:\$\{PATH}"
     stages {
-        stage ('prepare') {
+        stage ('pre-clean') {
 .       jenkins_agent (project, 0)
                     steps {
                         dir("tmp") {
@@ -300,8 +300,13 @@ pipeline {
 .       endif
                             deleteDir()
                         }
+                        sh 'rm -f ccache.log cppcheck.xml'
+                    }
+        }
+        stage ('prepare') {
+.       jenkins_agent (project, 0)
+                    steps {
                         sh './autogen.sh'
-                        sh 'rm -f ccache.log'
                         stash (name: 'prepped', includes: '**/*', excludes: '**/cppcheck.xml')
                     }
         }

--- a/zproject_jenkins.gsl
+++ b/zproject_jenkins.gsl
@@ -285,6 +285,26 @@ pipeline {
     }
 .   endif
 .  endif
+.  if project.jenkins_use_checkout_explicit ?= 1 | project.jenkins_use_build_nonconcurrent ?= 1
+
+    // Jenkins tends to reschedule jobs that have not yet completed if they took
+    // too long, maybe this happens in combination with polling. Either way, if
+    // the server gets into this situation, the snowball of same builds grows as
+    // the build system lags more and more. Let the devs avoid it in a few ways.
+    options {
+.   if project.jenkins_use_build_nonconcurrent ?= 1
+        disableConcurrentBuilds()
+.   endif
+.   if project.jenkins_use_checkout_explicit ?= 1
+        // Jenkins community suggested that instead of a default checkout, we can do
+        // an explicit step for that. It is expected that either way Jenkins "should"
+        // record that a particular commit is being processed, but the explicit ways
+        // might work better. In either case it honors SCM settings like refrepo if
+        // set up in the Pipeline or MultiBranchPipeline job.
+        skipDefaultCheckout()
+.   endif
+    }
+.  endif
 .# TODO: Add a --enable-address-sanitizer=yes matrix
 // Note: your Jenkins setup may benefit from similar setup on side of agents:
 //        PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/bin:/bin:\$\{PATH}"
@@ -292,6 +312,9 @@ pipeline {
         stage ('pre-clean') {
 .       jenkins_agent (project, 0)
                     steps {
+.  if project.jenkins_use_earlymilestone ?= 1
+                        milestone ordinal: 20, label: "${env.JOB_NAME}@${env.BRANCH_NAME}"
+.  endif
                         dir("tmp") {
                             sh 'if [ -s Makefile ]; then make -k distclean || true ; fi'
                             sh 'chmod -R u+w .'
@@ -303,11 +326,27 @@ pipeline {
                         sh 'rm -f ccache.log cppcheck.xml'
                     }
         }
+.  if project.jenkins_use_checkout_explicit ?= 1
+        stage ('git') {
+.       jenkins_agent (project, 0)
+                    steps {
+                        retry(3) {
+                            checkout scm
+                        }
+.  if project.jenkins_use_earlymilestone ?= 1
+                        milestone ordinal: 30, label: "${env.JOB_NAME}@${env.BRANCH_NAME}"
+.  endif
+                    }
+        }
+.  endif
         stage ('prepare') {
 .       jenkins_agent (project, 0)
                     steps {
                         sh './autogen.sh'
                         stash (name: 'prepped', includes: '**/*', excludes: '**/cppcheck.xml')
+.  if project.jenkins_use_earlymilestone ?= 1
+                        milestone ordinal: 40, label: "${env.JOB_NAME}@${env.BRANCH_NAME}"
+.  endif
                     }
         }
         stage ('compile') {


### PR DESCRIPTION
Solution: Jenkins IRC community is not quite sure why this happens: it may be that jobs are scheduled "thanks" to both Branch Indexing and SCM Polling and ... enabled on the build farm, but anyhow the implicit `checkout scm` should (but maybe does not) record the commits that are being processed. It was suggested that an explicit step instead of the implicit checkout can be better.

While at it, can also try the milestone mechanism to cancel out needless builds, and an option to disable concurrent builds at all.

These three approaches can be mixed to experiment what works best for a particular project to balance latency and overhead (e.g. many PRs merged to master branches quickly, with increments to be tested separately or just the latest ones?) and neither option is enabled by default, so existing projects using a Jenkinsfile should not see any behavioral difference until they elect to.

One change that would impact all Jenkinsfiles is separation of "pre-clean" and "prep" activities into two different stages, so their logs and timings are separated.