### PR TITLE
Problem: Dependency headers are converted to lowercase

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -740,7 +740,7 @@ s\
         $(use.project:c)_synthetic_libs="-l$(use.linkname)"
 
         if test -n "${with_$(use.libname:c)}" && test x"${with_$(use.libname:c)}" != xyes && test x"${with_$(use.libname:c)}" != xno; then
-            if test -r "${with_$(use.libname:c)}/include/$(use.header)"; then
+            if test -r "${with_$(use.libname:c)}/include/$(use.header:)"; then
                 $(use.project:c)_synthetic_cflags="-I${with_$(use.libname:c)}/include"
                 $(use.project:c)_synthetic_libs="-L${with_$(use.libname:c)}/lib -l$(use.linkname)"
             else
@@ -749,16 +749,16 @@ s\
 .   else
             AC_MSG_ERROR([\
 .   endif
-Header file ${with_$(use.libname)}/include/$(use.header) was not found. Please check $(use.libname) prefix])
+Header file ${with_$(use.libname)}/include/$(use.header:) was not found. Please check $(use.libname) prefix])
             fi
         else
-            AC_CHECK_HEADER([$(use.header)], [],
+            AC_CHECK_HEADER([$(use.header:)], [],
 .   if optional
             AC_MSG_WARN([\
 .   else
             AC_MSG_ERROR([\
 .   endif
-Header file $(use.header) was not found in default search paths])
+Header file $(use.header:) was not found in default search paths])
                 )
         fi
 

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -549,12 +549,14 @@ JNI Binding for $(project.name:)
 
 ## Building the JNI Layer for Linux and OSX
 
-Ensure you have gradle and cmake installed, then run:
+Before you start make sure $(project.name:) is built and installed on your system.
+
+Next, ensure you have gradle and cmake installed, then run:
 
     gradle build jar
     gradle test
 
-If you don't like to install gradle beforehand just use the gradle wrapper.
+If you don't like to install gradle beforehand simply use the gradle wrapper.
 
     ./gradlew build jar
     ./gradlew test
@@ -570,6 +572,8 @@ If libraries of dependent projects are not installed in any of the default locat
     ./gradlew build jar -PbuildPrefix=/tmp/jni_build
 
 ## Building the JNI Layer for Android
+
+Before you start make sure that you've built the JNI Layer for your current OS.
 
 Please read the prerequisites section of the [README](../../builds/android/README.md) in the android build directory.
 


### PR DESCRIPTION
Solution: Keep them as defined in the known projects or user defined use's.