### PR TITLE
Problem: test for C++11 (so g++-4.9) is unavoidable now

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1278,7 +1278,7 @@ int main() {
 #endif
   return result ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
+     ], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
      AC_LANG_POP([C++])
     ]
   ,[AC_MSG_WARN([Not checking for GNU C++11 support level expected by gcc-4.9 release or newer, due to explicit configure option])

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1238,7 +1238,16 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
 # One of big missing features in gcc-4.8 was std::regex support fixed in 4.9
 # Testing code from https://stackoverflow.com/a/41186162/4715872
 # caveats apply (use of unguaranteed private macros)
+AC_ARG_ENABLE([gcc-std-regex],
+    AS_HELP_STRING([--enable-gcc-std-regex],
+        [Check for std::regex support if compiler is GCC, assuming it means satisfactory level of C++11 there [default=yes]]),
+    [enable_gcc_std_regex=$enableval],
+    [enable_gcc_std_regex=$defaultval])
+
+AM_CONDITIONAL([ENABLE_GCC_STD_REGEX], [test x$enable_gcc_std_regex != xno])
+
 AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+  [AS_IF([test "x$enable_gcc_std_regex" = "xyes" || test "x$enable_gcc_std_regex" = "xauto"],
     [AC_MSG_CHECKING([for GNU C++11 support level expected by gcc-4.9 release or newer])
      CXXFLAGS="$CXXFLAGS --std=c++11"
      AC_LANG_PUSH([C++])
@@ -1272,6 +1281,9 @@ int main() {
 ], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
      AC_LANG_POP([C++])
     ]
+  ,[AC_MSG_WARN([Not checking for GNU C++11 support level expected by gcc-4.9 release or newer, due to explicit configure option])
+    AC_MSG_WARN([YOU ARE AT RISK OF SOMETHING NOT WORKING WITH THIS BUILD OF THE CODEBASE])]
+  )]
 )])
 
 .endif


### PR DESCRIPTION
Solution: make the check for std::regex (assuming it means the sufficient
level of C++11 in GCC) optional with --enable-gcc-std-regex=no and by
default enabled if gcc-4.9 is requested by the project's "classfilename" tag.

A build with this option set to 'no' should compile in some of the earlier
toolchains, such as the default gcc-4.8 in "trusty" VMs on Travis, but the
result would not necessarily function (gcc-4.8 and earlier could include the
API routines for supporting the standard, but not really implement it).

Primary intended use-case:

If Travis CI tests of some projects "use" a project that by itself
requires C++11, but do not really use this aspect of it in their own
unit-tests, this is sufficient for "trusty" machines with older GCC.
In this case, the "use" tag for such project can be amended with
````
    <add_config_opts>--enable-gcc-std-regex=no</add_config_opts>
````
tags to avoid configure-time failures in Travis CI builds of the
whole dependency chain (unpackaged mode).

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>