### PR TITLE
Problem: cmake override autotools platform.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ if (NOT HAVE_NET_IF_H)
     CHECK_INCLUDE_FILE("net/if.h" HAVE_NET_IF_H)
 endif()
 
-file(WRITE "${SOURCE_DIR}/src/platform.h.in" "
+file(REMOVE "${SOURCE_DIR}/src/platform.h")
+
+file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -55,7 +57,7 @@ file(WRITE "${SOURCE_DIR}/src/platform.h.in" "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file("${SOURCE_DIR}/src/platform.h.in" "${SOURCE_DIR}/src/platform.h")
+configure_file("${CMAKE_BINARY_DIR}/platform.h.in" "${CMAKE_BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
@@ -184,7 +186,7 @@ set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
                     ${CMAKE_BINARY_DIR}/DartConfiguration.tcl
                     ${CMAKE_BINARY_DIR}/Testing
                     ${CMAKE_BINARY_DIR}/compile_commands.json
-                    ${CMAKE_BINARY_DIR}/src/platform.h
+                    ${CMAKE_BINARY_DIR}/platform.h
                     ${CMAKE_BINARY_DIR}/src/libzproject.pc
                     ${CMAKE_BINARY_DIR}/src/libzproject.so
                     ${CMAKE_BINARY_DIR}/src/zproject_selftest

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -93,7 +93,9 @@ if (NOT HAVE_NET_IF_H)
     CHECK_INCLUDE_FILE("net/if.h" HAVE_NET_IF_H)
 endif()
 
-file(WRITE "${SOURCE_DIR}/src/platform.h.in" "
+file(REMOVE "${SOURCE_DIR}/src/platform.h")
+
+file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -101,7 +103,7 @@ file(WRITE "${SOURCE_DIR}/src/platform.h.in" "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file("${SOURCE_DIR}/src/platform.h.in" "${SOURCE_DIR}/src/platform.h")
+configure_file("${CMAKE_BINARY_DIR}/platform.h.in" "${CMAKE_BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
@@ -251,7 +253,7 @@ install(FILES ${$(project.prefix)_headers} DESTINATION include)
 ########################################################################
 
 
-include_directories("${SOURCE_DIR}/src" "${SOURCE_DIR}/include")
+include_directories("${SOURCE_DIR}/src" "${SOURCE_DIR}/include" "${CMAKE_BINARY_DIR}")
 set ($(project.linkname)_sources
 .for class where !draft
 .   if project.use_cxx
@@ -570,7 +572,7 @@ set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
                     ${CMAKE_BINARY_DIR}/DartConfiguration.tcl
                     ${CMAKE_BINARY_DIR}/Testing
                     ${CMAKE_BINARY_DIR}/compile_commands.json
-                    ${CMAKE_BINARY_DIR}/src/platform.h
+                    ${CMAKE_BINARY_DIR}/platform.h
                     ${CMAKE_BINARY_DIR}/src/$(project.libname).pc
                     ${CMAKE_BINARY_DIR}/src/$(project.libname).so
                     ${CMAKE_BINARY_DIR}/src/$(project.name)_selftest


### PR DESCRIPTION
Solution: Use a different path for each tool

Still an issue though, the `src/platform.h` is only get deleted when generating cmake but after that, if I run autotools and only recompile cmake build the file doesn't get deleted.

Any suggestions?