### PR TITLE
Problem: docker target doesn't use project repository.

### DIFF
--- a/zproject.gsl
+++ b/zproject.gsl
@@ -102,6 +102,7 @@ project.linkname ?= project.prefix
 project.libname ?= "lib" + project.linkname
 project.prelude ?= project.prefix + "_prelude.h"
 project.description ?= "Project"
+project.repository ?= "https://github.com/zeromq/$(project.name:c)"
 project.header ?= "$(project.name:$(project.filename_prettyprint)).$(project.header_ext)"
 
 if count (project.version) = 0

--- a/zproject_docker.gsl
+++ b/zproject_docker.gsl
@@ -50,7 +50,7 @@ RUN sudo ldconfig
 
 .endfor
 WORKDIR /home/zmq
-RUN git clone --quiet git://github.com/zeromq/$(project.name:c).git $(project.name:c)
+RUN git clone --quiet $(project.repository) $(project.name:c)
 WORKDIR /home/zmq/$(project.name:c)
 RUN ./autogen.sh 2> /dev/null
 RUN ./configure --quiet --without-docs


### PR DESCRIPTION
When generating a Dockerfile, the docker target assumes the project code is in the repository
`git://github.com/zeromq/$(project.name:c).git`
It should rather use the repository defined in the `<project>` tag in project.xml.

In order to generate a sane Dockerfile when the repository is not set in the project tag, we set it to
`https://github.com/zeromq/$(project.name:c)`, i.e. using HTTPS instead of SSH protocol.
