### PR TITLE
Problem: Findlibzmq.cmake doesn't work on Win32

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -661,11 +661,79 @@ find_path (
     HINTS ${PC_$(USE.PROJECT)_INCLUDE_HINTS}
 )
 
+.       if use.libname = "libzmq"
+if (MSVC)
+    # libzmq dll/lib built with MSVC is named using the Boost convention.
+    # https://github.com/zeromq/czmq/issues/577
+    # https://github.com/zeromq/czmq/issues/1972
+    if (MSVC_IDE)
+        set(MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
+    else ()
+        set(MSVC_TOOLSET "")
+    endif ()
+
+    # Retrieve ZeroMQ version number from zmq.h
+    file(STRINGS "${LIBZMQ_INCLUDE_DIRS}/zmq.h" zmq_version_defines
+        REGEX "#define ZMQ_VERSION_(MAJOR|MINOR|PATCH)")
+    foreach(ver ${zmq_version_defines})
+        if(ver MATCHES "#define ZMQ_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+            set(ZMQ_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
+        endif()
+    endforeach()
+
+    set(_zmq_version ${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH})
+
+    set(_zmq_debug_names)
+    set(_zmq_release_names)
+
+    set(_zmq_debug_names
+        "libzmq${MSVC_TOOLSET}-mt-gd-${_zmq_version}" # Debug, BUILD_SHARED
+        "libzmq${MSVC_TOOLSET}-mt-sgd-${_zmq_version}" # Debug, BUILD_STATIC
+        "libzmq-mt-gd-${_zmq_version}" # Debug, BUILD_SHARED
+        "libzmq-mt-sgd-${_zmq_version}" # Debug, BUILD_STATIC
+    )
+
+    set(_zmq_release_names
+        "libzmq${MSVC_TOOLSET}-mt-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_SHARED
+        "libzmq${MSVC_TOOLSET}-mt-s-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_STATIC
+        "libzmq-mt-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_SHARED
+        "libzmq-mt-s-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_STATIC
+    )
+
+    find_library (ZeroMQ_LIBRARY_DEBUG
+        NAMES ${_zmq_debug_names}
+    )
+
+    find_library (ZeroMQ_LIBRARY_RELEASE
+        NAMES ${_zmq_release_names}
+    )
+
+    if (ZeroMQ_LIBRARY_RELEASE AND ZeroMQ_LIBRARY_DEBUG)
+        set(LIBZMQ_LIBRARIES
+            debug ${ZeroMQ_LIBRARY_DEBUG}
+            optimized ${ZeroMQ_LIBRARY_RELEASE}
+        )
+    elseif (ZeroMQ_LIBRARY_RELEASE)
+        set(LIBZMQ_LIBRARIES ${ZeroMQ_LIBRARY_RELEASE})
+    elseif (ZeroMQ_LIBRARY_DEBUG)
+        set(LIBZMQ_LIBRARIES ${ZeroMQ_LIBRARY_DEBUG})
+    endif ()
+endif ()
+
+if (NOT LIBZMQ_LIBRARIES)
+    find_library (
+        LIBZMQ_LIBRARIES
+        NAMES zmq libzmq
+        HINTS ${PC_LIBZMQ_LIBRARY_HINTS}
+    )
+endif ()
+.       else
 find_library (
     $(USE.PROJECT)_LIBRARIES
     NAMES $(use.linkname)
     HINTS ${PC_$(USE.PROJECT)_LIBRARY_HINTS}
 )
+.       endif
 
 include(FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
Findlibzmq.cmake doesn't work out-of-box on Win32.
libzmq dll/lib built with MSVC is named using the Boost convention(something like libzmq-mt-4_3_1.lib, libzmq-mt-4_3_1.dll): https://github.com/zeromq/libzmq/blob/master/CMakeLists.txt#L1147-L1173
So find_library (LIBZMQ_LIBRARIES NAMES zmq HINTS ${PC_LIBZMQ_LIBRARY_HINTS}) will not work.

This patch tries to solve the `libzmq not found` error on Win32 with CMake:
https://github.com/zeromq/czmq/issues/1972#issuecomment-484842328
https://github.com/zeromq/czmq/issues/2004

