### PR TITLE
Problem: NativeLoader fails on android 6

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -766,11 +766,14 @@ implements AutoCloseable\
 .   endif
 {
     static {
-        try {
-            NativeLoader.loadLibrary("$(project.prefix:c)jni");
-        }
-        catch (Exception e) {
-            System.exit (-1);
+        if (System.getProperty("java.vm.vendor").contains("Android")) {
+            System.loadLibrary("$(project.prefix:c)jni");
+        } else {
+            try {
+                NativeLoader.loadLibrary("$(project.prefix:c)jni");
+            } catch (Exception e) {
+                System.exit (-1);
+            }
         }
     }
     public long self;


### PR DESCRIPTION
Solution: Android already ship with its own lib extractor so there's no need to use NativeLoader.