### PR TITLE
Travis options for checking zproject and ABI compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ zproject's `project.xml` contains an extensive description of the available conf
             <option name="clangformat_allow_failures" value="0" /> "1" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: 1)
             <option name="clangformat_require_good" value="0" /> "1" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "0" hides the failure, and devs must look in test logs) (default: same as allow_failures)
             <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
+            <option name="check_abi_compliance" value="0" /> "1" will compare the currently tested commit's ABI to the one in a "latest_release" branch or tag, using packaged prerequisites. Due to these limitations, the option is off by default.
+            <option name="check_zproject" value="0" /> "1" will regenerate the zproject of the tested commit, and will verify that nothing changed, "2" will enable it as a special testcase allowed to fail. Many projects do customize their originally generated codebase, so to avoid surprises this option is off by default.
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010
         vs2012              Microsoft Visual Studio 2012

--- a/project.xml
+++ b/project.xml
@@ -27,6 +27,7 @@
             <option name="clangformat_allow_failures" value="0" /> "1" will generate the option allowing non-fatal failure of clang-format test in Travis CI (default: 1)
             <option name="clangformat_require_good" value="0" /> "1" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "0" hides the failure, and devs must look in test logs) (default: same as allow_failures)
             <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
+            <option name="check_abi_compliance" value="0" /> "1" will compare the currently tested commit's ABI to the one in a "latest_release" branch or tag, using packaged prerequisites. Due to these limitations, the option is off by default.
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010
         vs2012              Microsoft Visual Studio 2012

--- a/project.xml
+++ b/project.xml
@@ -28,6 +28,7 @@
             <option name="clangformat_require_good" value="0" /> "1" will generate the option allowing to report and not ignore failure of clang-format test in Travis CI (otherwise "0" hides the failure, and devs must look in test logs) (default: same as allow_failures)
             <option name="clangformat_implem" value="cmake|autotools" /> will pick one of two implems of the clang-format test in Travis CI (cmake is default and faster if available, since autotools needs to configure first)
             <option name="check_abi_compliance" value="0" /> "1" will compare the currently tested commit's ABI to the one in a "latest_release" branch or tag, using packaged prerequisites. Due to these limitations, the option is off by default.
+            <option name="check_zproject" value="0" /> "1" will regenerate the zproject of the tested commit, and will verify that nothing changed, "2" will enable it as a special testcase allowed to fail. Many projects do customize their originally generated codebase, so to avoid surprises this option is off by default.
         vs2008              Microsoft Visual Studio 2008
         vs2010              Microsoft Visual Studio 2010
         vs2012              Microsoft Visual Studio 2012

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -151,6 +151,15 @@ pkg_deps_prereqs: &pkg_deps_prereqs
     - *pkg_deps_prereqs_source
     - *pkg_deps_prereqs_distro
 
+.if defined(project.travis_check_zproject) & !(project.travis_check_zproject ?= 0)
+# NOTE: Currently the shell script does support use of packages or checkout
+# of latest github code for these tools - but only from zeromq org repos,
+# no forks/branches.
+pkg_deps_zproject: &pkg_deps_zproject
+    - generator-scripting-language
+    - zproject
+
+.endif
 pkg_deps_doctools: &pkg_deps_doctools
     - asciidoc
     - xmlto
@@ -203,6 +212,17 @@ matrix:
         sources: *pkg_src_zeromq_ubuntu16
         packages:
         - *pkg_deps_common
+.if defined(project.travis_check_zproject) & !(project.travis_check_zproject ?= 0)
+  - env: BUILD_TYPE=check_zproject
+    os: linux
+    dist: xenial
+    addons:
+      apt:
+        sources: *pkg_src_zeromq_ubuntu16
+        packages:
+        - *pkg_deps_devtools
+        - *pkg_deps_zproject
+.endif
 .if project.travis_clangformat_implem ?= "autotools" | ( !defined(project.travis_clangformat_implem) & project.travis_use_cmake ?= 0 )
 .   echo "TRAVIS: CLANG-FORMAT: implementation: autotools"
 ### Note: we don't use CMake
@@ -237,6 +257,10 @@ matrix:
 .   if project.travis_distcheck ?= 2
 .   echo "TRAVIS: DISTCHECK: allow-fail: true"
   - env: BUILD_TYPE=default CI_TEST_DISTCHECK=true
+.   endif
+.   if project.travis_check_zproject ?= 2
+.   echo "TRAVIS: CHECK_ZPROJECT: allow-fail: true"
+  - env: BUILD_TYPE=check_zproject
 .   endif
 .   if project.travis_clangformat_allow_failures ?= 1
 .   echo "TRAVIS: CLANG-FORMAT: allow-fail: true"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -250,7 +250,12 @@ matrix:
   - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
 .   endif
 .endif
-.if project.exports_classes
+.if project.travis_check_abi_compliance ?= 1
+.   if project.exports_classes
+# Note: the ABI compliance checker script currently assumes that:
+# 1) Your project sources have a "latest_release" branch or tag
+#    to check out and compare the current commit's ABI to;
+# 2) Prerequisites are available as packages - no custom rebuilds.
   - env: BUILD_TYPE=abi-compliance-checker
     os: linux
     dist: xenial
@@ -260,9 +265,11 @@ matrix:
         - sourceline: 'deb http://ppa.launchpad.net/hnakamur/universal-ctags/ubuntu bionic main'
           key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x60D954A11017341E'
         packages:
+        - *pkg_deps_common
         - universal-ctags
         - abi-dumper
         - abi-compliance-checker
+.   endif
 .endif
 
 before_install:
@@ -742,11 +749,17 @@ fi
 .chmod_x ("builds/check_zproto/ci_build.sh")
 .endif
 .
-.if project.exports_classes
-.directory.create ("builds/abi-compliance-checker")
-.output "builds/abi-compliance-checker/ci_build.sh"
+.if project.travis_check_abi_compliance ?= 1
+.   if project.exports_classes
+.       directory.create ("builds/abi-compliance-checker")
+.       output "builds/abi-compliance-checker/ci_build.sh"
 #!/usr/bin/env bash
 set -x
+
+# Note: the ABI compliance checker script currently assumes that:
+# 1) Your project sources have a "latest_release" branch or tag
+#    to check out and compare the current commit's ABI to;
+# 2) Prerequisites are available as packages - no custom rebuilds.
 
 cd ../../
 
@@ -784,8 +797,9 @@ make VERBOSe=1 -j5
 abi-dumper -public-headers include src/.libs/$(project.libname).so -o ${BUILD_PREFIX}/$(project.libname).latest.dump -lver ${LATEST_VERSION}
 
 abi-compliance-checker -l $(project.libname) -d1 ${BUILD_PREFIX}/$(project.libname).latest.dump -d2 ${BUILD_PREFIX}/$(project.libname).head.dump -list-affected || print_abi_api_breakages
-.close
-.chmod_x ("builds/abi-compliance-checker/ci_build.sh")
+.       close
+.       chmod_x ("builds/abi-compliance-checker/ci_build.sh")
+.   endif
 .endif
 .
 .output "ci_deploy.sh"


### PR DESCRIPTION
The former was missing (only the script was generated) and the latter was imposed regardless of project readiness.