### PR TITLE
Problem: earlier changes to warning flags in configure.ac lost logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -405,10 +405,12 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
         ])])])
      AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
-         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"],
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+        ],
         [AS_IF([$CXX --version 2>&1 | grep 'clang version' > /dev/null],
             [AC_MSG_NOTICE([Enabling pedantic errors for clang CPP preprocessor])
-             CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"],
+             CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+            ],
             [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU or clang CPP)])
              AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
         ])])])

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1215,10 +1215,20 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
         ])])])
      AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
         [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
-         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"],
+.if project.use_cxx
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall"
+.else
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+.endif
+        ],
         [AS_IF([$CXX --version 2>&1 | grep 'clang version' > /dev/null],
             [AC_MSG_NOTICE([Enabling pedantic errors for clang CPP preprocessor])
-             CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"],
+.if project.use_cxx
+             CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall"
+.else
+             CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+.endif
+            ],
             [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU or clang CPP)])
              AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
         ])])])


### PR DESCRIPTION
Solution: fix back the -Wc++compat flag that should only be in non-CXX builds

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>