### PR TITLE
Problem: JNI android build will fail if dependant libs do not sit alo…

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -729,9 +729,10 @@ export MIN_SDK_VERSION=21
 export ANDROID_BUILD_DIR=/tmp/android_build
 
 #   Build any dependent libraries
+#   Use a default value assuming that dependent libraries sits alongside this one
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-( cd ../../../../../$(use.project)/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
+( cd ${$$(USE.PROJECT)_ROOT:-../../../../..}/$(use.project)/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
 .   endif
 .endfor
 
@@ -767,7 +768,7 @@ echo "********  Building jar for $TOOLCHAIN_ABI"
 find ../../build/libs/ -type f -name '$(project.prefix)-jni-*.jar' ! -name '*javadoc.jar' ! -name '*sources.jar' -exec unzip -q {} +
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-unzip -qo "../../../../../../$(use.project)/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
+unzip -qo "${$$(USE.PROJECT)_ROOT:-../../../../../..}/$(use.project)/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
 .   endif
 .endfor
 


### PR DESCRIPTION
…ngside

Solution: Assume as a default value that dependant libs sit alongside
but allow this value to be overridden by an environment variable