### PR TITLE
Problem : default travis dist is hardcoded (xenial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="dist" value="trusty" /> Select a Linux distribution to use by default on Travis CI, also impacts the OBS-served repository of ZMQ-family packages to use (if not building from source all the time per use_pkg_deps_prereqs_source below). By default the choice is made by Travis CI platform.
+            <option name="dist" value="trusty" /> Select a Linux distribution to use by default on Travis CI, also impacts the OBS-served repository of ZMQ-family packages to use (if not building from source all the time per use_pkg_deps_prereqs_source below). By default it would be "xenial" as of now.
             <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI, "2" will enable it as a special testcase allowed to fail (default: 1 to enable and require to pass)
             <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
             <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ zproject's `project.xml` contains an extensive description of the available conf
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
+            <option name="dist" value="trusty" /> Select a Linux distribution to use by default on Travis CI, also impacts the OBS-served repository of ZMQ-family packages to use (if not building from source all the time per use_pkg_deps_prereqs_source below). By default the choice is made by Travis CI platform.
             <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI, "2" will enable it as a special testcase allowed to fail (default: 1 to enable and require to pass)
             <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
             <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)

--- a/project.xml
+++ b/project.xml
@@ -20,6 +20,7 @@
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
+            <option name="dist" value="trusty" /> Select a Linux distribution to use by default on Travis CI, also impacts the OBS-served repository of ZMQ-family packages to use (if not building from source all the time per use_pkg_deps_prereqs_source below). By default the choice is made by Travis CI platform.
             <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI, "2" will enable it as a special testcase allowed to fail (default: 1 to enable and require to pass)
             <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
             <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)

--- a/project.xml
+++ b/project.xml
@@ -20,7 +20,7 @@
         redhat              Packaging for RedHat
         ruby                Ruby binding
         travis              Travis CI scripts
-            <option name="dist" value="trusty" /> Select a Linux distribution to use by default on Travis CI, also impacts the OBS-served repository of ZMQ-family packages to use (if not building from source all the time per use_pkg_deps_prereqs_source below). By default the choice is made by Travis CI platform.
+            <option name="dist" value="trusty" /> Select a Linux distribution to use by default on Travis CI, also impacts the OBS-served repository of ZMQ-family packages to use (if not building from source all the time per use_pkg_deps_prereqs_source below). By default it would be "xenial" as of now.
             <option name="distcheck" value="0" /> "0" will disable run of make distcheck in Travis CI, "2" will enable it as a special testcase allowed to fail (default: 1 to enable and require to pass)
             <option name="use_pkg_deps_prereqs_source" value="0" /> "0" will disable use of use_pkg_deps_prereqs_source list in Travis CI and so cause rebuild of everything from scratch (default: 1, recently packaged prereqs must exist then)
             <option name="use_cmake" value="0" /> "0" will disable use of CMake recipes in Travis CI (default: 1)

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -33,12 +33,43 @@ cache:
 os:
 - linux
 
-# The default distro for env:/matrix: tests and unspecified matrix: tests;
+# The default distro for env:/matrix:/* and unspecified-dist matrix:/* tests;
 # for the latter see also addons/apt/sources with the package repos in use.
 # See https://docs.travis-ci.com/user/reference/overview/ for up-to-date
 # allowed values of "dist" supported by the Travis CI service.
+.# Note: by default zproject before 2019-05-22 enforced xenial
+.# in specific build items in the matrix: below, and nothing here
+.if defined(project.travis_dist)
+.   if project.travis_dist ?= ""
+#dist:
+#- xenial
+.   else
+dist:
+- $(project.travis_dist)
+.   endif
+.else
 dist:
 - xenial
+.endif
+.#
+.if !defined(project.travis_dist) | (project.travis_dist ?= "")
+.   if project.travis_use_pkg_deps_prereqs_source ?= 1
+.# Even if our zproject user did not want a distro specified,
+.# we need something specific installed in the build env
+.       project.travis_dist = "xenial"
+.   else
+.# Have it defined() at least
+.       project.travis_dist = ""
+.   endif
+.endif
+.#
+.# TODO: Add the older "precise"/"ubuntu12" back for completness?
+.pkg_src_zeromq_dist = ""
+.if (project.travis_dist ?= "trusty")
+.    pkg_src_zeromq_dist = "pkg_src_zeromq_ubuntu14"
+.elsif (project.travis_dist ?= "xenial")
+.    pkg_src_zeromq_dist = "pkg_src_zeromq_ubuntu16"
+.endif
 
 #services:
 #- docker
@@ -171,20 +202,25 @@ pkg_deps_doctools: &pkg_deps_doctools
 pkg_deps_devtools: &pkg_deps_devtools
     - git
 
+# dist==trusty means ubuntu14
 pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
 - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
 
+# dist==xenial means ubuntu16
 pkg_src_zeromq_ubuntu16: &pkg_src_zeromq_ubuntu16
 - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/ ./'
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/Release.key'
 
-# Note: refer to ubuntu16 if you use dist==xenial
 # Also note that as of early 2017, either dist==trusty or services==docker
-# is needed for C++11 support; docker envs are usually faster to start up
+# is needed for some C++11 support; docker envs are usually faster to start up
+# A newer dist==xenial completes the C++11 support with gcc-5+
 addons:
   apt:
-    sources: *pkg_src_zeromq_ubuntu16
+.if (pkg_src_zeromq_dist ?<> "")
+    sources:
+    - *$(pkg_src_zeromq_dist)
+.endif
     packages: &pkg_deps_common
     - *pkg_deps_devtools
     - *pkg_deps_prereqs
@@ -193,36 +229,57 @@ matrix:
   include:
   - env: BUILD_TYPE=default-with-docs
     os: linux
+.if (project.travis_dist ?<> "")
+    dist: $(project.travis_dist)
+.endif
     addons:
       apt:
-        sources: *pkg_src_zeromq_ubuntu16
+.if (pkg_src_zeromq_dist ?<> "")
+        sources:
+        - *$(pkg_src_zeromq_dist)
+.endif
         packages:
         - *pkg_deps_common
         - *pkg_deps_doctools
   - env: BUILD_TYPE=valgrind
     os: linux
-    dist: xenial
+.if (project.travis_dist ?<> "")
+    dist: $(project.travis_dist)
+.endif
     addons:
       apt:
-        sources: *pkg_src_zeromq_ubuntu16
+.if (pkg_src_zeromq_dist ?<> "")
+        sources:
+        - *$(pkg_src_zeromq_dist)
+.endif
         packages:
         - valgrind
         - *pkg_deps_common
   - env: BUILD_TYPE=default ADDRESS_SANITIZER=enabled
     os: linux
-    dist: xenial
+.if (project.travis_dist ?<> "")
+    dist: $(project.travis_dist)
+.endif
     addons:
       apt:
-        sources: *pkg_src_zeromq_ubuntu16
+.if (pkg_src_zeromq_dist ?<> "")
+        sources:
+        - *$(pkg_src_zeromq_dist)
+.endif
         packages:
         - *pkg_deps_common
 .if defined(project.travis_check_zproject) & !(project.travis_check_zproject ?= 0)
   - env: BUILD_TYPE=check_zproject
     os: linux
-    dist: xenial
+.   if (project.travis_dist ?<> "")
+    dist: $(project.travis_dist)
+.   endif
     addons:
       apt:
-        sources: *pkg_src_zeromq_ubuntu16
+.   if (pkg_src_zeromq_dist ?<> "")
+        sources:
+        - *$(pkg_src_zeromq_dist)
+.   endif
         packages:
         - *pkg_deps_devtools
         - *pkg_deps_zproject


### PR DESCRIPTION
For some projects it is a problem, since the new distro brings a newer compiler and its warning become fatal for CI (see also #1176) ;)

This PR adds an ability for `project.xml` author to specify which distro should be used, and this impacts which package source for OBS-built zeromq stack would be used (unless the project wants to build everything from sources... as our forked one does...)

If nothing was specified, it should still specify "xenial" and corresponding "ubuntu16" repos.