### PR TITLE
Problem: czmq cannot be used as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
 file(REMOVE "${SOURCE_DIR}/src/platform.h")
 
-file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
+file(WRITE "${PROJECT_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -57,7 +57,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file("${CMAKE_BINARY_DIR}/platform.h.in" "${CMAKE_BINARY_DIR}/platform.h")
+configure_file("${PROJECT_BINARY_DIR}/platform.h.in" "${PROJECT_BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
@@ -143,17 +143,17 @@ set(TEST_CLASSES
 
 add_custom_target(
     copy-selftest-ro ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/selftest-ro ${CMAKE_BINARY_DIR}/src/selftest-ro
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/src/selftest-ro ${PROJECT_BINARY_DIR}/src/selftest-ro
 )
 
 add_custom_target(
     make-selftest-rw ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/src/selftest-rw
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/src/selftest-rw
 )
 
 set_directory_properties(
     PROPERTIES
-    ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_BINARY_DIR}/src/selftest-ro;${CMAKE_BINARY_DIR}/src/selftest-rw"
+    ADDITIONAL_MAKE_CLEAN_FILES "${PROJECT_BINARY_DIR}/src/selftest-ro;${PROJECT_BINARY_DIR}/src/selftest-rw"
 )
 
 foreach(TEST_CLASS ${TEST_CLASSES})
@@ -178,18 +178,18 @@ include(CTest)
 ########################################################################
 add_custom_target (distclean @echo Cleaning for source distribution)
 
-set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
-                    ${CMAKE_BINARY_DIR}/cmake_install.cmake
-                    ${CMAKE_BINARY_DIR}/Makefile
-                    ${CMAKE_BINARY_DIR}/CMakeFiles
-                    ${CMAKE_BINARY_DIR}/CTestTestfile.cmake
-                    ${CMAKE_BINARY_DIR}/DartConfiguration.tcl
-                    ${CMAKE_BINARY_DIR}/Testing
-                    ${CMAKE_BINARY_DIR}/compile_commands.json
-                    ${CMAKE_BINARY_DIR}/platform.h
-                    ${CMAKE_BINARY_DIR}/src/libzproject.pc
-                    ${CMAKE_BINARY_DIR}/src/libzproject.so
-                    ${CMAKE_BINARY_DIR}/src/zproject_selftest
+set(cmake_generated ${PROJECT_BINARY_DIR}/CMakeCache.txt
+                    ${PROJECT_BINARY_DIR}/cmake_install.cmake
+                    ${PROJECT_BINARY_DIR}/Makefile
+                    ${PROJECT_BINARY_DIR}/CMakeFiles
+                    ${PROJECT_BINARY_DIR}/CTestTestfile.cmake
+                    ${PROJECT_BINARY_DIR}/DartConfiguration.tcl
+                    ${PROJECT_BINARY_DIR}/Testing
+                    ${PROJECT_BINARY_DIR}/compile_commands.json
+                    ${PROJECT_BINARY_DIR}/platform.h
+                    ${PROJECT_BINARY_DIR}/src/libzproject.pc
+                    ${PROJECT_BINARY_DIR}/src/libzproject.so
+                    ${PROJECT_BINARY_DIR}/src/zproject_selftest
 )
 
 add_custom_command(

--- a/builds/cmake/Modules/ClangFormat.cmake
+++ b/builds/cmake/Modules/ClangFormat.cmake
@@ -3,15 +3,15 @@
 # get all project files
 file(GLOB_RECURSE ALL_SOURCE_FILES
      RELATIVE ${CMAKE_CURRENT_BINARY_DIR}
-     ${CMAKE_SOURCE_DIR}/src/*.c ${CMAKE_SOURCE_DIR}/src/*.cc ${CMAKE_SOURCE_DIR}/src/*.cpp
-     ${CMAKE_SOURCE_DIR}/src/*.h ${CMAKE_SOURCE_DIR}/src/*.hpp
-     ${CMAKE_SOURCE_DIR}/tests/*.c ${CMAKE_SOURCE_DIR}/tests/*.cc ${CMAKE_SOURCE_DIR}/tests/*.cpp
-     ${CMAKE_SOURCE_DIR}/tests/*.h ${CMAKE_SOURCE_DIR}/tests/*.hpp
-     ${CMAKE_SOURCE_DIR}/perf/*.c ${CMAKE_SOURCE_DIR}/perf/*.cc ${CMAKE_SOURCE_DIR}/perf/*.cpp
-     ${CMAKE_SOURCE_DIR}/perf/*.h ${CMAKE_SOURCE_DIR}/perf/*.hpp
-     ${CMAKE_SOURCE_DIR}/tools/*.c ${CMAKE_SOURCE_DIR}/tools/*.cc ${CMAKE_SOURCE_DIR}/tools/*.cpp
-     ${CMAKE_SOURCE_DIR}/tools/*.h ${CMAKE_SOURCE_DIR}/tools/*.hpp
-     ${CMAKE_SOURCE_DIR}/include/*.h ${CMAKE_SOURCE_DIR}/include/*.hpp
+     ${PROJECT_SOURCE_DIR}/src/*.c ${PROJECT_SOURCE_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/src/*.cpp
+     ${PROJECT_SOURCE_DIR}/src/*.h ${PROJECT_SOURCE_DIR}/src/*.hpp
+     ${PROJECT_SOURCE_DIR}/tests/*.c ${PROJECT_SOURCE_DIR}/tests/*.cc ${PROJECT_SOURCE_DIR}/tests/*.cpp
+     ${PROJECT_SOURCE_DIR}/tests/*.h ${PROJECT_SOURCE_DIR}/tests/*.hpp
+     ${PROJECT_SOURCE_DIR}/perf/*.c ${PROJECT_SOURCE_DIR}/perf/*.cc ${PROJECT_SOURCE_DIR}/perf/*.cpp
+     ${PROJECT_SOURCE_DIR}/perf/*.h ${PROJECT_SOURCE_DIR}/perf/*.hpp
+     ${PROJECT_SOURCE_DIR}/tools/*.c ${PROJECT_SOURCE_DIR}/tools/*.cc ${PROJECT_SOURCE_DIR}/tools/*.cpp
+     ${PROJECT_SOURCE_DIR}/tools/*.h ${PROJECT_SOURCE_DIR}/tools/*.hpp
+     ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/*.hpp
     )
 
 if("${CLANG_FORMAT}" STREQUAL "")

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -95,7 +95,7 @@ endif()
 
 file(REMOVE "${SOURCE_DIR}/src/platform.h")
 
-file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
+file(WRITE "${PROJECT_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -103,7 +103,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file("${CMAKE_BINARY_DIR}/platform.h.in" "${CMAKE_BINARY_DIR}/platform.h")
+configure_file("${PROJECT_BINARY_DIR}/platform.h.in" "${PROJECT_BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
@@ -257,7 +257,7 @@ install(FILES ${$(project.prefix)_headers} DESTINATION include)
 ########################################################################
 
 
-include_directories("${SOURCE_DIR}/src" "${SOURCE_DIR}/include" "${CMAKE_BINARY_DIR}")
+include_directories("${SOURCE_DIR}/src" "${SOURCE_DIR}/include" "${PROJECT_BINARY_DIR}")
 set ($(project.linkname)_sources
 .for class where !draft
 .   if project.use_cxx
@@ -541,17 +541,17 @@ ENDIF (ENABLE_DRAFTS)
 
 add_custom_target(
     copy-selftest-ro ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/selftest-ro ${CMAKE_BINARY_DIR}/src/selftest-ro
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/src/selftest-ro ${PROJECT_BINARY_DIR}/src/selftest-ro
 )
 
 add_custom_target(
     make-selftest-rw ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/src/selftest-rw
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/src/selftest-rw
 )
 
 set_directory_properties(
     PROPERTIES
-    ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_BINARY_DIR}/src/selftest-ro;${CMAKE_BINARY_DIR}/src/selftest-rw"
+    ADDITIONAL_MAKE_CLEAN_FILES "${PROJECT_BINARY_DIR}/src/selftest-ro;${PROJECT_BINARY_DIR}/src/selftest-rw"
 )
 
 foreach(TEST_CLASS ${TEST_CLASSES})
@@ -576,20 +576,20 @@ include(CTest)
 ########################################################################
 add_custom_target (distclean @echo Cleaning for source distribution)
 
-set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
-                    ${CMAKE_BINARY_DIR}/cmake_install.cmake
-                    ${CMAKE_BINARY_DIR}/Makefile
-                    ${CMAKE_BINARY_DIR}/CMakeFiles
-                    ${CMAKE_BINARY_DIR}/CTestTestfile.cmake
-                    ${CMAKE_BINARY_DIR}/DartConfiguration.tcl
-                    ${CMAKE_BINARY_DIR}/Testing
-                    ${CMAKE_BINARY_DIR}/compile_commands.json
-                    ${CMAKE_BINARY_DIR}/platform.h
-                    ${CMAKE_BINARY_DIR}/src/$(project.libname).pc
-                    ${CMAKE_BINARY_DIR}/src/$(project.libname).so
-                    ${CMAKE_BINARY_DIR}/src/$(project.name)_selftest
+set(cmake_generated ${PROJECT_BINARY_DIR}/CMakeCache.txt
+                    ${PROJECT_BINARY_DIR}/cmake_install.cmake
+                    ${PROJECT_BINARY_DIR}/Makefile
+                    ${PROJECT_BINARY_DIR}/CMakeFiles
+                    ${PROJECT_BINARY_DIR}/CTestTestfile.cmake
+                    ${PROJECT_BINARY_DIR}/DartConfiguration.tcl
+                    ${PROJECT_BINARY_DIR}/Testing
+                    ${PROJECT_BINARY_DIR}/compile_commands.json
+                    ${PROJECT_BINARY_DIR}/platform.h
+                    ${PROJECT_BINARY_DIR}/src/$(project.libname).pc
+                    ${PROJECT_BINARY_DIR}/src/$(project.libname).so
+                    ${PROJECT_BINARY_DIR}/src/$(project.name)_selftest
 .for project.main
-                    ${CMAKE_BINARY_DIR}/src/$(main.name)
+                    ${PROJECT_BINARY_DIR}/src/$(main.name)
 .endfor
 )
 
@@ -990,15 +990,15 @@ echo "==="
 # get all project files
 file(GLOB_RECURSE ALL_SOURCE_FILES
      RELATIVE ${CMAKE_CURRENT_BINARY_DIR}
-     ${CMAKE_SOURCE_DIR}/src/*.c ${CMAKE_SOURCE_DIR}/src/*.cc ${CMAKE_SOURCE_DIR}/src/*.cpp
-     ${CMAKE_SOURCE_DIR}/src/*.h ${CMAKE_SOURCE_DIR}/src/*.hpp
-     ${CMAKE_SOURCE_DIR}/tests/*.c ${CMAKE_SOURCE_DIR}/tests/*.cc ${CMAKE_SOURCE_DIR}/tests/*.cpp
-     ${CMAKE_SOURCE_DIR}/tests/*.h ${CMAKE_SOURCE_DIR}/tests/*.hpp
-     ${CMAKE_SOURCE_DIR}/perf/*.c ${CMAKE_SOURCE_DIR}/perf/*.cc ${CMAKE_SOURCE_DIR}/perf/*.cpp
-     ${CMAKE_SOURCE_DIR}/perf/*.h ${CMAKE_SOURCE_DIR}/perf/*.hpp
-     ${CMAKE_SOURCE_DIR}/tools/*.c ${CMAKE_SOURCE_DIR}/tools/*.cc ${CMAKE_SOURCE_DIR}/tools/*.cpp
-     ${CMAKE_SOURCE_DIR}/tools/*.h ${CMAKE_SOURCE_DIR}/tools/*.hpp
-     ${CMAKE_SOURCE_DIR}/include/*.h ${CMAKE_SOURCE_DIR}/include/*.hpp
+     ${PROJECT_SOURCE_DIR}/src/*.c ${PROJECT_SOURCE_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/src/*.cpp
+     ${PROJECT_SOURCE_DIR}/src/*.h ${PROJECT_SOURCE_DIR}/src/*.hpp
+     ${PROJECT_SOURCE_DIR}/tests/*.c ${PROJECT_SOURCE_DIR}/tests/*.cc ${PROJECT_SOURCE_DIR}/tests/*.cpp
+     ${PROJECT_SOURCE_DIR}/tests/*.h ${PROJECT_SOURCE_DIR}/tests/*.hpp
+     ${PROJECT_SOURCE_DIR}/perf/*.c ${PROJECT_SOURCE_DIR}/perf/*.cc ${PROJECT_SOURCE_DIR}/perf/*.cpp
+     ${PROJECT_SOURCE_DIR}/perf/*.h ${PROJECT_SOURCE_DIR}/perf/*.hpp
+     ${PROJECT_SOURCE_DIR}/tools/*.c ${PROJECT_SOURCE_DIR}/tools/*.cc ${PROJECT_SOURCE_DIR}/tools/*.cpp
+     ${PROJECT_SOURCE_DIR}/tools/*.h ${PROJECT_SOURCE_DIR}/tools/*.hpp
+     ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/*.hpp
     )
 
 if("${CLANG_FORMAT}" STREQUAL "")


### PR DESCRIPTION
Solution: Use PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR instead of
CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR

See zeromq/czmq#2033