### PR TITLE
project.xml : make sure zproject building itself does not break…

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ zproject's `project.xml` contains an extensive description of the available conf
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"
     license = "MPLv2"
+    check_license_years = "0"
     url = "https://github.com/zeromq/zproject"
     repository = "https://github.com/zeromq/zproject">
 

--- a/project.xml
+++ b/project.xml
@@ -55,6 +55,7 @@
 <project script = "zproject.gsl" name = "zproject"
     email = "zeromq-dev@lists.zeromq.org"
     license = "MPLv2"
+    check_license_years = "0"
     url = "https://github.com/zeromq/zproject"
     repository = "https://github.com/zeromq/zproject">
 


### PR DESCRIPTION
… due to licensing (check for Copyright years being up to date - not listed in zproject's own `license.xml`), if our defaults for check_license_years behavior evolve in the future.

Follows up on last comment from #1205 