### PR TITLE
Recursive CI builds for dependencies

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -719,7 +719,10 @@ if \
     if [ -e ci_dependencies.sh ]; then
         PROPAGATED_BRANCH="`git branch | grep \* | cut -d ' ' -f2`"
         DEFAULT_BRANCH="`git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`"
-        if [ "x$PROPAGATED_BRANCH" = "x$PROPAGATED_BRANCH" ]; then
+        if [ "x$REQUESTED_BRANCH" = "x" ]; then
+            echo "`date`: INFO: Building prerequisites of '$(use.project)' using ci_dependencies.sh the default branch..." >&2
+            ($CI_TIME source ./ci_dependencies.sh)
+        elif [ "x$PROPAGATED_BRANCH" = "x$DEFAULT_BRANCH" ]; then
             echo "`date`: INFO: Building prerequisites of '$(use.project)' using ci_dependencies.sh the default branch..." >&2
             ($CI_TIME source ./ci_dependencies.sh)
         else
@@ -969,7 +972,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     fi
     
     DEFAULT_BRANCH="`git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`"
-    if [ "x$PROPAGATED_BRANCH" = "x$PROPAGATED_BRANCH" ]; then
+    if [ "x$PROPAGATED_BRANCH" = "x$DEFAULT_BRANCH" ]; then
         [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh..."
         (source ./ci_dependencies.sh)
     else

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -616,11 +616,11 @@ $(project.GENERATED_WARNING_HEADER)
 
 set -e
 
-if [ -d "./tmp-deps" ]; then
-    # Checkout/unpack and build area for dependencies
-    rm -rf ./tmp-deps
+if [ -z "$DEPENDENCIES_DIR" ]; then
+    export DEPENDENCIES_DIR="`pwd`/tmp-deps"
 fi
-mkdir -p tmp-deps
+mkdir -p "$DEPENDENCIES_DIR"
+cd "$DEPENDENCIES_DIR"
 
 # Clone and build dependencies, if not yet installed to Travis env as DEBs
 # or MacOS packages; other OSes are not currently supported by Travis cloud
@@ -638,7 +638,8 @@ if \
 .   else
 \! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
 .   endif
-       (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
+       (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) || \\
+       ([ -e "$(use.project)" ]) \\
 ; then
     echo ""
 .    if ! defined (use.repository) & ! defined (use.tarball)
@@ -649,13 +650,11 @@ if \
     BASE_PWD=${PWD}
 .        if defined (use.tarball)
     echo "`date`: INFO: Building prerequisite '$(use.project)' from tarball..." >&2
-    cd ./tmp-deps
     $CI_TIME wget $(use.tarball)
     tar -xzf \$(basename "$(use.tarball)")
     cd \$(basename "$(use.tarball)" .tar.gz) || exit \$?
 .        elsif defined (use.repository)
     echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
-    cd ./tmp-deps
 .            if defined (use.release)
     $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .            elsif project.travis_implicit_releases ?= 1
@@ -890,6 +889,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     CONFIG_OPTS+=("--with-docs=no")
 
     # Build dependencies, if needed
+    export DEPENDENCIES_DIR="`pwd`/tmp-deps"
     (source ./ci_dependencies.sh)
 
     # Build and check this project; note that zprojects always have an autogen.sh

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -693,7 +693,7 @@ if \
     $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $FOLDER_NAME
 .            else
     if [ "x$REQUESTED_BRANCH" = "x" ]; then
-        echo "git clone -b $(use.repository) $FOLDER_NAME"
+        echo "git clone $(use.repository) $FOLDER_NAME"
         $CI_TIME git clone --quiet --depth 1 $(use.repository) $FOLDER_NAME
     else
         if git ls-remote --heads $(use.repository) | grep -q "$REQUESTED_BRANCH"; then
@@ -701,7 +701,7 @@ if \
             $CI_TIME git clone --quiet --depth 1 -b "$REQUESTED_BRANCH" $(use.repository) $FOLDER_NAME
         else
             echo "$REQUESTED_BRANCH not found for $(use.repository)"
-            echo "git clone -b $(use.repository) $FOLDER_NAME"
+            echo "git clone $(use.repository) $FOLDER_NAME"
             $CI_TIME git clone --quiet --depth 1 $(use.repository) $FOLDER_NAME
         fi
     fi  
@@ -718,8 +718,14 @@ if \
 .        endif
     if [ -e ci_dependencies.sh ]; then
         PROPAGATED_BRANCH="`git branch | grep \* | cut -d ' ' -f2`"
-        echo "`date`: INFO: Building prerequisites of '$(use.project)' using ci_dependencies.sh $PROPAGATED_BRANCH..." >&2
-        ($CI_TIME source ./ci_dependencies.sh $PROPAGATED_BRANCH)
+        DEFAULT_BRANCH="`git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`"
+        if [ "x$PROPAGATED_BRANCH" = "x$PROPAGATED_BRANCH" ]; then
+            echo "`date`: INFO: Building prerequisites of '$(use.project)' using ci_dependencies.sh the default branch..." >&2
+            ($CI_TIME source ./ci_dependencies.sh)
+        else
+            echo "`date`: INFO: Building prerequisites of '$(use.project)' using ci_dependencies.sh $PROPAGATED_BRANCH branch..." >&2
+            ($CI_TIME source ./ci_dependencies.sh $PROPAGATED_BRANCH)
+        fi
     fi
     if [ -e autogen.sh ]; then
         $CI_TIME ./autogen.sh 2> /dev/null
@@ -957,11 +963,18 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     export DEPENDENCIES_DIR="`pwd`/tmp-deps"
     GLOBAL_RELEASE="`head -n 1 .ci_global_release 2> /dev/null`"
     if [ "x$GLOBAL_RELEASE" = "x" ]; then
-      [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh $TRAVIS_BRANCH..."
-      (source ./ci_dependencies.sh $TRAVIS_BRANCH)
+      PROPAGATED_BRANCH="$TRAVIS_BRANCH"
     else
-    [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh $GLOBAL_RELEASE..."
-      (source ./ci_dependencies.sh $GLOBAL_RELEASE)
+      PROPAGATED_BRANCH="$GLOBAL_RELEASE"
+    fi
+    
+    DEFAULT_BRANCH="`git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`"
+    if [ "x$PROPAGATED_BRANCH" = "x$PROPAGATED_BRANCH" ]; then
+        [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh..."
+        (source ./ci_dependencies.sh)
+    else
+        [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh $PROPAGATED_BRANCH branch..."
+        (source ./ci_dependencies.sh $PROPAGATED_BRANCH)
     fi
 .else
     # Clone and build dependencies, if not yet installed to Travis env as DEBs

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -658,6 +658,8 @@ if \
     cd ./tmp-deps
 .            if defined (use.release)
     $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
+.            elsif project.travis_implicit_releases ?= 1
+    $CI_TIME git clone --quiet --depth 1 -b "$TRAVIS_BRANCH" $(use.repository) $(use.project)
 .            else
     $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
 .            endif
@@ -1001,6 +1003,8 @@ cd "$REPO_DIR/.."
 .for project.use where !optional & defined (use.repository)
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
+.   elsif project.travis_implicit_releases ?= 1
+git clone --quiet --depth 1 -b "$TRAVIS_BRANCH" $(use.repository) $(use.project)
 .   else
 git clone --quiet --depth 1 $(use.repository) $(use.project)
 .   endif

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -33,6 +33,11 @@ cache:
 os:
 - linux
 
+.if defined (project.travis_recursive_dependencies) & project.travis_recursive_dependencies ?= "true"
+#Sudo is need because we need to be able to install package for the depencies using apt-get
+sudo: required
+.endif
+
 # The default distro for env:/matrix:/* and unspecified-dist matrix:/* tests;
 # for the latter see also addons/apt/sources with the package repos in use.
 # See https://docs.travis-ci.com/user/reference/overview/ for up-to-date
@@ -609,7 +614,7 @@ deploy:
 .   echo "NOT regenerating an existing .travis.yml file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .
-.if defined (project.recursive_dependencies) & (project.recursive_dependencies = 'true')
+. if project.travis_recursive_dependencies ?= "true"
 .output "ci_dependencies.sh"
 #!/usr/bin/env bash
 
@@ -627,7 +632,7 @@ cd "$DEPENDENCIES_DIR"
 
 # Clone and build dependencies, if not yet installed to Travis env as DEBs
 # or MacOS packages; other OSes are not currently supported by Travis cloud
-[ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
+echo "`date`: Starting build of dependencies (if any) using ci_dependencies.sh $REQUESTED_BRANCH..."
 .for use
 
 # Start of recipe for dependency: $(use.project)
@@ -644,6 +649,31 @@ if \
        (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) || \\
        ([ -e "$(use.project)" ]) \\
 ; then
+.if ! defined (use.repository) & ! defined (use.tarball)
+.         if defined (use.debian_name)
+.             if !(use.debian_name = '')
+ echo "INFO: Get '$(use.project)' using apt-get $(use.debian_name)" >&2
+ sudo apt-get install $(use.debian_name) -y || exit \$? 
+.             endif
+.         elsif defined (use.libname)
+ echo "INFO: Get '$(use.project)' using apt-get $(string.replace (use.libname, "_|-"):lower)-dev" >&2
+ sudo apt-get install $(string.replace (use.libname, "_|-"):lower)-dev -y || exit \$? 
+.         else
+ echo "INFO: Get '$(use.project)' using apt-get $(string.replace (use.project, "_|-"))-dev" >&2
+ sudo apt-get install $(string.replace (use.project, "_|-"))-dev -y || exit \$? 
+.         endif
+.else
+. if defined (use.repository)
+.    if defined (use.release)
+ FOLDER_NAME="$(use.project)-$(use.release)"
+.    else
+ FOLDER_NAME="$(use.project)"
+.    endif
+
+ if [ -d "$FOLDER_NAME" ]; then
+    echo "$FOLDER_NAME already exist. Skipped." >&2
+ else
+. endif
     echo ""
 .    if ! defined (use.repository) & ! defined (use.tarball)
     echo "WARNING: Can not build prerequisite '$(use.project)'" >&2
@@ -659,19 +689,24 @@ if \
 .        elsif defined (use.repository)
     echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
 .            if defined (use.release)
-    $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
+    echo "git clone -b $(use.release:) $(use.repository) $FOLDER_NAME"
+    $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $FOLDER_NAME
 .            else
     if [ "x$REQUESTED_BRANCH" = "x" ]; then
-        $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+        echo "git clone -b $(use.repository) $FOLDER_NAME"
+        $CI_TIME git clone --quiet --depth 1 $(use.repository) $FOLDER_NAME
     else
         if git ls-remote --heads $(use.repository) | grep -q "$REQUESTED_BRANCH"; then
-            $CI_TIME git clone --quiet --depth 1 -b "$REQUESTED_BRANCH" $(use.repository) $(use.project)
+            echo "git clone -b "$REQUESTED_BRANCH" $(use.repository) $FOLDER_NAME"
+            $CI_TIME git clone --quiet --depth 1 -b "$REQUESTED_BRANCH" $(use.repository) $FOLDER_NAME
         else
-            $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+            echo "$REQUESTED_BRANCH not found for $(use.repository)"
+            echo "git clone -b $(use.repository) $FOLDER_NAME"
+            $CI_TIME git clone --quiet --depth 1 $(use.repository) $FOLDER_NAME
         fi
     fi  
 .            endif
-    cd ./$(use.project)
+    cd "./$FOLDER_NAME"
 .        endif
 .        if defined (use.builddir)
     cd ./$(use.builddir)
@@ -682,8 +717,9 @@ if \
         git --no-pager log --oneline -n1
 .        endif
     if [ -e ci_dependencies.sh ]; then
-        echo "`date`: INFO: Building prerequisites of '$(use.project)'..." >&2
-        ($CI_TIME source ./ci_dependencies.sh $REQUESTED_BRANCH)
+        PROPAGATED_BRANCH="`git branch | grep \* | cut -d ' ' -f2`"
+        echo "`date`: INFO: Building prerequisites of '$(use.project)' using ci_dependencies.sh $PROPAGATED_BRANCH..." >&2
+        ($CI_TIME source ./ci_dependencies.sh $PROPAGATED_BRANCH)
     fi
     if [ -e autogen.sh ]; then
         $CI_TIME ./autogen.sh 2> /dev/null
@@ -720,13 +756,19 @@ if \
 else
     CONFIG_OPTS+=("--with-$(use.libname)=yes")
 .    endif
+. if defined (use.repository)
 fi
+. endif
+.endif
+fi
+
 .endfor
+
 .close
 .chmod_x ("ci_dependencies.sh")
 .output ".ci_global_release"
-. if defined (project.global_release)
-$(project.global_release:)
+. if defined (project.travis_global_release)
+$(project.travis_global_release:)
 . endif
 .close
 .endif
@@ -766,7 +808,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         rm -rf ./tmp
     fi
     mkdir -p tmp
-. if !defined (project.recursive_dependencies) | ! (project.recursive_dependencies = 'true')   
+. if !defined (project.travis_recursive_dependencies) | ! (project.travis_recursive_dependencies ?= "true")   
     if [ -d "./tmp-deps" ]; then
         # Checkout/unpack and build area for dependencies
         rm -rf ./tmp-deps
@@ -910,13 +952,15 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     CONFIG_OPTS_COMMON=$CONFIG_OPTS
     CONFIG_OPTS+=("--with-docs=no")
 
-.if defined (project.recursive_dependencies) & (project.recursive_dependencies = 'true')
+.if defined (project.travis_recursive_dependencies) & (project.travis_recursive_dependencies ?= "true")
     # Build dependencies, if needed
     export DEPENDENCIES_DIR="`pwd`/tmp-deps"
     GLOBAL_RELEASE="`head -n 1 .ci_global_release 2> /dev/null`"
-    if [ "x$GLOBAL_RELEASE" = "x" ]; then 
+    if [ "x$GLOBAL_RELEASE" = "x" ]; then
+      [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh $TRAVIS_BRANCH..."
       (source ./ci_dependencies.sh $TRAVIS_BRANCH)
     else
+    [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any) using ./ci_dependencies.sh $GLOBAL_RELEASE..."
       (source ./ci_dependencies.sh $GLOBAL_RELEASE)
     fi
 .else

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -609,6 +609,111 @@ deploy:
 .   echo "NOT regenerating an existing .travis.yml file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .
+.output "ci_dependencies.sh"
+#!/usr/bin/env bash
+
+$(project.GENERATED_WARNING_HEADER)
+
+set -e
+
+if [ -d "./tmp-deps" ]; then
+    # Checkout/unpack and build area for dependencies
+    rm -rf ./tmp-deps
+fi
+mkdir -p tmp-deps
+
+# Clone and build dependencies, if not yet installed to Travis env as DEBs
+# or MacOS packages; other OSes are not currently supported by Travis cloud
+[ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
+.for use
+
+# Start of recipe for dependency: $(use.project)
+if \
+.      if defined (use.debian_name)
+.        if !(use.debian_name = '')
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
+.        endif
+.   elsif defined (use.libname)
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
+.   else
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
+.   endif
+       (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
+; then
+    echo ""
+.    if ! defined (use.repository) & ! defined (use.tarball)
+    echo "WARNING: Can not build prerequisite '$(use.project)'" >&2
+    echo "because neither tarball nor repository sources are known for it," >&2
+    echo "and it was not installed as a package; this may cause the test to fail!" >&2
+.    else
+    BASE_PWD=${PWD}
+.        if defined (use.tarball)
+    echo "`date`: INFO: Building prerequisite '$(use.project)' from tarball..." >&2
+    cd ./tmp-deps
+    $CI_TIME wget $(use.tarball)
+    tar -xzf \$(basename "$(use.tarball)")
+    cd \$(basename "$(use.tarball)" .tar.gz) || exit \$?
+.        elsif defined (use.repository)
+    echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
+    cd ./tmp-deps
+.            if defined (use.release)
+    $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
+.            else
+    $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+.            endif
+    cd ./$(use.project)
+.        endif
+.        if defined (use.builddir)
+    cd ./$(use.builddir)
+.        endif
+    CCACHE_BASEDIR=${PWD}
+    export CCACHE_BASEDIR
+.        if defined (use.repository) & ! defined (use.tarball)
+        git --no-pager log --oneline -n1
+.        endif
+    if [ -e ci_dependencies.sh ]; then
+        echo "`date`: INFO: Building prerequisites of '$(use.project)'..." >&2
+        ($CI_TIME source ./ci_dependencies.sh)
+    fi
+    if [ -e autogen.sh ]; then
+        $CI_TIME ./autogen.sh 2> /dev/null
+    fi
+    if [ -e buildconf ]; then
+        $CI_TIME ./buildconf 2> /dev/null
+    fi
+    if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+        $CI_TIME libtoolize --copy --force && \\
+        $CI_TIME aclocal -I . && \\
+        $CI_TIME autoheader && \\
+        $CI_TIME automake --add-missing --copy && \\
+        $CI_TIME autoconf || \\
+        $CI_TIME autoreconf -fiv
+    fi
+.        if count(use.add_config_opts) > 0
+    ( # Custom additional options for $(use.project)
+.            for use.add_config_opts as add_cfgopt
+        CONFIG_OPTS+=("$(add_cfgopt)")
+.            endfor
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    )
+.        else
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.        endif
+    $CI_TIME make -j4
+    $CI_TIME make install
+    cd "${BASE_PWD}"
+.        if use.optional
+    CONFIG_OPTS+=("--with-$(use.libname)=yes")
+.        endif
+.    endif
+.    if use.optional
+else
+    CONFIG_OPTS+=("--with-$(use.libname)=yes")
+.    endif
+fi
+.endfor
+.close
+.chmod_x ("ci_dependencies.sh")
 .output "ci_build.sh"
 #!/usr/bin/env bash
 
@@ -644,11 +749,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         # Proto installation area for this project and its deps
         rm -rf ./tmp
     fi
-    if [ -d "./tmp-deps" ]; then
-        # Checkout/unpack and build area for dependencies
-        rm -rf ./tmp-deps
-    fi
-    mkdir -p tmp tmp-deps
+    mkdir -p tmp
     BUILD_PREFIX=$PWD/tmp
 
     PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'`"
@@ -786,92 +887,8 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     CONFIG_OPTS_COMMON=$CONFIG_OPTS
     CONFIG_OPTS+=("--with-docs=no")
 
-    # Clone and build dependencies, if not yet installed to Travis env as DEBs
-    # or MacOS packages; other OSes are not currently supported by Travis cloud
-    [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
-.   for use
-
-    # Start of recipe for dependency: $(use.project)
-    if \
-.      if defined (use.debian_name)
-.           if !(use.debian_name = '')
-\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
-.           endif
-.      elsif defined (use.libname)
-\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
-.      else
-\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
-.      endif
-           (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
-    ; then
-        echo ""
-.       if ! defined (use.repository) & ! defined (use.tarball)
-        echo "WARNING: Can not build prerequisite '$(use.project)'" >&2
-        echo "because neither tarball nor repository sources are known for it," >&2
-        echo "and it was not installed as a package; this may cause the test to fail!" >&2
-.       else
-        BASE_PWD=${PWD}
-.           if defined (use.tarball)
-        echo "`date`: INFO: Building prerequisite '$(use.project)' from tarball..." >&2
-        cd ./tmp-deps
-        $CI_TIME wget $(use.tarball)
-        tar -xzf \$(basename "$(use.tarball)")
-        cd \$(basename "$(use.tarball)" .tar.gz) || exit \$?
-.           elsif defined (use.repository)
-        echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
-        cd ./tmp-deps
-.               if defined (use.release)
-        $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
-.               else
-        $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
-.               endif
-        cd ./$(use.project)
-.           endif
-.           if defined (use.builddir)
-        cd ./$(use.builddir)
-.           endif
-        CCACHE_BASEDIR=${PWD}
-        export CCACHE_BASEDIR
-.           if defined (use.repository) & ! defined (use.tarball)
-        git --no-pager log --oneline -n1
-.           endif
-        if [ -e autogen.sh ]; then
-            $CI_TIME ./autogen.sh 2> /dev/null
-        fi
-        if [ -e buildconf ]; then
-            $CI_TIME ./buildconf 2> /dev/null
-        fi
-        if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-            $CI_TIME libtoolize --copy --force && \\
-            $CI_TIME aclocal -I . && \\
-            $CI_TIME autoheader && \\
-            $CI_TIME automake --add-missing --copy && \\
-            $CI_TIME autoconf || \\
-            $CI_TIME autoreconf -fiv
-        fi
-.           if count(use.add_config_opts) > 0
-        ( # Custom additional options for $(use.project)
-.               for use.add_config_opts as add_cfgopt
-            CONFIG_OPTS+=("$(add_cfgopt)")
-.               endfor
-            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
-        )
-.           else
-        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
-.           endif
-        $CI_TIME make -j4
-        $CI_TIME make install
-        cd "${BASE_PWD}"
-.           if use.optional
-        CONFIG_OPTS+=("--with-$(use.libname)=yes")
-.           endif
-.       endif
-.       if use.optional
-    else
-        CONFIG_OPTS+=("--with-$(use.libname)=yes")
-.       endif
-    fi
-.   endfor
+    # Build dependencies, if needed
+    (source ./ci_dependencies.sh)
 
     # Build and check this project; note that zprojects always have an autogen.sh
     echo ""

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -609,10 +609,13 @@ deploy:
 .   echo "NOT regenerating an existing .travis.yml file; you might want to move yours out of the way and re-generate the project again to get updated settings"
 .endif
 .
+.if defined (project.recursive_dependencies) & (project.recursive_dependencies = 'true')
 .output "ci_dependencies.sh"
 #!/usr/bin/env bash
 
 $(project.GENERATED_WARNING_HEADER)
+
+REQUESTED_BRANCH=$1
 
 set -e
 
@@ -657,10 +660,16 @@ if \
     echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
 .            if defined (use.release)
     $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
-.            elsif project.travis_implicit_releases ?= 1
-    $CI_TIME git clone --quiet --depth 1 -b "$TRAVIS_BRANCH" $(use.repository) $(use.project)
 .            else
-    $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+    if [ "x$REQUESTED_BRANCH" = "x" ]; then
+        $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+    else
+        if git ls-remote --heads $(use.repository) | grep -q "$REQUESTED_BRANCH"; then
+            $CI_TIME git clone --quiet --depth 1 -b "$REQUESTED_BRANCH" $(use.repository) $(use.project)
+        else
+            $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+        fi
+    fi  
 .            endif
     cd ./$(use.project)
 .        endif
@@ -674,7 +683,7 @@ if \
 .        endif
     if [ -e ci_dependencies.sh ]; then
         echo "`date`: INFO: Building prerequisites of '$(use.project)'..." >&2
-        ($CI_TIME source ./ci_dependencies.sh)
+        ($CI_TIME source ./ci_dependencies.sh $REQUESTED_BRANCH)
     fi
     if [ -e autogen.sh ]; then
         $CI_TIME ./autogen.sh 2> /dev/null
@@ -715,6 +724,12 @@ fi
 .endfor
 .close
 .chmod_x ("ci_dependencies.sh")
+.output ".ci_global_release"
+. if defined (project.global_release)
+$(project.global_release:)
+. endif
+.close
+.endif
 .output "ci_build.sh"
 #!/usr/bin/env bash
 
@@ -751,6 +766,13 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         rm -rf ./tmp
     fi
     mkdir -p tmp
+. if !defined (project.recursive_dependencies) | ! (project.recursive_dependencies = 'true')   
+    if [ -d "./tmp-deps" ]; then
+        # Checkout/unpack and build area for dependencies
+        rm -rf ./tmp-deps
+    fi
+    mkdir -p tmp-deps
+.endif
     BUILD_PREFIX=$PWD/tmp
 
     PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'`"
@@ -888,9 +910,103 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
     CONFIG_OPTS_COMMON=$CONFIG_OPTS
     CONFIG_OPTS+=("--with-docs=no")
 
+.if defined (project.recursive_dependencies) & (project.recursive_dependencies = 'true')
     # Build dependencies, if needed
     export DEPENDENCIES_DIR="`pwd`/tmp-deps"
-    (source ./ci_dependencies.sh)
+    GLOBAL_RELEASE="`head -n 1 .ci_global_release 2> /dev/null`"
+    if [ "x$GLOBAL_RELEASE" = "x" ]; then 
+      (source ./ci_dependencies.sh $TRAVIS_BRANCH)
+    else
+      (source ./ci_dependencies.sh $GLOBAL_RELEASE)
+    fi
+.else
+    # Clone and build dependencies, if not yet installed to Travis env as DEBs
+    # or MacOS packages; other OSes are not currently supported by Travis cloud
+    [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
+.   for use
+
+    # Start of recipe for dependency: $(use.project)
+    if \
+.      if defined (use.debian_name)
+.           if !(use.debian_name = '')
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
+.           endif
+.      elsif defined (use.libname)
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.libname)-dev >/dev/null 2>&1) || \\
+.      else
+\! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)-dev >/dev/null 2>&1) || \\
+.      endif
+           (command -v brew >/dev/null 2>&1 && brew ls --versions $(use.project) >/dev/null 2>&1) \\
+    ; then
+        echo ""
+.       if ! defined (use.repository) & ! defined (use.tarball)
+        echo "WARNING: Can not build prerequisite '$(use.project)'" >&2
+        echo "because neither tarball nor repository sources are known for it," >&2
+        echo "and it was not installed as a package; this may cause the test to fail!" >&2
+.       else
+        BASE_PWD=${PWD}
+.           if defined (use.tarball)
+        echo "`date`: INFO: Building prerequisite '$(use.project)' from tarball..." >&2
+        cd ./tmp-deps
+        $CI_TIME wget $(use.tarball)
+        tar -xzf \$(basename "$(use.tarball)")
+        cd \$(basename "$(use.tarball)" .tar.gz) || exit \$?
+.           elsif defined (use.repository)
+        echo "`date`: INFO: Building prerequisite '$(use.project)' from Git repository..." >&2
+        cd ./tmp-deps
+.               if defined (use.release)
+        $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
+.               else
+        $CI_TIME git clone --quiet --depth 1 $(use.repository) $(use.project)
+.               endif
+        cd ./$(use.project)
+.           endif
+.           if defined (use.builddir)
+        cd ./$(use.builddir)
+.           endif
+        CCACHE_BASEDIR=${PWD}
+        export CCACHE_BASEDIR
+.           if defined (use.repository) & ! defined (use.tarball)
+        git --no-pager log --oneline -n1
+.           endif
+        if [ -e autogen.sh ]; then
+            $CI_TIME ./autogen.sh 2> /dev/null
+        fi
+        if [ -e buildconf ]; then
+            $CI_TIME ./buildconf 2> /dev/null
+        fi
+        if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
+            $CI_TIME libtoolize --copy --force && \\
+            $CI_TIME aclocal -I . && \\
+            $CI_TIME autoheader && \\
+            $CI_TIME automake --add-missing --copy && \\
+            $CI_TIME autoconf || \\
+            $CI_TIME autoreconf -fiv
+        fi
+.           if count(use.add_config_opts) > 0
+        ( # Custom additional options for $(use.project)
+.               for use.add_config_opts as add_cfgopt
+            CONFIG_OPTS+=("$(add_cfgopt)")
+.               endfor
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        )
+.           else
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+.           endif
+        $CI_TIME make -j4
+        $CI_TIME make install
+        cd "${BASE_PWD}"
+.           if use.optional
+        CONFIG_OPTS+=("--with-$(use.libname)=yes")
+.           endif
+.       endif
+.       if use.optional
+    else
+        CONFIG_OPTS+=("--with-$(use.libname)=yes")
+.       endif
+    fi
+.   endfor
+.endif
 
     # Build and check this project; note that zprojects always have an autogen.sh
     echo ""
@@ -1003,8 +1119,6 @@ cd "$REPO_DIR/.."
 .for project.use where !optional & defined (use.repository)
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
-.   elsif project.travis_implicit_releases ?= 1
-git clone --quiet --depth 1 -b "$TRAVIS_BRANCH" $(use.repository) $(use.project)
 .   else
 git clone --quiet --depth 1 $(use.repository) $(use.project)
 .   endif

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -663,17 +663,20 @@ if \
  sudo apt-get install $(string.replace (use.project, "_|-"))-dev -y || exit \$? 
 .         endif
 .else
-. if defined (use.repository)
-.    if defined (use.release)
- FOLDER_NAME="$(use.project)-$(use.release)"
-.    else
- FOLDER_NAME="$(use.project)"
-.    endif
 
- if [ -d "$FOLDER_NAME" ]; then
+.   if defined (use.repository)
+.       if defined (use.release)
+    FOLDER_NAME="$(use.project)-$(use.release)"
+.       else
+    FOLDER_NAME="$(use.project)"
+.       endif
+.   endif
+
+.   if defined (use.repository)
+if [ -d "$FOLDER_NAME" ]; then
     echo "$FOLDER_NAME already exist. Skipped." >&2
- else
-. endif
+else
+.   endif
     echo ""
 .    if ! defined (use.repository) & ! defined (use.tarball)
     echo "WARNING: Can not build prerequisite '$(use.project)'" >&2
@@ -706,7 +709,8 @@ if \
         fi
     fi  
 .            endif
-    cd "./$FOLDER_NAME"
+    echo "Entering in ${PWD}/${FOLDER_NAME}"
+    cd "./${FOLDER_NAME}"
 .        endif
 .        if defined (use.builddir)
     cd ./$(use.builddir)
@@ -756,18 +760,20 @@ if \
 .        endif
     $CI_TIME make -j4
     $CI_TIME make install
+    echo "Leaving from ${PWD}"
     cd "${BASE_PWD}"
+    echo "Now in ${PWD}"
 .        if use.optional
     CONFIG_OPTS+=("--with-$(use.libname)=yes")
 .        endif
 .    endif
+. if defined (use.repository)
+fi
+. endif
 .    if use.optional
 else
     CONFIG_OPTS+=("--with-$(use.libname)=yes")
 .    endif
-. if defined (use.repository)
-fi
-. endif
 .endif
 fi
 


### PR DESCRIPTION
This PR implements the last option listed in #1217 - allowing to minimize the `project.xml` considerably, keeping just the top-level `use` tags for dependencies whose APIs are directly used by this component, e.g. https://github.com/42ity/fty-asset/pull/120/files#diff-c0a33b20a5bf94bd7bd5c012bf96f702

As detailed in #1217, this approach is not a magic silver bullet and gotta have use-cases that do not fit its idea and/or implementation.

It is recognized that this solution originated for our pain point, being "Travis Linux builds our unpackaged ecosystem from scratch with gcc/automake" (so there is no similar handling for MacOS or CMake, or non-travis builds). If the idea picks up, followers are welcome to fill the gaps.

It also introduces the notion of a new optional magical file `.ci_global_release` that would cause the CI source-builds of this component to request either certain branch or its currently checked out branch for the dependencies.

Cheers and kudos go to my colleagues. I did the initial analysis outlined in the #1217 issue, and was skeptical about the particular route they took, but it seems to have panned out well and simplified our release process in the end. Now we want to share back (hopefully removing the need to have a fork of zproject), and to get additional sanity review from the community :-)

I am not sure how critical it was so did not include in the PR, but there was also removal of the hardcoded reference to non-default branch of `libsodium` (`stable` rather than `master`) from `known_projects.xml` so our components could refer to a particular branch themselves:
* https://github.com/42ity/zproject/commit/92c1d54c377412233dd414d8b15bea5e91c84c38
* https://github.com/42ity/zproject/commit/66f5e0600e0e1743c398f66e774625fc204db957

IIRC it was a problem because of ZMQ ecosystem pulling it in, and `czmq` hardcoded as being required by `zproject` generated codebases at some point.