### PR TITLE
Problem: Automatic JNI android release failing

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -1336,10 +1336,10 @@ if [ "$BUILD_TYPE" == "default" ]; then
     md5sum *.zip *.tar.gz > MD5SUMS
     sha1sum *.zip *.tar.gz > SHA1SUMS
     cd -
-elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ]; then
-    ( cd bindings/jni && TERM=dumb PKG_CONFIG_PATH=/tmp/lib/pkgconfig ./gradlew clean bintrayUpload )
-    cp bindings/jni/android/$(project.name:c)-android.jar $(project.name:c)-android*.jar
-    export $(PROJECT.NAME:c)_DEPLOYMENT=$(project.name:c)-android*.jar
+elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ] && [ ! -z "$BINDING_OPTS" ]; then
+    ( cd bindings/jni && TERM=dumb ./gradlew clean bintrayUpload -PisRelease -PbuildPrefix=/tmp/jni_build )
+elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ] && [ "$BINDING_OPTS" == "android" ]; then
+    export $(PROJECT.NAME:c)_DEPLOYMENT=bindings/jni/$(project.prefix)-jni/android/$(project.prefix)-android-*.jar
 else
     export $(PROJECT.NAME:c)_DEPLOYMENT=""
 fi


### PR DESCRIPTION
Solution: Adjust the ci_deploy.sh and check the binding opts before
exporting the files to deploy. Also adjust the file glob where the
android jars can be found.