### PR TITLE
Problem: python target fails when bindings/python directory does not …

### DIFF
--- a/zproject_python.gsl
+++ b/zproject_python.gsl
@@ -242,6 +242,7 @@ function method_definition (method)
 endfunction
 
 function generate_setup_py
+    directory.create ("bindings/python")
     output "bindings/python/setup.py"
     >$(project.GENERATED_WARNING_HEADER:)
     >from setuptools import setup


### PR DESCRIPTION
…exist

Solution: create the bindings/python directory

See https://github.com/zeromq/zproject/issues/1164