### PR TITLE
Use cmake --build . instead of make

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -182,7 +182,7 @@ task initCMake(type: Exec, dependsOn: 'generateJniHeaders') {
     commandLine "cmake", "."
 }
 task buildNative(type: Exec, dependsOn: 'initCMake') {
-    commandLine "make"
+    commandLine "cmake", "--build", "."
 }
 
 task copyLibs(type: Copy) {


### PR DESCRIPTION
Use cmake --build ., which calls the correct program according to the generator used.
Currently this doesn't work on Windows with MSVC (no make)