### PR TITLE
Problem: CZMQ is linking with OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Model is described in `zproject_known_projects.xml` file:
     <use project = "libcurl"
         prefix = "curl"
         repository = "https://github.com/curl/curl.git"
-        debian_name = "libcurl4-openssl-dev"
+        debian_name = "libcurl4-nss-dev"
         test = "curl_easy_init"
         header = "curl/curl.h" />
 

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -94,7 +94,7 @@
     <use project = "libcurl"
         prefix = "curl"
         repository = "https://github.com/curl/curl.git"
-        debian_name = "libcurl4-openssl-dev"
+        debian_name = "libcurl4-nss-dev"
         test = "curl_easy_init"
         header = "curl/curl.h" />
 


### PR DESCRIPTION
Solution: change libcurl dependency to the nss implementation. This
links to nss for TLS support, which is licensed under the MPL and so it
is compatible.
OpenSSL is not compatible with the GPL, which could cause issues for
GPL-licensed programs that want to use CZMQ with libcurl.

@somdoron FYI https://curl.haxx.se/legal/licmix.html