### PR TITLE
Problem: travis recipe allows to only do(1) or skip(0) distcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI (default: 1)
+            <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI, "2" will enable it as a special testcase allowed to fail (default: 1 to enable and require to pass)
             <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
             <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)
             <option name="clangformat_allow_failures" value="0" /> "1" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: 1)

--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Model is described in `zproject_known_projects.xml` file:
 
     <use project = "libcurl"
         repository = "https://github.com/curl/curl.git"
+        debian_name = "libcurl4-openssl-dev"
         test = "curl_easy_init"
         header = "curl/curl.h" />
 

--- a/project.xml
+++ b/project.xml
@@ -19,7 +19,7 @@
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI (default: 1)
+            <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI, "2" will enable it as a special testcase allowed to fail (default: 1 to enable and require to pass)
             <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
             <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)
             <option name="clangformat_allow_failures" value="0" /> "1" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: 1)

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -75,6 +75,14 @@ true
 false
 .   endif
 .endif
+    - CI_TEST_DISTCHECK=\
+.if !defined(project.travis_distcheck) | project.travis_distcheck ?= 1
+.# 1 = required, is default if nothing is set
+true
+.else
+.# 0 = skip, 2 = allowed fail (in a special test case, skip in others)
+false
+.endif
     # tokens to deploy releases on OBS and create/delete temporary branch on Github.
     # 1) Create a token on https://github.com/settings/tokens/new with "public_repo"
     #    capability and encrypt it with travis encrypt --org -r <org>/<repo> GH_TOKEN="<token>"
@@ -88,6 +96,9 @@ false
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=default-Werror
+.if project.travis_distcheck ?= 2
+    - BUILD_TYPE=default CI_TEST_DISTCHECK=true
+.endif
 .if project.travis_use_cmake ?= 0
 ### Note: we don't use CMake
 #\
@@ -223,18 +234,24 @@ matrix:
 #autotools#\
 .endif
         - *pkg_deps_prereqs
-.if project.travis_clangformat_allow_failures ?= 1
-.   echo "TRAVIS: CLANG-FORMAT: allow-fail: 1"
+.if project.travis_clangformat_allow_failures ?= 1 | project.travis_distcheck ?= 2
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
-.   if project.travis_clangformat_implem ?= "autotools" | ( !defined(project.travis_clangformat_implem) & project.travis_use_cmake ?= 0 )
-#\
+.   if project.travis_distcheck ?= 2
+.   echo "TRAVIS: DISTCHECK: allow-fail: true"
+  - env: BUILD_TYPE=default CI_TEST_DISTCHECK=true
 .   endif
+.   if project.travis_clangformat_allow_failures ?= 1
+.   echo "TRAVIS: CLANG-FORMAT: allow-fail: true"
+.       if project.travis_clangformat_implem ?= "autotools" | ( !defined(project.travis_clangformat_implem) & project.travis_use_cmake ?= 0 )
+#\
+.       endif
   - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
-.   if project.travis_clangformat_implem ?= "cmake" | ( !defined(project.travis_clangformat_implem) & ( project.travis_use_cmake ?= 1 | !defined(project.travis_use_cmake) ) )
+.       if project.travis_clangformat_implem ?= "cmake" | ( !defined(project.travis_clangformat_implem) & ( project.travis_use_cmake ?= 1 | !defined(project.travis_use_cmake) ) )
 #\
-.   endif
+.       endif
   - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
+.   endif
 .endif
 
 before_install:
@@ -567,18 +584,18 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     make check-gitignore
     echo "==="
 
-.   if project.travis_distcheck ?= 0
-    make check
-.   else
+    if [ "$CI_TEST_DISTCHECK" = false ]; then
+        make check
+    else
     (
-        export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}"
-        $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
-
-        echo "=== Are GitIgnores good after 'make distcheck' with drafts?"
-        make check-gitignore
-        echo "==="
+        export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=yes ${CONFIG_OPTS[@]}" && \\
+        $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
     )
-.   endif
+    fi
+
+    echo "=== Are GitIgnores good after 'make (dist)check' with drafts?"
+    make check-gitignore
+    echo "==="
 
     # Build and check this project without DRAFT APIs
     echo ""
@@ -591,18 +608,18 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         $CI_TIME ./autogen.sh 2> /dev/null
         $CI_TIME ./configure --enable-drafts=no "${CONFIG_OPTS[@]}"
         $CI_TIME make VERBOSE=1 all || exit $?
-.   if project.travis_distcheck ?= 0
-        make check
-.   else
+        if [ "$CI_TEST_DISTCHECK" = false ]; then
+            make check
+        else
         (
             export DISTCHECK_CONFIGURE_FLAGS="--enable-drafts=no ${CONFIG_OPTS[@]}" && \\
             $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck || exit $?
         )
-.   endif
+        fi
     ) || exit 1
     [ -z "$CI_TIME" ] || echo "`date`: Builds completed without fatal errors!"
 
-    echo "=== Are GitIgnores good after 'make distcheck' without drafts?"
+    echo "=== Are GitIgnores good after 'make (dist)check' without drafts?"
     make check-gitignore
     echo "==="
 


### PR DESCRIPTION
Solution: add an option to generally skip it, but run it in a special test case allowed to fail (2) as a project approaches maturity

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>