### PR TITLE
Problem: [JNI] Errors loading libs on Android are not caught

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -773,14 +773,14 @@ public class ZmqNativeLoader {
 
     public static void loadLibrary(String libname) {
         if (!loadedLibraries.contains(libname)) {
-            if (System.getProperty("java.vm.vendor").contains("Android")) {
-                System.loadLibrary(libname);
-            } else {
-                try {
+            try {
+                if (System.getProperty("java.vm.vendor").contains("Android")) {
+                    System.loadLibrary(libname);
+                } else {
                     NativeLoader.loadLibrary(libname);
-                } catch (Exception e) {
-                    System.err.println("[WARN] " + e.getMessage() +" from jar. Assuming it is installed on the system.");
                 }
+            } catch (Exception e) {
+                System.err.println("[WARN] " + e.getMessage() +" from jar. Assuming it is installed on the system.");
             }
             loadedLibraries.add(libname);
         }


### PR DESCRIPTION
Solution: Move the try catch block around the load library call for
android as well