### PR TITLE
Problem: Private class self tests hidden by public test failures

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -247,22 +247,6 @@ typedef struct {
 
 static test_item_t
 all_tests [] = {
-.for class where !draft & selftest & private ?<> 1
-.   if first ()
-// Tests for stable public classes:
-.   endif
-    { "$(class.c_name)", $(class.c_name)_test, true, true, NULL },
-.endfor
-.for class where draft & selftest & private ?<> 1
-.   if first ()
-#ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
-// Tests for draft public classes:
-.   endif
-    { "$(class.c_name)", $(class.c_name)_test, false, true, NULL },
-.   if last ()
-#endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
-.   endif
-.endfor
 .for class where selftest & private ?= 1
 .   if first ()
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
@@ -276,6 +260,22 @@ all_tests [] = {
 .   endif
 .   if last ()
     { "private_classes", NULL, false, false, "$ALL" }, // compat option for older projects
+#endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
+.   endif
+.endfor
+.for class where !draft & selftest & private ?<> 1
+.   if first ()
+// Tests for stable public classes:
+.   endif
+    { "$(class.c_name)", $(class.c_name)_test, true, true, NULL },
+.endfor
+.for class where draft & selftest & private ?<> 1
+.   if first ()
+#ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+// Tests for draft public classes:
+.   endif
+    { "$(class.c_name)", $(class.c_name)_test, false, true, NULL },
+.   if last ()
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif
 .endfor


### PR DESCRIPTION
Solution: Shuffle the test order, so private classes are tested first.
Assumption is that they are the internal implementation detail,
and if they fail their selftests in a new iteration, the public
classes would also fail for these reason (but without delivering
the real cause of failure so clearly, being higher-level consumers).

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>
Asked-for-by: Jiri Kukacka <JiriKukacka@eaton.com>