### PR TITLE
Fix linker issue in cmake -G Xcode projects

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -313,11 +313,15 @@ ENDIF (NOT MSVC)
 
 # shared
 if ($(PROJECT.PREFIX)_BUILD_SHARED)
-  IF (MSVC)
+  IF (APPLE)
     add_library($(project.linkname) SHARED ${$(project.linkname)_sources})
-  ELSE (MSVC)
-    add_library($(project.linkname) SHARED $<TARGET_OBJECTS:$(project.linkname)_objects>)
-  ENDIF (MSVC)
+  ELSE (APPLE)
+    IF (MSVC)
+      add_library($(project.linkname) SHARED ${$(project.linkname)_sources})
+    ELSE (MSVC)
+      add_library($(project.linkname) SHARED $<TARGET_OBJECTS:$(project.linkname)_objects>)
+    ENDIF (MSVC)
+  ENDIF(APPLE)
 
   set_target_properties ($(project.linkname) PROPERTIES
     PUBLIC_HEADER "${public_headers}"
@@ -353,11 +357,15 @@ endif()
 
 # static
 if ($(PROJECT.PREFIX)_BUILD_STATIC)
-  IF (MSVC)
+  IF (APPLE)
     add_library($(project.linkname)-static STATIC ${$(project.linkname)_sources})
-  ELSE (MSVC)
-    add_library($(project.linkname)-static STATIC $<TARGET_OBJECTS:$(project.linkname)_objects>)
-  ENDIF (MSVC)
+  ELSE (APPLE)
+    IF (MSVC)
+      add_library($(project.linkname)-static STATIC ${$(project.linkname)_sources})
+    ELSE (MSVC)
+      add_library($(project.linkname)-static STATIC $<TARGET_OBJECTS:$(project.linkname)_objects>)
+    ENDIF (MSVC)
+  ENDIF (APPLE)
 
   set_target_properties($(project.linkname)-static PROPERTIES
     PUBLIC_HEADER "${public_headers}"


### PR DESCRIPTION
re #1200

Tested on OSX Mojave (10.14.6) and XCode 11.1.

Previously a generated Xcode project would not compile because an incorrectly named .dylib file was being generated (it defaulted to "0.dylib", but our project.xml defined "0.0.1.dylib"). After some searching this might actually be a non-compliance with Apple guidelines (they want only major versions in .dylib, and minor/patch in config or something.

This edit uses sources more directly, and bypasses the whole issue.