### PR TITLE
Problem: CMake dev warning related to CMP0022 on Win32

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -19,7 +19,7 @@ $(project.GENERATED_WARNING_HEADER:)
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 project($(project.name:c))
 .if project.use_cxx
 enable_language(CXX)
@@ -151,7 +151,7 @@ find_package($(use.project) REQUIRED)
 IF ($(USE.PROJECT)_FOUND)
 .else
 find_package($(use.project))
-option($(PROJECT.PREFIX)_WITH_$(USE.PROJECT) "Build czmq with $(use.project)" ${$(USE.PROJECT)_FOUND})
+option($(PROJECT.PREFIX)_WITH_$(USE.PROJECT) "Build $(project.linkname) with $(use.project)" ${$(USE.PROJECT)_FOUND})
 IF ($(PROJECT.PREFIX)_WITH_$(USE.PROJECT) AND $(USE.PROJECT)_FOUND)
 .endif
 .if use.libname ?<> ""


### PR DESCRIPTION
> cmake .. -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"

> ......
>-- Configuring done
CMake Warning (dev) in CMakeLists.txt:
  Policy CMP0022 is not set: INTERFACE_LINK_LIBRARIES defines the link
  interface.  Run "cmake --help-policy CMP0022" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
>
>  Target "czmq" has an INTERFACE_LINK_LIBRARIES property which differs from
  its LINK_INTERFACE_LIBRARIES_DEBUG properties.
>
>  INTERFACE_LINK_LIBRARIES:
>
>    ws2_32;Rpcrt4;Iphlpapi;$<$<NOT:$<CONFIG:DEBUG>>:C:/vcpkg/installed/x86-windows/lib/libzmq-mt-4_3_2.lib>;$<$<CONFIG:DEBUG>:C:/vcpkg/installed/x86-windows/debug/lib/libzmq-mt-gd-4_3_2.lib>;E:/ProgramData/Anaconda3/Library/lib/libcurl.lib
>
>  LINK_INTERFACE_LIBRARIES_DEBUG:
>
>    ws2_32;Rpcrt4;Iphlpapi;C:/vcpkg/installed/x86-windows/debug/lib/libzmq-mt-gd-4_3_2.lib;E:/ProgramData/Anaconda3/Library/lib/libcurl.lib
>
>This warning is for project developers.  Use -Wno-dev to suppress it.


This warning will disappear by upgrading the minimum required CMake version to 2.8.12.
(libzmq also sets minimum required version to 2.8.12)