### PR TITLE
Ensure at least GCC-4.9 if a project needs real C++11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,12 +803,13 @@ Model is described in `zproject_known_projects.xml` file:
 
 ### Optional : Class filename configuration
 
-Exemple:
+Example:
 ```classfilename
-<classfilename use-cxx = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
+<classfilename use-cxx = "true" use-cxx-gcc-4-9 = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
 ```
 
 * use-cxx will force usage (or not) of c++.
+* use-cxx-gcc-4-9 will enable "use-cxx" AND enforce the use of gcc-4.9 on Travis CI for nearly complete C++11 language support that is lacking in default gcc-4.8 there.
 * keep-tree will keep the include tree structure on the install (as opposed to flat delivery of include files basenames into the single-level target directory), must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
 * pkgincludedir option chooses whether headers of this project should be dumped into the common system includedir (legacy default), or into an includedir/projname subdirectory?. Currently only supported with autotool.
 * pretty-print define the type of class name format change in order to generate the filename. It uses the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/zeromq/gsl#expressions for more information).
@@ -819,7 +820,8 @@ Default value :
 * pretty-print : substitute_non_alpha_to_make_c_identifier (c option)
 * header-extension : h
 * source-extension : c (unless a cc file is present, then cc)
-* use-cxx : true if a cc file is present false otherwhise
+* use-cxx : true if a cc file is present, false otherwhise
+* use-cxx-gcc-4-9 : false by default, older GCC versions still suffice for many C++11 features
 
 ### Targets
 

--- a/README.txt
+++ b/README.txt
@@ -144,10 +144,11 @@ Model is described in `zproject_known_projects.xml` file:
 
 Example:
 ```classfilename
-<classfilename use-cxx = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
+<classfilename use-cxx = "true" use-cxx-gcc-4-9 = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
 ```
 
 * use-cxx will force usage (or not) of c++.
+* use-cxx-gcc-4-9 will enable "use-cxx" AND enforce the use of gcc-4.9 on Travis CI for nearly complete C++11 language support that is lacking in default gcc-4.8 there.
 * keep-tree will keep the include tree structure on the install (as opposed to flat delivery of include files basenames into the single-level target directory), must be used with a conservative name format (ex: pretty-print = "no"). Currently only supported with autotool.
 * pkgincludedir option chooses whether headers of this project should be dumped into the common system includedir (legacy default), or into an includedir/projname subdirectory?. Currently only supported with autotool.
 * pretty-print define the type of class name format change in order to generate the filename. It uses the pretty-print option of gsl (see Substituting Symbols and Expressions on https://github.com/zeromq/gsl#expressions for more information).
@@ -159,6 +160,7 @@ Default value :
 * header-extension : h
 * source-extension : c (unless a cc file is present, then cc)
 * use-cxx : true if a cc file is present, false otherwhise
+* use-cxx-gcc-4-9 : false by default, older GCC versions still suffice for many C++11 features
 
 ### Targets
 

--- a/README.txt
+++ b/README.txt
@@ -142,7 +142,7 @@ Model is described in `zproject_known_projects.xml` file:
 
 ### Optional : Class filename configuration
 
-Exemple:
+Example:
 ```classfilename
 <classfilename use-cxx = "true" pkgincludedir = "false" keep-tree = "true" pretty-print = "no" source-extension = "cpp" header-extension = "hpp" />
 ```
@@ -158,7 +158,7 @@ Default value :
 * pretty-print : substitute_non_alpha_to_make_c_identifier (c option)
 * header-extension : h
 * source-extension : c (unless a cc file is present, then cc)
-* use-cxx : true if a cc file is present false otherwhise
+* use-cxx : true if a cc file is present, false otherwhise
 
 ### Targets
 

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -68,6 +68,19 @@ function resolve_classfilename_option()
             endif
         endif
 
+        # Some but not all C++ projects require the fuller scope of C++11
+        # and do not compile under gcc-4.8 which is Travis default in "trusty".
+        # This optional toggle allows to require a newer gcc-4.9 for them.
+        # Note that with current implementation, it effectively hardcodes
+        # the use of specifically 4.9, not allowing for "4.9 or newer".
+        if defined (classfilename.use\-cxx\-gcc\-4\-9)
+            if classfilename.use\-cxx\-gcc\-4\-9 ?= "true"
+                use_cxx_gcc_4_9 = 1
+                use_cxx = 1
+            elsif classfilename.use\-cxx\-gcc\-4\-9 ?= "false"
+                use_cxx_gcc_4_9 = 0
+            endif
+        endif
 
         if defined (classfilename.keep\-tree)
             if classfilename.keep\-tree ?= "true"
@@ -93,6 +106,7 @@ project.filename_prettyprint = "c"
 project.header_ext = "h"
 project.source_ext = "c"
 project.use_cxx = project_use_cxx ()
+project.use_cxx_gcc_4_9 = 0
 project.keep_tree = 0
 project.pkgincludedir = 0
 resolve_classfilename_option()

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1220,6 +1220,47 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
         ])])
 ])
 
+.if project.use_cxx_gcc_4_9
+# One of big missing features in gcc-4.8 was std::regex support fixed in 4.9
+# Testing code from https://stackoverflow.com/a/41186162/4715872
+# caveats apply (use of unguaranteed private macros)
+AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+    [AC_MSG_CHECKING([for GNU C++11 support level expected by gcc-4.9 release or newer])
+     CXXFLAGS="$CXXFLAGS --std=c++11"
+     AC_LANG_PUSH([C++])
+     AC_TRY_RUN([/* Note: private macros in use, test can break over time */
+#include <regex>
+
+#if __cplusplus >= 201103L &&                             \\
+    (!defined(__GLIBCXX__) || (__cplusplus >= 201402L) || \\
+        (defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) || \\
+         defined(_GLIBCXX_REGEX_STATE_LIMIT)           || \\
+             (defined(_GLIBCXX_RELEASE)                && \\
+             _GLIBCXX_RELEASE > 4)))
+#define HAVE_WORKING_REGEX 1
+#else
+#define HAVE_WORKING_REGEX 0
+#endif
+
+#include <iostream>
+
+int main() {
+  const std::regex regex(".*");
+  const std::string string = "This should match!";
+  const auto result = std::regex_search(string, regex);
+#if HAVE_WORKING_REGEX
+  std::cerr << "<regex> works, look: " << std::boolalpha << result << std::endl;
+#else
+  std::cerr << "<regex> doesn't work, look: " << std::boolalpha << result << std::endl;
+#endif
+  return result ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
+     AC_LANG_POP([C++])
+    ]
+)])
+
+.endif
 .if file.exists ("acinclude.m4")
 # Optional project-local hook to (re-)define some variables that can be used
 # in your project files generated from .in templates - in your acinclude.m4,

--- a/zproject_debian.gsl
+++ b/zproject_debian.gsl
@@ -60,6 +60,9 @@ Build-Depends: debhelper (>= 9),
 .  endif
 ,
 .endfor
+.if defined(use_cxx_gcc_4_9) & !(use_cxx_gcc_4_9 ?= 0)
+    gcc (>= 4.9.0), g++ (>= 4.9.0),
+.endif
 .if systemd ?= 1
 .# necessary for systemd.pc to get unit install path
     systemd,

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -84,7 +84,15 @@ BuildRequires:  systemd
 .endif
 BuildRequires:  xmlto
 .if project.use_cxx
+.   if defined(project.use_cxx_gcc_4_9) & !(project.use_cxx_gcc_4_9 ?= 0)
+# Note that with current implementation of zproject use-cxx-gcc-4-9 option,
+# this effectively hardcodes the use of specifically 4.9, not allowing for
+# "4.9 or newer".
+BuildRequires:  devtoolset-3-gcc devtoolset-3-gcc-c++
+BuildRequires:  gcc-c++ >= 4.9.0
+.   else
 BuildRequires:  gcc-c++
+.   endif
 .endif
 .for project.use
 .if defined(use.redhat_name)

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -212,6 +212,10 @@ pkg_src_zeromq_ubuntu16: &pkg_src_zeromq_ubuntu16
 - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/ ./'
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/Release.key'
 
+pkg_deps_common: &pkg_deps_common
+- *pkg_deps_devtools
+- *pkg_deps_prereqs
+
 # Also note that as of early 2017, either dist==trusty or services==docker
 # is needed for some C++11 support; docker envs are usually faster to start up
 # A newer dist==xenial completes the C++11 support with gcc-5+
@@ -221,9 +225,8 @@ addons:
     sources:
     - *$(pkg_src_zeromq_dist)
 .endif
-    packages: &pkg_deps_common
-    - *pkg_deps_devtools
-    - *pkg_deps_prereqs
+    packages:
+    - *pkg_deps_common
 
 matrix:
   include:

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -394,22 +394,24 @@ matrix:
         - clang-3.8
 .endif
 .if defined (project.travis_shadow_gcc) & !(project.travis_shadow_gcc ?= 0)
+.   if !(defined(use_cxx_gcc_4_9)) | !(use_cxx_gcc_4_9 ?= 1)
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     os: linux
-.if (project.travis_dist ?<> "")
+.       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
-.endif
+.       endif
     addons:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-.if (pkg_src_zeromq_dist ?<> "")
+.       if (pkg_src_zeromq_dist ?<> "")
         - *$(pkg_src_zeromq_dist)
-.endif
+.       endif
         packages:
         - *pkg_deps_common
         - g++-4.9
         - gcc-4.9
+.   endif
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
     os: linux
 .if (project.travis_dist ?<> "")
@@ -500,7 +502,9 @@ matrix:
 .   endif
 .   if project.travis_shadow_gcc ?= 2
 .   echo "TRAVIS: Shadow GCC versions: allow-fail: true"
+.       if !(use_cxx_gcc_4_9 ?= 1)
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+.       endif
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -219,14 +219,28 @@ pkg_deps_common: &pkg_deps_common
 # Also note that as of early 2017, either dist==trusty or services==docker
 # is needed for some C++11 support; docker envs are usually faster to start up
 # A newer dist==xenial completes the C++11 support with gcc-5+
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9)
+# Note that with current implementation of zproject use-cxx-gcc-4-9 option,
+# this effectively hardcodes the use of specifically 4.9, not allowing for
+# "4.9 or newer".
+.endif
 addons:
   apt:
-.if (pkg_src_zeromq_dist ?<> "")
+.if (pkg_src_zeromq_dist ?<> "") | (defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0))
     sources:
+.endif
+.if (pkg_src_zeromq_dist ?<> "")
     - *$(pkg_src_zeromq_dist)
+.endif
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+    - ubuntu-toolchain-r-test
 .endif
     packages:
     - *pkg_deps_common
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+    - gcc-4.9
+    - g++-4.9
+.endif
 
 matrix:
   include:
@@ -237,13 +251,22 @@ matrix:
 .endif
     addons:
       apt:
-.if (pkg_src_zeromq_dist ?<> "")
+.if (pkg_src_zeromq_dist ?<> "") | (defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0))
         sources:
+.endif
+.if (pkg_src_zeromq_dist ?<> "")
         - *$(pkg_src_zeromq_dist)
+.endif
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+        - ubuntu-toolchain-r-test
 .endif
         packages:
         - *pkg_deps_common
         - *pkg_deps_doctools
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+        - gcc-4.9
+        - g++-4.9
+.endif
   - env: BUILD_TYPE=valgrind
     os: linux
 .if (project.travis_dist ?<> "")
@@ -251,13 +274,22 @@ matrix:
 .endif
     addons:
       apt:
-.if (pkg_src_zeromq_dist ?<> "")
+.if (pkg_src_zeromq_dist ?<> "") | (defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0))
         sources:
+.endif
+.if (pkg_src_zeromq_dist ?<> "")
         - *$(pkg_src_zeromq_dist)
+.endif
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+        - ubuntu-toolchain-r-test
 .endif
         packages:
         - valgrind
         - *pkg_deps_common
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+        - gcc-4.9
+        - g++-4.9
+.endif
   - env: BUILD_TYPE=default ADDRESS_SANITIZER=enabled
     os: linux
 .if (project.travis_dist ?<> "")
@@ -265,12 +297,21 @@ matrix:
 .endif
     addons:
       apt:
-.if (pkg_src_zeromq_dist ?<> "")
+.if (pkg_src_zeromq_dist ?<> "") | (defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0))
         sources:
+.endif
+.if (pkg_src_zeromq_dist ?<> "")
         - *$(pkg_src_zeromq_dist)
+.endif
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+        - ubuntu-toolchain-r-test
 .endif
         packages:
         - *pkg_deps_common
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+        - gcc-4.9
+        - g++-4.9
+.endif
 .if defined(project.travis_check_zproject) & !(project.travis_check_zproject ?= 0)
   - env: BUILD_TYPE=check_zproject
     os: linux
@@ -509,6 +550,9 @@ before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "android" ] ; then brew install binutils ; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew install valgrind ; fi
 - if [ -n "\${MATRIX_EVAL}" ] ; then eval \${MATRIX_EVAL} ; fi
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
+- if [ "$CXX" == "g++" ] ; then export CXX="g++-4.9" CC="gcc-4.9" ; fi
+.endif
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh


### PR DESCRIPTION
Should solve the woes of #1174

Note that not all projects require it on one hand, and not all projects survive the new "xenial" distro out of the box on another, hence the toggle.

Note: as comments say, for packaging (BuildRequires etc) and Travis this might hardcode usage of gcc-4.9 even if your current distro offers a newer one by default. Where possible, I tried to make this extensible (e.g. requiring "at least 4.9.0" in packages, and checking for practical features in `configure.ac`).