### PR TITLE
Problem: JNI bindings not compatible with Android SDK < 24

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -151,7 +151,7 @@ dependencies {
     compile 'org.zeromq:$(use.project)-jni:+'
 .       endif
 .   endfor
-    compile 'org.scijava:native-lib-loader:2.3.2'
+    compile 'org.scijava:native-lib-loader:2.3.4'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
@@ -763,6 +763,7 @@ popd
 .   output "$(topdir)/src/main/java/org/zeromq/tools/ZmqNativeLoader.java"
 package org.zeromq.tools;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.HashSet;
 import org.scijava.nativelib.NativeLoader;
@@ -771,16 +772,16 @@ public class ZmqNativeLoader {
 
     private static final Set<String> loadedLibraries = new HashSet<>();
 
-    public static void loadLibrary(String libname) {
+    public static void loadLibrary(String libname, boolean optional) {
         if (!loadedLibraries.contains(libname)) {
             try {
-                if (System.getProperty("java.vm.vendor").contains("Android")) {
-                    System.loadLibrary(libname);
+                NativeLoader.loadLibrary(libname);
+            } catch (IOException e) {
+                if (optional) {
+                    System.err.println("[WARN] " + e.getMessage() + " from jar. Assuming it is installed on the system.");
                 } else {
-                    NativeLoader.loadLibrary(libname);
+                    System.exit(-1);
                 }
-            } catch (Exception e) {
-                System.err.println("[WARN] " + e.getMessage() +" from jar. Assuming it is installed on the system.");
             }
             loadedLibraries.add(libname);
         }
@@ -797,7 +798,6 @@ $(project.GENERATED_WARNING_HEADER:)
 */
 package org.zeromq.$(project.prefix:c);
 
-import java.util.stream.Stream;
 import org.zeromq.tools.ZmqNativeLoader;
 .   for project.use
 .       if count (project->dependencies.class, class.project = use.project) > 0
@@ -807,28 +807,15 @@ import org.zeromq.$(use.project).*;
 
 public class $(my.class.name:pascal) \
 .   if count (my.class.constructor)
-implements AutoCloseable\
+implements AutoCloseable \
 .   endif
 {
     static {
-        Stream.of(
 .       for project.use
-                "$(use.prefix:c)",
+        ZmqNativeLoader.loadLibrary("$(use.prefix:c)", true);
 .       endfor
-                "$(project.prefix:c)"
-            )
-            .forEach(lib -> {
-                try {
-                    ZmqNativeLoader.loadLibrary(lib);
-                } catch (Exception e) {
-                    System.err.println("[WARN] " + e.getMessage() +" from jar. Assuming it is installed on the system.");
-                }
-            });
-        try {
-            ZmqNativeLoader.loadLibrary("$(project.prefix:c)jni");
-        } catch (Exception e) {
-            System.exit (-1);
-        }
+        ZmqNativeLoader.loadLibrary("$(project.prefix:c)", true);
+        ZmqNativeLoader.loadLibrary("$(project.prefix:c)jni", false);
     }
     public long self;
 .   my.class.jni_void_new = 0


### PR DESCRIPTION
Solution: Remove usage of Java 8's Stream API. Also, native-lib-loader 2.3.4 handle loading libraries for Android so there is no need for this extra check anymore.

 Fix #1194
@sappo let me know if any change is necessary