### PR TITLE
Problem: Copied la files are invalid

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -143,6 +143,8 @@ fi
     (bash ${$(USE.PROJECT)_ROOT}/builds/android/build.sh $BUILD_ARCH) || exit 1
     UPSTREAM_PREFIX=${$(USE.PROJECT)_ROOT}/builds/android/prefix/${TOOLCHAIN_ARCH}
     cp -r ${UPSTREAM_PREFIX}/* ${ANDROID_BUILD_PREFIX}
+    # Remove copied *.la files as the contain absolute paths to $UPSTREAM_PREFIX
+    find ${ANDROID_BUILD_PREFIX} -name '*.la' -exec rm {} +
 }
 
 .endfor


### PR DESCRIPTION
Solution: Remove copied *.la files as the contain absolute paths to their $UPSTREAM_PREFIX