### PR TITLE
Some fixes around GCC-4.9 and shadow compilation features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(zproject)
 enable_language(C)
 enable_testing()

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -335,7 +335,7 @@ matrix:
 # Shadow-compilation setups below inspired by https://docs.travis-ci.com/user/languages/cpp/
 .endif
 .   if defined (project.travis_shadow_clang) & !(project.travis_shadow_clang ?= 0)
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0 && export CC CXX"
     os: linux
 .       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -356,7 +356,7 @@ matrix:
         packages:
         - *pkg_deps_common
         - clang-5.0
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && export CC CXX"
     os: linux
 .       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -377,7 +377,7 @@ matrix:
         packages:
         - *pkg_deps_common
         - clang-4.0
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9 && export CC CXX"
     os: linux
 .       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -398,7 +398,7 @@ matrix:
         packages:
         - *pkg_deps_common
         - clang-3.9
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8 && export CC CXX"
     os: linux
 .       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -422,7 +422,7 @@ matrix:
 .endif
 .if defined (project.travis_shadow_gcc) & !(project.travis_shadow_gcc ?= 0)
 .   if !(defined(use_cxx_gcc_4_9)) | !(use_cxx_gcc_4_9 ?= 1)
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9 && export CC CXX"
     os: linux
 .       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -440,7 +440,7 @@ matrix:
         - gcc-4.9
 .   endif
 .   if !defined(project.travis_dist) | (project.travis_dist ?<> "xenial")
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && export CC CXX"
     os: linux
 .       if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -457,7 +457,7 @@ matrix:
         - g++-5
         - gcc-5
 .   endif
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && export CC CXX"
     os: linux
 .   if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -473,7 +473,7 @@ matrix:
         - *pkg_deps_common
         - g++-6
         - gcc-6
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && export CC CXX"
     os: linux
 .   if (project.travis_dist ?<> "")
     dist: $(project.travis_dist)
@@ -532,20 +532,20 @@ matrix:
 .   if project.travis_shadow_gcc ?= 2
 .   echo "TRAVIS: Shadow GCC versions: allow-fail: true"
 .       if !(use_cxx_gcc_4_9 ?= 1)
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9 && export CC CXX"
 .       endif
 .       if !defined(project.travis_dist) | (project.travis_dist ?<> "xenial")
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && export CC CXX"
 .       endif
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && export CC CXX"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && export CC CXX"
 .   endif
 .   if project.travis_shadow_clang ?= 2
 .   echo "TRAVIS: Shadow CLANG versions: allow-fail: true"
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
-  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0 && export CC CXX"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && export CC CXX"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9 && export CC CXX"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8 && export CC CXX"
 .   endif
 .   if project.travis_clangformat_allow_failures ?= 1
 .   echo "TRAVIS: CLANG-FORMAT: allow-fail: true"

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -219,7 +219,7 @@ pkg_deps_common: &pkg_deps_common
 # Also note that as of early 2017, either dist==trusty or services==docker
 # is needed for some C++11 support; docker envs are usually faster to start up
 # A newer dist==xenial completes the C++11 support with gcc-5+
-.if defined(use_cxx) & defined(use_cxx_gcc_4_9)
+.if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
 # Note that with current implementation of zproject use-cxx-gcc-4-9 option,
 # this effectively hardcodes the use of specifically 4.9, not allowing for
 # "4.9 or newer".

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -584,10 +584,10 @@ matrix:
 before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "android" ] ; then brew install binutils ; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew install valgrind ; fi
-- if [ -n "\${MATRIX_EVAL}" ] ; then eval \${MATRIX_EVAL} ; fi
 .if defined(use_cxx) & defined(use_cxx_gcc_4_9) & !(use_cxx ?= 0) & !(use_cxx_gcc_4_9 ?= 0)
 - if [ "$CXX" == "g++" ] ; then export CXX="g++-4.9" CC="gcc-4.9" ; fi
 .endif
+- if [ -n "\${MATRIX_EVAL}" ] ; then eval \${MATRIX_EVAL} ; fi
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -202,14 +202,17 @@ pkg_deps_doctools: &pkg_deps_doctools
 pkg_deps_devtools: &pkg_deps_devtools
     - git
 
+# NOTE: Unlike earlier zproject versions, the pkg_src* objects below do not
+# start with a dash, due to peculiarities of YAML alias dereferencing in Travis
+
 # dist==trusty means ubuntu14
 pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
-- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
+  sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
 
 # dist==xenial means ubuntu16
 pkg_src_zeromq_ubuntu16: &pkg_src_zeromq_ubuntu16
-- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/ ./'
+  sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/ ./'
   key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/Release.key'
 
 pkg_deps_common: &pkg_deps_common


### PR DESCRIPTION
Most of the fixes are pre-emptive or cosmetic really, and the major one is a trivial change after hours of experiments, to remove a dash. Go figure :)

From 
````
Adding APT Sources
'sourceline' key missing:
\{"key_url"\=\>"http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key",\ "sourceline"\=\>"deb\ http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/\ ./"\}
1.59s$ sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
gpg: keyring `/tmp/tmpj85g34bj/secring.gpg' created
gpg: keyring `/tmp/tmpj85g34bj/pubring.gpg' created
gpg: requesting key BA9EF27F from hkp server keyserver.ubuntu.com
gpg: /tmp/tmpj85g34bj/trustdb.gpg: trustdb created
gpg: key BA9EF27F: public key "Launchpad Toolchain builds" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK
````
per #1188 we get to desired
````
Adding APT Sources
0.61s$ curl -sSL "http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key" | sudo -E apt-key add -
OK
0.01s$ echo "deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list >/dev/null
1.62s$ sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
gpg: keyring `/tmp/tmp50j7da2g/secring.gpg' created
gpg: keyring `/tmp/tmp50j7da2g/pubring.gpg' created
gpg: requesting key BA9EF27F from hkp server keyserver.ubuntu.com
gpg: /tmp/tmp50j7da2g/trustdb.gpg: trustdb created
gpg: key BA9EF27F: public key "Launchpad Toolchain builds" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK
````
