### PR TITLE
Zconfig.remove is not correctly generated.

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -807,7 +807,6 @@ implements AutoCloseable\
     $(my.prefix) $(->return.jni_java_type:) $(jni_name:) ($(jni_method_signature:)) {
 .       if defined (method.return_self_p)
         self = __$(name:camel) ($(jni_shim_invocation_java:));
-        return 0;
 .       elsif ->return.type = "nothing"
         __$(name:camel) ($(jni_shim_invocation_java:));
 .       elsif ->return.jni_is_class = 1
@@ -846,7 +845,11 @@ $(jni_shim_signature_c:))
 .   endif
 .   if ->return.type = "nothing"
     $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
-.       my.return = ""
+.       if defined (my.method.return_self_p) & !my.method.is_destructor
+.           my.return = "    return self;\n"
+.       else
+.           my.return = ""
+.   endif
 .#
 .   elsif ->return.type = "buffer"
 .       if regexp.match ("^\\.(.*)", ->return.size, my.size)

--- a/zproject_java_lib.gsl
+++ b/zproject_java_lib.gsl
@@ -214,6 +214,8 @@ function resolve_method (method)
             if type = "buffer" & !defined (return.size)
                 my.method.okay = 0
                 #echo "Skipping $(class.name).$(my.method.name) - can't return unsized fresh buffer"
+            elsif defined(my.method.return_self_p)
+                jni_java_type = "void"
             endif
         endif
     endfor


### PR DESCRIPTION
JAVA: Zconfig.remove is not correctly generated.
JNI: Corresponding jni native function return and hazardous value.
JAVA: If a function always return 0 it should return void.

Solution:
Fix java binding generator.