### PR TITLE
Problem: code tested in different distros, confusing results

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -33,8 +33,12 @@ cache:
 os:
 - linux
 
-#dist:
-#- xenial
+# The default distro for env:/matrix: tests and unspecified matrix: tests;
+# for the latter see also addons/apt/sources with the package repos in use.
+# See https://docs.travis-ci.com/user/reference/overview/ for up-to-date
+# allowed values of "dist" supported by the Travis CI service.
+dist:
+- xenial
 
 #services:
 #- docker


### PR DESCRIPTION
* zproject_travis.gsl : default distro should match the one specified in matrix tests to minimize the surprises

End-users of zproject are still free to define a specific distro, or comment away and use Travis CI default. But we found it confusing to have half the tests fail due to new compiler warnings, and the other half pass because they are on another compiler by default :)