### PR TITLE
Problem: Distcheck gitignore rules on all path to verbose

### DIFF
--- a/zproject_git.gsl
+++ b/zproject_git.gsl
@@ -46,9 +46,9 @@ if !file.exists (".gitignore")
     >core
     >
     ># Distcheck workspace and archives
-    >$(project.name)-*/
-    >$(project.name)-*.tar.gz
-    >$(project.name)-*.zip
+    >/$(project.name)-*/
+    >/$(project.name)-*.tar.gz
+    >/$(project.name)-*.zip
     >
     ># Man pages
     >doc/*.1


### PR DESCRIPTION
Solution: Only use them on the root path where they are required