### PR TITLE
Problem: Qt-Binding fails to compile if a class name == project name

### DIFF
--- a/zproject_qt.gsl
+++ b/zproject_qt.gsl
@@ -438,8 +438,8 @@ endfunction
 /*
 $(project.GENERATED_WARNING_HEADER:)
 */
-#ifndef Q_$(PROJECT.PREFIX)_H
-#define Q_$(PROJECT.PREFIX)_H
+#ifndef Q_$(PROJECT.QTNAME)_H
+#define Q_$(PROJECT.QTNAME)_H
 
 #include <QObject>
 #include <QString>
@@ -780,6 +780,9 @@ $(project.GENERATED_WARNING_HEADER:)
         project.QtName = "q$(project.name)"
         for class where defined (class.api) & class.private = "0"
             class.QtName = "Q$(class.c_name:Pascal)"
+            if "$(class.qtname)" = "$(project.qtname)"
+                project.QtName = "qt$(project.name)"
+            endif
         endfor
         for dependencies.class
             class.QtName = "Q$(class.c_name:Pascal)"


### PR DESCRIPTION
Solution: If there's a class with the same name as the project
choose another Qt project name to resolve the conflict.