### PR TITLE
problem: zproject missing a way to configure/enable/install language bindings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,23 @@ else
     AC_MSG_RESULT([no])
 fi
 
+# Install Python Bindings
+AC_MSG_CHECKING([whether to install Python bindings])
+
+AC_ARG_ENABLE([bindings-python],
+    AS_HELP_STRING([--enable-bindings-python=yes/no],
+        [Install Python Bindings [default=no]]),
+    [ZPROJECT_BINDINGS_PYTHON=$enableval],
+    [ZPROJECT_BINDINGS_PYTHON=no])
+
+if test "x$ZPROJECT_BINDINGS_PYTHON" == "xyes"; then
+    AM_CONDITIONAL(ENABLE_BINDINGS_PYTHON, true)
+    AC_MSG_RESULT([yes])
+else
+    AM_CONDITIONAL(ENABLE_BINDINGS_PYTHON, false)
+    AC_MSG_RESULT([no])
+fi
+
 # See if clang-format is in PATH; the result unblocks the relevant recipes
 WITH_CLANG_FORMAT=""
 AS_IF([test x"$CLANG_FORMAT" = x],
@@ -433,6 +450,7 @@ echo Build docs.................... : $zproject_build_doc
 echo Build host.................... : $BUILD_HOST
 echo Build user.................... : $USER
 echo Draft API..................... : $enable_drafts
+echo Python Bindings............... : $ZPROJECT_BINDINGS_PYTHON
 echo Install dir................... : $prefix
 echo Install man pages............. : $zproject_install_man
 
@@ -452,6 +470,7 @@ echo Configure complete! Now proceed with:
 echo "    - 'make'               compile the project"
 echo "    - 'make check'         run the project's selftest"
 echo "    - 'make install'       install the project to $prefix"
+echo "    - 'make bindings       install enabled language bindings (Python, etc)"
 echo
 echo Further options are:
 echo "    - 'make callcheck'     run the project's selftest with valgrind to"

--- a/packaging/debian/zproject.install
+++ b/packaging/debian/zproject.install
@@ -39,3 +39,4 @@ usr/bin/zproject_vs20xx_props.gsl
 usr/bin/zproject_known_projects.xml
 usr/bin/mkapi.py
 usr/bin/fake_cpp
+

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -191,6 +191,16 @@ coverage: src/zproject_selftest
 	@exit 1
 endif
 
+bindings: python-bindings
+
+python-bindings:
+if ENABLE_BINDINGS_PYTHON
+	-( cd bindings/python && python setup.py install )
+else
+	@echo "Python Bindings not enabled or missing setup.py... skipping"
+
+endif
+
 # A series of tests that the codebase and recipes are pretty, easy
 # to maintain and with predictable behavior. These generally are not
 # expected to directly expose functional issues in the code, but

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -552,6 +552,23 @@ else
     AC_MSG_RESULT([no])
 fi
 
+# Install Python Bindings
+AC_MSG_CHECKING([whether to install Python bindings])
+
+AC_ARG_ENABLE([bindings-python],
+    AS_HELP_STRING([--enable-bindings-python=yes/no],
+        [Install Python Bindings [default=no]]),
+    [ZPROJECT_BINDINGS_PYTHON=$enableval],
+    [ZPROJECT_BINDINGS_PYTHON=no])
+
+if test "x$ZPROJECT_BINDINGS_PYTHON" == "xyes"; then
+    AM_CONDITIONAL(ENABLE_BINDINGS_PYTHON, true)
+    AC_MSG_RESULT([yes])
+else
+    AM_CONDITIONAL(ENABLE_BINDINGS_PYTHON, false)
+    AC_MSG_RESULT([no])
+fi
+
 # See if clang-format is in PATH; the result unblocks the relevant recipes
 WITH_CLANG_FORMAT=""
 AS_IF([test x"$CLANG_FORMAT" = x],
@@ -1344,6 +1361,7 @@ echo Build docs.................... : $$(project.name:c)_build_doc
 echo Build host.................... : $BUILD_HOST
 echo Build user.................... : $USER
 echo Draft API..................... : $enable_drafts
+echo Python Bindings............... : $ZPROJECT_BINDINGS_PYTHON
 echo Install dir................... : $prefix
 echo Install man pages............. : $$(project.name:c)_install_man
 
@@ -1363,6 +1381,7 @@ echo Configure complete! Now proceed with:
 echo "    - 'make'               compile the project"
 echo "    - 'make check'         run the project's selftest"
 echo "    - 'make install'       install the project to $prefix"
+echo "    - 'make bindings       install enabled language bindings (Python, etc)"
 echo
 echo Further options are:
 echo "    - 'make callcheck'     run the project's selftest with valgrind to"
@@ -1998,6 +2017,16 @@ else
 coverage: src/$(project.prefix)_selftest
 \t@echo "call make clean && configure --with-gcov to enable code coverage"
 \t@exit 1
+endif
+
+bindings: python-bindings
+
+python-bindings:
+if ENABLE_BINDINGS_PYTHON
+\t-( cd bindings/python && python setup.py install )
+else
+\t@echo "Python Bindings not enabled or missing setup.py... skipping"
+
 endif
 
 # A series of tests that the codebase and recipes are pretty, easy


### PR DESCRIPTION
a redo of #1120 

solution: modify zproject_autotools.gsl to provide basic configure flags for python bindings and drop an "make bindings" option in src/Makemodule.am when a project is created.


(some day i will learn to rebase properly... old bad habits die hard)