### PR TITLE
Problem: Dependency headers are converted to lowercase

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -65,10 +65,10 @@ $(project.GENERATED_WARNING_HEADER:)
 .# TODO: Fix up GSL to only reference same macro once (e.g. if variants are
 .# defined for OS packages named vastly different in various distros, like lua)
 #if defined (HAVE_$(USE.AM_LIB_MACRO))
-#include <$(use.header)>
+#include <$(use.header:)>
 #endif
 .    else
-#include <$(use.header)>
+#include <$(use.header:)>
 .    endif
 .endfor
 


### PR DESCRIPTION
Solution: Keep them as defined in the known projects or user defined
use's.