### PR TITLE
Problem: Android build script is severely outdated

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -114,7 +114,7 @@ android_build_verify_so "$(project.libname).so"\
  "$(use.libname).so"\
 .endfor
 
-echo "Android build successful"
+echo "Android (${TOOLCHAIN_ARCH}) build successful"
 $(project.GENERATED_WARNING_HEADER:)
 .close
 .chmod_x ("builds/android/build.sh")
@@ -123,31 +123,24 @@ $(project.GENERATED_WARNING_HEADER:)
 #!/usr/bin/env bash
 $(project.GENERATED_WARNING_HEADER:)
 
-NDK_VER=android-ndk-r11c
-NDK_ABI_VER=4.9
+NDK_VERSION=android-ndk-r20
+NDK_ABI_VERSION=4.9
 
 if [ $TRAVIS_OS_NAME == "linux" ]; then
-    NDK_PLATFORM=linux-x86_64
+    HOST_PLATFORM=linux-x86_64
 elif [ $TRAVIS_OS_NAME == "osx" ]; then
-    NDK_PLATFORM=darwin-x86_64
+    HOST_PLATFORM=darwin-x86_64
 else
     echo "Unsupported platform $TRAVIS_OS_NAME"
     exit 1
 fi
 
-export FILENAME=$NDK_VER-$NDK_PLATFORM.zip
+export FILENAME=$NDK_VERSION-$HOST_PLATFORM.zip
 
 (cd '/tmp' \\
     && wget http://dl.google.com/android/repository/$FILENAME &> /dev/null \\
     && unzip $FILENAME &> /dev/null ) || exit 1
 unset FILENAME
-
-export ANDROID_NDK_ROOT="/tmp/$NDK_VER"
-export TOOLCHAIN_PATH="$ANDROID_NDK_ROOT/toolchains/arm-linux-androideabi-$NDK_ABI_VER/prebuilt/$NDK_PLATFORM/bin"
-export TOOLCHAIN_VERSION=$NDK_ABI_VER
-export TOOLCHAIN_NAME="arm-linux-androideabi-$NDK_ABI_VER"
-export TOOLCHAIN_HOST="arm-linux-androideabi"
-export TOOLCHAIN_ARCH="arm"
 
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
@@ -161,7 +154,49 @@ git clone --quiet --depth 1 $(use.repository) $$(USE.PROJECT)_ROOT
 .   endif
 
 .endfor
-source ./build.sh
+function _build_arch {
+    export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
+    export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
+    export TOOLCHAIN_HOST=$1
+    export TOOLCHAIN_COMP=$2
+    export TOOLCHAIN_CXXSTL=$3
+    export TOOLCHAIN_ARCH=$4
+    export TOOLCHAIN_NAME="${TOOLCHAIN_HOST}-${NDK_ABI_VERSION}"
+
+    source ./build.sh
+}
+
+# Define the minimum Android API level for the library to run.
+# With NDK r20, the minimum SDK version range is [16, 29]
+export MIN_SDK_VERSION="21"
+
+HOST_ARM="arm-linux-androideabi"
+HOST_ARM64="aarch64-linux-android"
+HOST_X86="i686-linux-android"
+HOST_X86_64="x86_64-linux-android"
+
+COMP_ARM="armv7a-linux-androideabi${MIN_SDK_VERSION}"
+COMP_ARM64="aarch64-linux-android${MIN_SDK_VERSION}"
+COMP_X86="i686-linux-android${MIN_SDK_VERSION}"
+COMP_X86_64="x86_64-linux-android${MIN_SDK_VERSION}"
+
+CXXSTL_ARM="armeabi-v7a"
+CXXSTL_ARM64="arm64-v8a"
+CXXSTL_X86="x86"
+CXXSTL_X86_64="x86_64"
+
+ARCH_ARM="arm"
+ARCH_ARM64="arm64"
+ARCH_X86="x86"
+ARCH_X86_64="x86_64"
+
+_build_arch $HOST_ARM $COMP_ARM $CXXSTL_ARM $ARCH_ARM
+_build_arch $HOST_X86 $COMP_X86 $CXXSTL_X86 $ARCH_X86
+
+if [[ $MIN_SDK_VERSION -ge 21 ]] ; then
+    _build_arch $HOST_ARM64 $COMP_ARM64 $CXXSTL_ARM64 $ARCH_ARM64
+    _build_arch $HOST_X86_64 $COMP_X86_64 $CXXSTL_X86_64 $ARCH_X86_64
+fi
 
 $(project.GENERATED_WARNING_HEADER:)
 .close
@@ -204,7 +239,7 @@ ANDROID_BUILD_FAIL=()
 
 function android_build_check_fail {
     if [ ! ${#ANDROID_BUILD_FAIL[@]} -eq 0 ]; then
-        echo "Android build failed for the following reasons:"
+        echo "Android (${TOOLCHAIN_ARCH}) build failed for the following reasons:"
         for reason in "${ANDROID_BUILD_FAIL[@]}"; do
             local formatted_reason="  ${reason}"
             echo "${formatted_reason}"
@@ -219,22 +254,27 @@ function android_build_env {
 
     if [ -z "$ANDROID_NDK_ROOT" ]; then
         ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_ROOT environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r11c\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r20\")")
     fi
 
     if [ -z "$TOOLCHAIN_PATH" ]; then
         ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_PATH environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r11c/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin\")")
-    fi
-
-    if [ -z "$TOOLCHAIN_NAME" ]; then
-        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_NAME environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"arm-linux-androideabi-4.9\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r20/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin\")")
     fi
 
     if [ -z "$TOOLCHAIN_HOST" ]; then
         ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_HOST environment variable")
         ANDROID_BUILD_FAIL+=("  (eg. \"arm-linux-androideabi\")")
+    fi
+
+    if [ -z "$TOOLCHAIN_COMP" ]; then
+        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_NAME environment variable")
+        ANDROID_BUILD_FAIL+=("  (eg. \"armv7a-linux-androideabi\")")
+    fi
+
+    if [ -z "$TOOLCHAIN_CXXSTL" ]; then
+        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_CXXSTL environment variable")
+        ANDROID_BUILD_FAIL+=("  (eg. \"armeabi-v7a\")")
     fi
 
     if [ -z "$TOOLCHAIN_ARCH" ]; then
@@ -260,7 +300,7 @@ function android_build_env {
     ##
     # Set up some local variables and check them
 
-    ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-9/arch-${TOOLCHAIN_ARCH}"
+    ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
 
     if [ ! -d "$ANDROID_BUILD_SYSROOT" ]; then
         ANDROID_BUILD_FAIL+=("The ANDROID_BUILD_SYSROOT directory does not exist")
@@ -278,18 +318,14 @@ function android_build_env {
 }
 
 function _android_build_opts_process_binaries {
-    local CPP="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-cpp"
-    local CC="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-gcc"
-    local CXX="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-g++"
+    local TOOLCHAIN="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}"
+    local CC="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang"
+    local CXX="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang++"
     local LD="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ld"
     local AS="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-as"
     local AR="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar"
     local RANLIB="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ranlib"
-
-    if [ ! -x "${CPP}" ]; then
-        ANDROID_BUILD_FAIL+=("The CPP binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${CPP}")
-    fi
+    local STRIP="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-strip"
 
     if [ ! -x "${CC}" ]; then
         ANDROID_BUILD_FAIL+=("The CC binary does not exist or is not executable")
@@ -321,82 +357,34 @@ function _android_build_opts_process_binaries {
         ANDROID_BUILD_FAIL+=("  ${RANLIB}")
     fi
 
-    ANDROID_BUILD_OPTS+=("CPP=${CPP}")
+    if [ ! -x "${STRIP}" ]; then
+        ANDROID_BUILD_FAIL+=("The STRIP binary does not exist or is not executable")
+        ANDROID_BUILD_FAIL+=("  ${STRIP}")
+    fi
+
+    ANDROID_BUILD_OPTS+=("TOOLCHAIN=${TOOLCHAIN}")
     ANDROID_BUILD_OPTS+=("CC=${CC}")
     ANDROID_BUILD_OPTS+=("CXX=${CXX}")
     ANDROID_BUILD_OPTS+=("LD=${LD}")
     ANDROID_BUILD_OPTS+=("AS=${AS}")
     ANDROID_BUILD_OPTS+=("AR=${AR}")
     ANDROID_BUILD_OPTS+=("RANLIB=${RANLIB}")
+    ANDROID_BUILD_OPTS+=("STRIP=${STRIP}")
 
     android_build_check_fail
-}
-
-function _android_build_opts_process_cxx_stl {
-    case "${ANDROID_BUILD_CXXSTL}" in
-    stlport_static)
-        LIBS+=" -lstlport_static"
-        CPPFLAGS+=" -I${ANDROID_NDK_ROOT}/sources/cxx-stl/stlport/stlport"
-        case "${TOOLCHAIN_ARCH}" in
-        arm)
-            LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/stlport/libs/armeabi"
-        ;;
-        x86)
-            LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/stlport/libs/x86"
-        ;;
-        mips)
-            LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/stlport/libs/mips"
-        ;;
-        *)
-            ANDROID_BUILD_FAIL+=("Unknown combination for ANDROID_BUILD_CXXSTL and TOOLCHAIN_ARCH")
-            ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_CXXSTL}")
-            ANDROID_BUILD_FAIL+=("  ${TOOLCHAIN_ARCH}")
-        ;;
-        esac
-    ;;
-    gnustl_shared_49)
-        LIBS+=" -lgnustl_shared"
-        CPPFLAGS+=" -I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/include"
-        case "${TOOLCHAIN_ARCH}" in
-        arm)
-            LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi"
-            CPPFLAGS+=" -I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi/include"
-        ;;
-        x86)
-            LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86"
-            CPPFLAGS+=" -I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/include"
-        ;;
-        mips)
-            LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/mips"
-            CPPFLAGS+=" -I${ANDROID_NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/mips/include"
-        ;;
-        *)
-            ANDROID_BUILD_FAIL+=("Unknown combination for ANDROID_BUILD_CXXSTL and TOOLCHAIN_ARCH")
-            ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_CXXSTL}")
-            ANDROID_BUILD_FAIL+=("  ${TOOLCHAIN_ARCH}")
-        ;;
-        esac
-    ;;
-    '');;
-    *)
-        ANDROID_BUILD_FAIL+=("Unknown value for ANDROID_BUILD_CXXSTL")
-        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_CXXSTL}")
-    ;;
-    esac
 }
 
 # Set the ANDROID_BUILD_OPTS variable to a bash array of configure options
 function android_build_opts {
     ANDROID_BUILD_OPTS=()
 
-    local CFLAGS="--sysroot=${ANDROID_BUILD_SYSROOT} -I${ANDROID_BUILD_PREFIX}/include"
-    local CPPFLAGS="--sysroot=${ANDROID_BUILD_SYSROOT} -I${ANDROID_BUILD_PREFIX}/include"
-    local CXXFLAGS="--sysroot=${ANDROID_BUILD_SYSROOT} -I${ANDROID_BUILD_PREFIX}/include"
-    local LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
-    local LIBS="-lc -lgcc -ldl"
-
     _android_build_opts_process_binaries
-    _android_build_opts_process_cxx_stl
+
+    local LIBS="-lc -lgcc -ldl -lm -llog -lc++_shared"
+    local LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
+    LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TOOLCHAIN_CXXSTL}"
+    CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
+    CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
 
     ANDROID_BUILD_OPTS+=("CFLAGS=${CFLAGS} ${ANDROID_BUILD_EXTRA_CFLAGS}")
     ANDROID_BUILD_OPTS+=("CPPFLAGS=${CPPFLAGS} ${ANDROID_BUILD_EXTRA_CPPFLAGS}")
@@ -404,7 +392,7 @@ function android_build_opts {
     ANDROID_BUILD_OPTS+=("LDFLAGS=${LDFLAGS} ${ANDROID_BUILD_EXTRA_LDFLAGS}")
     ANDROID_BUILD_OPTS+=("LIBS=${LIBS} ${ANDROID_BUILD_EXTRA_LIBS}")
 
-    ANDROID_BUILD_OPTS+=("PKG_CONFIG_LIBDIR=${ANDROID_NDK_ROOT}/prebuilt/linux-x86_64/lib/pkgconfig")
+    ANDROID_BUILD_OPTS+=("PKG_CONFIG_LIBDIR=${ANDROID_NDK_ROOT}/prebuilt/${HOST_PLATFORM}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_PATH=${ANDROID_BUILD_PREFIX}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_SYSROOT_DIR=${ANDROID_BUILD_SYSROOT}")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_DIR=")


### PR DESCRIPTION
Solution: Migrate build scripts from Android NDK r11c to r20.
- Standalone toolchain
- Migration from GCC to Clang
- Migration from libgnustl to libc++
- Dropped support for API level below 16 (Android 4.1), previously it was API level 9 (Android 2.3)
- Dropped support for mips architecture
- The build script now start the build of all 4 Android architectures (arm, arm64, x86, x86_64)