### PR TITLE
Problem: can't drop python from my system because of zproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,8 +580,6 @@ zproject's `project.xml` contains an extensive description of the available conf
     <bin name = "zproject_vs20xx_props.gsl" />
 
     <bin name = "zproject_known_projects.xml" />
-    <bin name = "mkapi.py" />
-    <bin name = "fake_cpp" />
 </project>
 ```
 

--- a/packaging/debian/zproject.install
+++ b/packaging/debian/zproject.install
@@ -37,6 +37,4 @@ usr/bin/zproject_vs2008.gsl
 usr/bin/zproject_vs20xx.gsl
 usr/bin/zproject_vs20xx_props.gsl
 usr/bin/zproject_known_projects.xml
-usr/bin/mkapi.py
-usr/bin/fake_cpp
 

--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -105,7 +105,5 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %{_bindir}/zproject_vs20xx.gsl
 %{_bindir}/zproject_vs20xx_props.gsl
 %{_bindir}/zproject_known_projects.xml
-%{_bindir}/mkapi.py
-%{_bindir}/fake_cpp
 
 %changelog

--- a/project.xml
+++ b/project.xml
@@ -403,6 +403,4 @@
     <bin name = "zproject_vs20xx_props.gsl" />
 
     <bin name = "zproject_known_projects.xml" />
-    <bin name = "mkapi.py" />
-    <bin name = "fake_cpp" />
 </project>

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -49,9 +49,7 @@ dist_bin_SCRIPTS = \
     zproject_vs2008.gsl \
     zproject_vs20xx.gsl \
     zproject_vs20xx_props.gsl \
-    zproject_known_projects.xml \
-    mkapi.py \
-    fake_cpp
+    zproject_known_projects.xml
 
 
 # Directories with test fixtures optionally provided by the project,


### PR DESCRIPTION
Solution: do not install `mkapi.py` and `fakecpp`. To be honest I would
personally frop them from zproject as I am not sure it even works
nowadays :)