### PR TITLE
Java: Fix variadic NULL terminated

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -899,7 +899,7 @@ $(jni_shim_signature_c:))
     zsys_handler_set (NULL);
 .   endif
 .   if ->return.type = "nothing"
-    $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
+    $(class.c_name)_$(c_name) ($(jni_native_invocation_c:));
 .       if defined (my.method.return_self_p) & !my.method.is_destructor
 .           my.return = "    return self;\n"
 .       else
@@ -912,14 +912,14 @@ $(jni_shim_signature_c:))
 .       else
 .           my.size = ->return.size
 .       endif
-    jbyte *$(c_name)_ = (jbyte *) $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
+    jbyte *$(c_name)_ = (jbyte *) $(class.c_name)_$(c_name) ($(jni_native_invocation_c:));
     jint return_size_ = (jint) $(my.size);
     jbyteArray return_data_ = (*env)->NewByteArray (env, return_size_);
     (*env)->SetByteArrayRegion (env, return_data_, 0, return_size_, (jbyte *) $(c_name)_);
 .       my.return = "    return return_data_;\n"
 .#
 .   elsif ->return.type = "string"
-    char *$(c_name)_ = (char *) $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
+    char *$(c_name)_ = (char *) $(class.c_name)_$(c_name) ($(jni_native_invocation_c:));
     jstring return_string_ = (*env)->NewStringUTF (env, $(c_name)_);
 .       if ->return.fresh
     zstr_free (&$(c_name)_);
@@ -927,10 +927,10 @@ $(jni_shim_signature_c:))
 .       my.return = "    return return_string_;\n"
 .#
 .   elsif ->return.jni_is_class = 1 | ->return.type = "anything" | ->return.type = "sockish"
-    jlong $(c_name)_ = (jlong) (intptr_t) $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
+    jlong $(c_name)_ = (jlong) (intptr_t) $(class.c_name)_$(c_name) ($(jni_native_invocation_c:));
 .       my.return = "    return $(c_name)_;\n"
 .   else
-    $(->return.jni_jni_type:) $(c_name)_ = ($(->return.jni_jni_type:)) $(class.c_name)_$(c_name) ($(jni_native_invocation_c));
+    $(->return.jni_jni_type:) $(c_name)_ = ($(->return.jni_jni_type:)) $(class.c_name)_$(c_name) ($(jni_native_invocation_c:));
 .       if defined (my.method.return_self_p)
 .           my.return = "    return self;\n"
 .       else

--- a/zproject_java_lib.gsl
+++ b/zproject_java_lib.gsl
@@ -172,6 +172,7 @@ function resolve_method (method)
             if va_start <> "format"
                 jni_method_signature += " []"
                 jni_shim_invocation_java += " [0]"
+                jni_native_invocation_c += ", NULL"
             endif
         elsif jni_self_p = 1
             jni_shim_signature_java += "$(comma)long self"


### PR DESCRIPTION
The code generated is not correct for variadic NULL terminated methods:
https://github.com/zeromq/czmq/blob/master/bindings/jni/src/main/c/org_zeromq_czmq_Zstr.c#L71
should be
`jint sendx_ = (jint) zstr_sendx ((void *) (intptr_t) dest, string_, NULL);`
instead of
`jint sendx_ = (jint) zstr_sendx ((void *) (intptr_t) dest, string_);`