### PR TITLE
Problem: Android build out of sync with upstream version from libzmq

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -15,28 +15,45 @@ register_target ("android", "Native shared library for Android")
 .macro target_android
 .directory.create ("builds/android")
 .
+.output "builds/android/README.md"
+# Android Build
+
+## Prerequisites
+
+You need the Android Native Development Kit (NDK) installed. See
+[here](https://developer.android.com/ndk) to download it.
+
+This project is tested against Android NDK version r20.
+
+If you installed version r20 all you have to do is to expose the NDK root
+directory as environment variable, e.g:
+
+    export ANDROID_NDK_ROOT=$HOME/android-ndk-r20
+
+If you installed another version you have to expose the NDK root directory as
+well as the NDK version, e.g:
+
+    export ANDROID_NDK_ROOT=$HOME/android-ndk-r17c
+    export NDK_VERSION=android-ndk-r17c
+
+To specify the minimum sdk version set the environment variable below:
+
+    export MIN_SDK_VERSION=21   # Default value if unset
+
+To specify the prefix directory set the environment variable below:
+
+    export ANDROID_BUILD_DIR=./builds/android/prefix/<android_arch> # Default value if unset
+
+## Build
+
+In the android directory, run:
+
+    \./build.sh [ arm | arm64 | x86 | x86_64 ]
+.close
+.
 .output "builds/android/build.sh"
 #!/usr/bin/env bash
 $(project.GENERATED_WARNING_HEADER:)
-
-# Use directory of current script as the build directory and working directory
-cd "\$( dirname "${BASH_SOURCE[0]}" )"
-ANDROID_BUILD_DIR="\$(pwd)"
-
-# Get access to android_build functions and variables
-source ${ANDROID_BUILD_DIR}/android_build_helper.sh
-
-# Choose a C++ standard library implementation from the ndk
-ANDROID_BUILD_CXXSTL="gnustl_shared_49"
-
-# Set up android build environment and set ANDROID_BUILD_OPTS array
-android_build_env
-android_build_opts
-
-# Use a temporary build directory
-cache="/tmp/android_build/${TOOLCHAIN_NAME}"
-rm -rf "${cache}"
-mkdir -p "${cache}"
 
 # Set this to enable verbose profiling
 [ -n "${CI_TIME-}" ] || CI_TIME=""
@@ -55,6 +72,52 @@ case "$CI_TRACE" in
     [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
         set -x ;;
 esac
+
+function usage {
+    echo "Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
+}
+
+# Use directory of current script as the build directory and working directory
+cd "\$( dirname "${BASH_SOURCE[0]}" )"
+ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-`pwd`}"
+
+# Get access to android_build functions and variables
+source ./android_build_helper.sh
+
+BUILD_ARCH=$1
+if [ -z $BUILD_ARCH ]; then
+    usage
+    exit 1
+fi
+
+case \$(uname | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    export HOST_PLATFORM=linux-x86_64
+    ;;
+  darwin*)
+    export HOST_PLATFORM=darwin-x86_64
+    ;;
+  *)
+    echo "Unsupported platform"
+    exit 1
+    ;;
+esac
+
+# Set default values used in ci builds
+export NDK_VERSION=${NDK_VERSION:-android-ndk-r20}
+# With NDK r20, the minimum SDK version range is [16, 29].
+# SDK version 21 is the minimum version for 64-bit builds.
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+
+# Set up android build environment and set ANDROID_BUILD_OPTS array
+android_build_set_env $BUILD_ARCH
+android_build_env
+android_build_opts
+
+# Use a temporary build directory
+cache="/tmp/android_build/${TOOLCHAIN_ARCH}"
+rm -rf "${cache}"
+mkdir -p "${cache}"
 
 # Check for environment variable to clear the prefix and do a clean build
 if [[ $ANDROID_BUILD_CLEAN ]]; then
@@ -77,8 +140,8 @@ fi
     fi
     echo "Building $(use.project) in ${$(USE.PROJECT)_ROOT}..."
 
-    (bash ${$(USE.PROJECT)_ROOT}/builds/android/build.sh) || exit 1
-    UPSTREAM_PREFIX=${$(USE.PROJECT)_ROOT}/builds/android/prefix/${TOOLCHAIN_NAME}
+    (bash ${$(USE.PROJECT)_ROOT}/builds/android/build.sh $BUILD_ARCH) || exit 1
+    UPSTREAM_PREFIX=${$(USE.PROJECT)_ROOT}/builds/android/prefix/${TOOLCHAIN_ARCH}
     cp -r ${UPSTREAM_PREFIX}/* ${ANDROID_BUILD_PREFIX}
 }
 
@@ -123,19 +186,23 @@ $(project.GENERATED_WARNING_HEADER:)
 #!/usr/bin/env bash
 $(project.GENERATED_WARNING_HEADER:)
 
-NDK_VERSION=android-ndk-r20
-NDK_ABI_VERSION=4.9
+export NDK_VERSION=android-ndk-r20
+export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
 
-if [ $TRAVIS_OS_NAME == "linux" ]; then
+case \$(uname | tr '[:upper:]' '[:lower:]') in
+  linux*)
     HOST_PLATFORM=linux-x86_64
-elif [ $TRAVIS_OS_NAME == "osx" ]; then
+    ;;
+  darwin*)
     HOST_PLATFORM=darwin-x86_64
-else
-    echo "Unsupported platform $TRAVIS_OS_NAME"
+    ;;
+  *)
+    echo "Unsupported platform"
     exit 1
-fi
+    ;;
+esac
 
-if [ ! -d "/tmp/${NDK_VERSION}" ]; then
+if [ ! -d "${ANDROID_NDK_ROOT}" ]; then
     export FILENAME=$NDK_VERSION-$HOST_PLATFORM.zip
 
     (cd '/tmp' \\
@@ -156,49 +223,10 @@ git clone --quiet --depth 1 $(use.repository) $$(USE.PROJECT)_ROOT
 .   endif
 
 .endfor
-function _build_arch {
-    export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
-    export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
-    export TOOLCHAIN_HOST=$1
-    export TOOLCHAIN_COMP=$2
-    export TOOLCHAIN_CXXSTL=$3
-    export TOOLCHAIN_ARCH=$4
-    export TOOLCHAIN_NAME="${TOOLCHAIN_HOST}-${NDK_ABI_VERSION}"
-
-    source ./build.sh
-}
-
-# Define the minimum Android API level for the library to run.
-# With NDK r20, the minimum SDK version range is [16, 29]
-export MIN_SDK_VERSION="21"
-
-HOST_ARM="arm-linux-androideabi"
-HOST_ARM64="aarch64-linux-android"
-HOST_X86="i686-linux-android"
-HOST_X86_64="x86_64-linux-android"
-
-COMP_ARM="armv7a-linux-androideabi${MIN_SDK_VERSION}"
-COMP_ARM64="aarch64-linux-android${MIN_SDK_VERSION}"
-COMP_X86="i686-linux-android${MIN_SDK_VERSION}"
-COMP_X86_64="x86_64-linux-android${MIN_SDK_VERSION}"
-
-CXXSTL_ARM="armeabi-v7a"
-CXXSTL_ARM64="arm64-v8a"
-CXXSTL_X86="x86"
-CXXSTL_X86_64="x86_64"
-
-ARCH_ARM="arm"
-ARCH_ARM64="arm64"
-ARCH_X86="x86"
-ARCH_X86_64="x86_64"
-
-_build_arch $HOST_ARM $COMP_ARM $CXXSTL_ARM $ARCH_ARM
-_build_arch $HOST_X86 $COMP_X86 $CXXSTL_X86 $ARCH_X86
-
-if [[ $MIN_SDK_VERSION -ge 21 ]] ; then
-    _build_arch $HOST_ARM64 $COMP_ARM64 $CXXSTL_ARM64 $ARCH_ARM64
-    _build_arch $HOST_X86_64 $COMP_X86_64 $CXXSTL_X86_64 $ARCH_X86_64
-fi
+\./build.sh "arm"
+\./build.sh "arm64"
+\./build.sh "x86"
+\./build.sh "x86_64"
 
 $(project.GENERATED_WARNING_HEADER:)
 .close
@@ -250,6 +278,38 @@ function android_build_check_fail {
     fi
 }
 
+function android_build_set_env {
+    BUILD_ARCH=$1
+
+    export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
+
+    # Set variables for each architecture
+    if [ $BUILD_ARCH == "arm" ]; then
+        export TOOLCHAIN_HOST="arm-linux-androideabi"
+        export TOOLCHAIN_COMP="armv7a-linux-androideabi${MIN_SDK_VERSION}"
+        export TOOLCHAIN_ABI="armeabi-v7a"
+        export TOOLCHAIN_ARCH="arm"
+    elif [ $BUILD_ARCH == "x86" ]; then
+        export TOOLCHAIN_HOST="i686-linux-android"
+        export TOOLCHAIN_COMP="i686-linux-android${MIN_SDK_VERSION}"
+        export TOOLCHAIN_ABI="x86"
+        export TOOLCHAIN_ARCH="x86"
+    elif [ $BUILD_ARCH == "arm64" ]; then
+        export TOOLCHAIN_HOST="aarch64-linux-android"
+        export TOOLCHAIN_COMP="aarch64-linux-android${MIN_SDK_VERSION}"
+        export TOOLCHAIN_ABI="arm64-v8a"
+        export TOOLCHAIN_ARCH="arm64"
+    elif [ $BUILD_ARCH == "x86_64" ]; then
+        export TOOLCHAIN_HOST="x86_64-linux-android"
+        export TOOLCHAIN_COMP="x86_64-linux-android${MIN_SDK_VERSION}"
+        export TOOLCHAIN_ABI="x86_64"
+        export TOOLCHAIN_ARCH="x86_64"
+    fi
+
+    export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
+    export ANDROID_BUILD_PREFIX="${ANDROID_BUILD_DIR}/prefix/${TOOLCHAIN_ARCH}"
+}
+
 function android_build_env {
     ##
     # Check that necessary environment variables are set
@@ -270,12 +330,12 @@ function android_build_env {
     fi
 
     if [ -z "$TOOLCHAIN_COMP" ]; then
-        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_NAME environment variable")
+        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_COMP environment variable")
         ANDROID_BUILD_FAIL+=("  (eg. \"armv7a-linux-androideabi\")")
     fi
 
-    if [ -z "$TOOLCHAIN_CXXSTL" ]; then
-        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_CXXSTL environment variable")
+    if [ -z "$TOOLCHAIN_ABI" ]; then
+        ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_ABI environment variable")
         ANDROID_BUILD_FAIL+=("  (eg. \"armeabi-v7a\")")
     fi
 
@@ -302,14 +362,10 @@ function android_build_env {
     ##
     # Set up some local variables and check them
 
-    ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
-
     if [ ! -d "$ANDROID_BUILD_SYSROOT" ]; then
         ANDROID_BUILD_FAIL+=("The ANDROID_BUILD_SYSROOT directory does not exist")
         ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_SYSROOT}")
     fi
-
-    ANDROID_BUILD_PREFIX="${ANDROID_BUILD_DIR}/prefix/${TOOLCHAIN_NAME}"
 
     mkdir -p "$ANDROID_BUILD_PREFIX" || {
         ANDROID_BUILD_FAIL+=("Failed to make ANDROID_BUILD_PREFIX directory")
@@ -384,7 +440,7 @@ function android_build_opts {
 
     local LIBS="-lc -lgcc -ldl -lm -llog -lc++_shared"
     local LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
-    LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TOOLCHAIN_CXXSTL}"
+    LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TOOLCHAIN_ABI}"
     CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
     CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
 
@@ -398,6 +454,7 @@ function android_build_opts {
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_PATH=${ANDROID_BUILD_PREFIX}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_SYSROOT_DIR=${ANDROID_BUILD_SYSROOT}")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_DIR=")
+    ANDROID_BUILD_OPTS+=("--with-sysroot=${ANDROID_BUILD_SYSROOT}")
     ANDROID_BUILD_OPTS+=("--host=${TOOLCHAIN_HOST}")
     ANDROID_BUILD_OPTS+=("--prefix=${ANDROID_BUILD_PREFIX}")
 


### PR DESCRIPTION
Solution: Adjust the scripts to the improved script in regard to
usability that were modified for libzmq.

These improvements include:

* Reduction of parameters that the user has to specify for each
  architecture
* Initializing the build environment variable in the android_build_helper
  scripts so higher level scripts can leverage them
* Renaming of TOOLCHAIN_CXXSTL to TOOLCHAIN_ABI
* Setting ANDROID_BUILD_DIR is now respected by the script and is no
  longer overwritten
* New README