### PR TITLE
Problem: tarball is not supported at known project level

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,9 +688,7 @@ Model is described in `zproject_known_projects.xml` file:
 
     <use project = "libmicrohttpd"
          prefix = "microhttpd"
-         repository = ""
-         tarball = "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.61.tar.gz"
-         debian_name = " libmicrohttpd-dev"
+         repository = "https://gnunet.org/git/libmicrohttpd.git"
          test = "MHD_start_daemon" />
 
     <use project = "editline"

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -100,9 +100,7 @@
 
     <use project = "libmicrohttpd"
          prefix = "microhttpd"
-         repository = ""
-         tarball = "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.61.tar.gz"
-         debian_name = " libmicrohttpd-dev"
+         repository = "https://gnunet.org/git/libmicrohttpd.git"
          test = "MHD_start_daemon" />
 
     <use project = "editline"


### PR DESCRIPTION
It is actually only supported at the project level.

Solution: make libmicrohttpd use a repository instead of a tarball