### PR TITLE
Problem: JNI android build script does a bad substitution

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -732,7 +732,7 @@ export ANDROID_BUILD_DIR=/tmp/android_build
 #   Use a default value assuming that dependent libraries sits alongside this one
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-( cd ${$$(USE.PROJECT)_ROOT:-../../../../..}/$(use.project)/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
+( cd ${$(USE.PROJECT)_ROOT:-../../../../../$(use.project)}/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
 .   endif
 .endfor
 
@@ -768,7 +768,7 @@ echo "********  Building jar for $TOOLCHAIN_ABI"
 find ../../build/libs/ -type f -name '$(project.prefix)-jni-*.jar' ! -name '*javadoc.jar' ! -name '*sources.jar' -exec unzip -q {} +
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-unzip -qo "${$$(USE.PROJECT)_ROOT:-../../../../../..}/$(use.project)/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
+unzip -qo "${$(USE.PROJECT)_ROOT:-../../../../../../$(use.project)}/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
 .   endif
 .endfor
 


### PR DESCRIPTION
Solution: Remove the dollar sign in front of the variable which is not
used for substitutions. Also include the projects folder in the default
value.