### PR TITLE
Problem: too easy to re-release a project with obsolete Copyrights

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,11 @@ zproject's `project.xml` contains an extensive description of the available conf
     name := The name of your project (optional)
     description := A short description for your project (optional)
     email := The email address where to reach you (optional)
+    url := The website or similar resource about the project or its ecosystem (optional)
     repository := git repository holding project (optional)
     unique_class_name := "0"|"1" (optional, defaults to 0) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable explicitly (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
+    license := optional common tag of the project's license ("MPLv2", "GPL-2.0+", "CompanyName Proprietary" etc.); see also license.xml for longer wording
+    check_license_years := "0"|"1"|"2" (optional, defaults to 0) When a project is regenerated, and if any license text(s) are defined, we check that at least one Copyright line in at least one license text contains the current year, and warn if not. If this option is set to "1", we also pause so that interactive developers can see this warning better and intervene. With "2" require that the year is mentioned, abort GSL with year if it is not.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"
@@ -237,7 +240,10 @@ zproject's `project.xml` contains an extensive description of the available conf
         part of the XML tree. This file can provide content of such tags
         as <license> (detailed text to put in generated file headers)
         and <starting_year> (a number to put in packaging copyright
-        summaries).
+        summaries). Note that a verbatim "license.xml" file would be
+        created if it is currently missing but the tag is present, and
+        then it would be seeded with a current starting_year and some
+        boilerplate reminder to specify a real license and copyright.
     -->
     <include filename = "license.xml" />
 

--- a/project.xml
+++ b/project.xml
@@ -46,8 +46,10 @@
     name := The name of your project (optional)
     description := A short description for your project (optional)
     email := The email address where to reach you (optional)
+    url := The website or similar resource about the project or its ecosystem (optional)
     repository := git repository holding project (optional)
     unique_class_name := "0"|"1" (optional, defaults to 0) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable explicitly (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
+    license := optional common tag of the project's license ("MPLv2", "GPL-2.0+", "CompanyName Proprietary" etc.); see also license.xml for longer wording
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/project.xml
+++ b/project.xml
@@ -50,6 +50,7 @@
     repository := git repository holding project (optional)
     unique_class_name := "0"|"1" (optional, defaults to 0) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable explicitly (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
     license := optional common tag of the project's license ("MPLv2", "GPL-2.0+", "CompanyName Proprietary" etc.); see also license.xml for longer wording
+    check_license_years := "0"|"1" (optional, defaults to 0) When a project is regenerated, and if any license text(s) are defined, we check that at least one Copyright line in at least one license text contains the current year, and warn if not. If this option is set to "1", we also pause so that interactive developers can see this warning better and intervene.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/project.xml
+++ b/project.xml
@@ -62,7 +62,10 @@
         part of the XML tree. This file can provide content of such tags
         as <license> (detailed text to put in generated file headers)
         and <starting_year> (a number to put in packaging copyright
-        summaries).
+        summaries). Note that a verbatim "license.xml" file would be
+        created if it is currently missing but the tag is present, and
+        then it would be seeded with a current starting_year and some
+        boilerplate reminder to specify a real license and copyright.
     -->
     <include filename = "license.xml" />
 

--- a/project.xml
+++ b/project.xml
@@ -50,7 +50,7 @@
     repository := git repository holding project (optional)
     unique_class_name := "0"|"1" (optional, defaults to 0) As a failsafe, forbid naming agents or classes same as the project itself (can cause conflicts in generated header filenames). Disable explicitly (set to 0) only in legacy projects that can not regenerate otherwise, and try to fix those.
     license := optional common tag of the project's license ("MPLv2", "GPL-2.0+", "CompanyName Proprietary" etc.); see also license.xml for longer wording
-    check_license_years := "0"|"1" (optional, defaults to 0) When a project is regenerated, and if any license text(s) are defined, we check that at least one Copyright line in at least one license text contains the current year, and warn if not. If this option is set to "1", we also pause so that interactive developers can see this warning better and intervene.
+    check_license_years := "0"|"1"|"2" (optional, defaults to 0) When a project is regenerated, and if any license text(s) are defined, we check that at least one Copyright line in at least one license text contains the current year, and warn if not. If this option is set to "1", we also pause so that interactive developers can see this warning better and intervene. With "2" require that the year is mentioned, abort GSL with year if it is not.
 -->
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -70,9 +70,16 @@ function check_license_years (xml)
         if (0 = my.year_seen)
             echo "W: Current year '$(my.now_year)' is not listed in any license tag / Copyright line!"
             echo "W: Do you want to Ctrl+Break now, edit your license.xml and regenerate the project?"
-            echo "W: (Sleeping 5 sec...)"
-            thread.sleep (500)
-            echo "W: Oh well, moving on with possibly obsoleted copyrights"
+            # Per PR review, there's no hard need for a pause - after the
+            # Bern convention the "copyright YYYY-YYYY" line is actually not
+            # legally required almost anywhere in the world, and is purely
+            # informative. Copyright is implicit and automatic, and with
+            # git there is enough metadata to satisfty any lawyer/court.
+            if (my.xml.check_license_years ?= 1)
+                echo "W: (Sleeping 5 sec...)"
+                thread.sleep (500)
+                echo "W: Oh well, moving on with possibly obsoleted copyrights"
+            endif
         endif
     endif
 endfunction

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -80,6 +80,9 @@ function check_license_years (xml)
                 thread.sleep (500)
                 echo "W: Oh well, moving on with possibly obsoleted copyrights"
             endif
+            if (my.xml.check_license_years ?= 2)
+                abort "E: This project is configured to require that copyrights are up to date"
+            endif
         endif
     endif
 endfunction

--- a/zproject.gsl
+++ b/zproject.gsl
@@ -50,7 +50,35 @@ function resolve_includes (xml)
     endfor
 endfunction
 
+# Sanity-check if project.xml, license.xml etc. reference the current
+# year (as starting, ending, just listed...) in Copyright line context
+function check_license_years (xml)
+    if count (my.xml.license) > 0
+        # Assign HHMMSSss into my.time and YYYYMMDD into my.date:
+        my.time = time.now(my.date)
+        my.now_year = string.substr(my.date, 0, , 4)
+        my.year_seen = 0
+        for my.xml.license
+            # This pattern supports several ways of spelling the copyright
+            # character (ASCII code 169) or registered symbol (ASCII 174).
+            # Note that in XML tag they should be spelled via escape sequences;
+            # a direct UTF character in the tag can be misinterpreted by GSL.
+            if regexp.match ("(opyright|\(C\)|\&\#(169|[xX][aA]9|174|[xX][aA][eE])\;|\&copy\;|&copy;|&#(169|174|[xX][aA]9|[xX][aA][eE]);|$(conv.chr(169))|$(conv.chr(174))).*$(my.now_year)", license.)
+                my.year_seen += 1
+            endif
+        endfor
+        if (0 = my.year_seen)
+            echo "W: Current year '$(my.now_year)' is not listed in any license tag / Copyright line!"
+            echo "W: Do you want to Ctrl+Break now, edit your license.xml and regenerate the project?"
+            echo "W: (Sleeping 5 sec...)"
+            thread.sleep (500)
+            echo "W: Oh well, moving on with possibly obsoleted copyrights"
+        endif
+    endif
+endfunction
+
 resolve_includes (project)
+check_license_years (project)
 
 # Check if project contains one or more C++ sources
 function project_use_cxx ()


### PR DESCRIPTION
Solution: Take legalese seriously. During regeneration, check
if the current year is mentioned (from, until, listed, whatever)
in a line with the "Copyright" word or some of the ways it can
be written in the XML `<license>` tag.

If the year is not listed in any such line (or no such lines are
there), warn the user in at least the build-logged messages, and
also pause for 5 sec so the interactive people can break, fix and
regenerate.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Loosely related to #1204 but not as invasive :)