### PR TITLE
Problem: manual selection of clang-format in travis.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ zproject's `project.xml` contains an extensive description of the available conf
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="0" /> will disable run of make distcheck in Travis CI
+            <option name="distcheck" value="0" /> "false" will disable run of make distcheck in Travis CI (default: true)
+            <option name="clangformat_allow_failures" value="0" /> "true" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: true)
+            <option name="clangformat_require_good" value="0" /> "true" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "false" hides the failure, devs must look in test logs) (default: same as allow_failures)
+            <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010
         vs2012              Microsoft Visual Studio 2012

--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ zproject's `project.xml` contains an extensive description of the available conf
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="0" /> "false" will disable run of make distcheck in Travis CI (default: true)
-            <option name="clangformat_allow_failures" value="0" /> "true" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: true)
-            <option name="clangformat_require_good" value="0" /> "true" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "false" hides the failure, devs must look in test logs) (default: same as allow_failures)
+            <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI (default: 1)
+            <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
+            <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)
+            <option name="clangformat_allow_failures" value="0" /> "1" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: 1)
+            <option name="clangformat_require_good" value="0" /> "1" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "0" hides the failure, and devs must look in test logs) (default: same as allow_failures)
             <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010

--- a/project.xml
+++ b/project.xml
@@ -19,9 +19,11 @@
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="0" /> "false" will disable run of make distcheck in Travis CI (default: true)
-            <option name="clangformat_allow_failures" value="0" /> "true" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: true)
-            <option name="clangformat_require_good" value="0" /> "true" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "false" hides the failure, devs must look in test logs) (default: same as allow_failures)
+            <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI (default: 1)
+            <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
+            <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)
+            <option name="clangformat_allow_failures" value="0" /> "1" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: 1)
+            <option name="clangformat_require_good" value="0" /> "1" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "0" hides the failure, and devs must look in test logs) (default: same as allow_failures)
             <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010

--- a/project.xml
+++ b/project.xml
@@ -19,7 +19,10 @@
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="0" /> will disable run of make distcheck in Travis CI
+            <option name="distcheck" value="0" /> "false" will disable run of make distcheck in Travis CI (default: true)
+            <option name="clangformat_allow_failures" value="0" /> "true" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: true)
+            <option name="clangformat_require_good" value="0" /> "true" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "false" hides the failure, devs must look in test logs) (default: same as allow_failures)
+            <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010
         vs2012              Microsoft Visual Studio 2012

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -58,7 +58,23 @@ env:
     - CI_TRACE=false
     - CI_CONFIG_QUIET=true
     - CI_REQUIRE_GOOD_GITIGNORE=false
-    - CI_REQUIRE_GOOD_CLANG_FORMAT=false
+    - CI_REQUIRE_GOOD_CLANG_FORMAT=\
+.if defined(project.travis_clangformat_require_good)
+.   echo "TRAVIS: CLANG-FORMAT: require-good: " + project.travis_clangformat_require_good
+.   if project.travis_clangformat_require_good ?= 1
+true
+.   else
+false
+.   endif
+.else
+.   if project.travis_clangformat_allow_failures ?= 1
+.   echo "TRAVIS: CLANG-FORMAT: require-good: " + 1 + " (default from allow_failed)"
+true
+.   else
+.   echo "TRAVIS: CLANG-FORMAT: require-good: " + 0 + " (default from allow_failed)"
+false
+.   endif
+.endif
     # tokens to deploy releases on OBS and create/delete temporary branch on Github.
     # 1) Create a token on https://github.com/settings/tokens/new with "public_repo"
     #    capability and encrypt it with travis encrypt --org -r <org>/<repo> GH_TOKEN="<token>"
@@ -169,12 +185,21 @@ matrix:
         sources: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_common
+.if project.travis_clangformat_implem ?= "autotools"
+.   echo "TRAVIS: CLANG-FORMAT: implementation: autotools"
+### Note: we don't use CMake
+#\
+.endif
   - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
 # For non-cmake users, there is an autotools solution with a bit more overhead
 # to have dependencies ready and pass configure script before making this check).
 # Note that the autotools variant will also require dependencies preinstalled to
 # pass its configure script:
-#  - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
+.if !defined(project.travis_clangformat_implem) | project.travis_clangformat_implem ?= "cmake"
+.   echo "TRAVIS: CLANG-FORMAT: implementation: cmake"
+#\
+.endif
+  - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
     os: linux
     dist: trusty
     addons:
@@ -184,7 +209,23 @@ matrix:
         packages:
         - clang-5.0
         - clang-format-5.0
-#autotools#        - *pkg_deps_prereqs
+.if !defined(project.travis_clangformat_implem) | project.travis_clangformat_implem ?= "cmake"
+#autotools#\
+.endif
+        - *pkg_deps_prereqs
+.if project.travis_clangformat_allow_failures ?= 1
+.   echo "TRAVIS: CLANG-FORMAT: allow-fail: 1"
+# Note: "env" lines below must exactly describe a matrix option defined above
+  allow_failures:
+.if project.travis_clangformat_implem ?= "autotools"
+#\
+.endif
+  - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
+.   if !defined(project.travis_clangformat_implem) | project.travis_clangformat_implem ?= "cmake"
+#\
+.   endif
+  - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
+.endif
 
 before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "android" ] ; then brew install binutils ; fi

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -557,7 +557,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     make check-gitignore
     echo "==="
 
-.   if travis_distcheck ?= 0
+.   if project.travis_distcheck ?= 0
     make check
 .   else
     (
@@ -581,7 +581,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         $CI_TIME ./autogen.sh 2> /dev/null
         $CI_TIME ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
         $CI_TIME make VERBOSE=1 all || exit $?
-.   if travis_distcheck ?= 0
+.   if project.travis_distcheck ?= 0
         make check
 .   else
         (

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -88,6 +88,10 @@ false
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=default-Werror
+.if project.travis_use_cmake ?= 0
+### Note: we don't use CMake
+#\
+.endif
     - BUILD_TYPE=cmake
 #   - BUILD_TYPE=android
 #   - BUILD_TYPE=check-py
@@ -129,7 +133,13 @@ pkg_deps_prereqs_source: &pkg_deps_prereqs_source
 .       endif
 .      endfor
 
+.if project.travis_use_pkg_deps_prereqs_source ?= 0
+# NOTE: Our forks are checked out and built without pkg dependencies in use
+.endif
 pkg_deps_prereqs: &pkg_deps_prereqs
+.if project.travis_use_pkg_deps_prereqs_source ?= 0
+#\
+.endif
     - *pkg_deps_prereqs_source
     - *pkg_deps_prereqs_distro
 
@@ -185,7 +195,7 @@ matrix:
         sources: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_common
-.if project.travis_clangformat_implem ?= "autotools"
+.if project.travis_clangformat_implem ?= "autotools" | ( !defined(project.travis_clangformat_implem) & project.travis_use_cmake ?= 0 )
 .   echo "TRAVIS: CLANG-FORMAT: implementation: autotools"
 ### Note: we don't use CMake
 #\
@@ -195,7 +205,7 @@ matrix:
 # to have dependencies ready and pass configure script before making this check).
 # Note that the autotools variant will also require dependencies preinstalled to
 # pass its configure script:
-.if !defined(project.travis_clangformat_implem) | project.travis_clangformat_implem ?= "cmake"
+.if project.travis_clangformat_implem ?= "cmake" | ( !defined(project.travis_clangformat_implem) & ( project.travis_use_cmake ?= 1 | !defined(project.travis_use_cmake) ) )
 .   echo "TRAVIS: CLANG-FORMAT: implementation: cmake"
 #\
 .endif
@@ -209,7 +219,7 @@ matrix:
         packages:
         - clang-5.0
         - clang-format-5.0
-.if !defined(project.travis_clangformat_implem) | project.travis_clangformat_implem ?= "cmake"
+.if project.travis_clangformat_implem ?= "cmake" | ( !defined(project.travis_clangformat_implem) & ( project.travis_use_cmake ?= 1 | !defined(project.travis_use_cmake) ) )
 #autotools#\
 .endif
         - *pkg_deps_prereqs
@@ -217,11 +227,11 @@ matrix:
 .   echo "TRAVIS: CLANG-FORMAT: allow-fail: 1"
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
-.if project.travis_clangformat_implem ?= "autotools"
+.   if project.travis_clangformat_implem ?= "autotools" | ( !defined(project.travis_clangformat_implem) & project.travis_use_cmake ?= 0 )
 #\
-.endif
+.   endif
   - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
-.   if !defined(project.travis_clangformat_implem) | project.travis_clangformat_implem ?= "cmake"
+.   if project.travis_clangformat_implem ?= "cmake" | ( !defined(project.travis_clangformat_implem) & ( project.travis_use_cmake ?= 1 | !defined(project.travis_use_cmake) ) )
 #\
 .   endif
   - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0


### PR DESCRIPTION
Solution: avoid the need to keep up manually customized travis.yml bits
in projects that chose to avoid CMake by making the clang-format related
options for Travis CI tests configurable (defaults match current state
of zproject).

Also this PR adds support for `allow_failures` block to report style mismatches
in a manner non-fatal for the build.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>