### PR TITLE
Problem: Gradle wrapper version 5.0 has a major security vulnerability

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -156,7 +156,7 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 
-wrapper.gradleVersion = '5.0'
+wrapper.gradleVersion = '5.4.1'
 
 //  ------------------------------------------------------------------
 //  Build section


### PR DESCRIPTION
Solution: Upgrade to the most recent version