### PR TITLE
Fix 'not key in', should be 'key not in'

### DIFF
--- a/zproject_python_cffi.gsl
+++ b/zproject_python_cffi.gsl
@@ -334,7 +334,7 @@ function generate_binding
     >    for libname in libs:
     >        foo = kwargs (libname)
     >        for key, value in foo.items ():
-    >            if not key in ret:
+    >            if key not in ret:
     >                ret [key] = value
     >            else:
     >                ret [key].extend (value)


### PR DESCRIPTION
`not key in ret` checks to see if the boolean value `not key` is in `ret`. `key not in ret` checks to see if the string value `key` is not in `ret`.