### PR TITLE
Problem: cmake runs private classes tests even if there are no private classes

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -530,7 +530,7 @@ IF (ENABLE_DRAFTS)
 ENDIF (ENABLE_DRAFTS)
 
 .endif
-.if count (class)
+.if count (class, private ?<> 0)
 IF (ENABLE_DRAFTS)
     list (APPEND TEST_CLASSES
     private_classes


### PR DESCRIPTION
Solution: only generate a private_classes entry if there are private classes.