### PR TITLE
Problem: release script for OBS build fails often

### DIFF
--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -2,6 +2,8 @@
   <service name="tar_scm">
     <param name="url">https://github.com/zeromq/zproject</param>
     <param name="scm">git</param>
+    <!-- delete to build from latest master on each refresh -->
+    <param name="revision">@PARENT_TAG@</param>
     <param name="versionformat">@PARENT_TAG@+git%cd</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <param name="versionrewrite-replacement">1</param>

--- a/zproject_obs.gsl
+++ b/zproject_obs.gsl
@@ -20,6 +20,8 @@ register_target ("obs", "service for Open Build Service")
   <service name="tar_scm">
     <param name="url">$(project.repository)</param>
     <param name="scm">git</param>
+    <!-- delete to build from latest master on each refresh -->
+    <param name="revision">@PARENT_TAG@</param>
     <param name="versionformat">@PARENT_TAG@+git%cd</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <param name="versionrewrite-replacement">\1</param>

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -120,12 +120,10 @@ true
 .# 0 = skip, 2 = allowed fail (in a special test case, skip in others)
 false
 .endif
-    # tokens to deploy releases on OBS and create/delete temporary branch on Github.
-    # 1) Create a token on https://github.com/settings/tokens/new with "public_repo"
-    #    capability and encrypt it with travis encrypt --org -r <org>/<repo> GH_TOKEN="<token>"
-    # 2) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
+    # tokens to deploy releases on OBS.
+    # 1) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
     #    encrypt them with travis encrypt --org -r <org>/<repo> OBS_<STABLE|DRAFT>_TOKEN="<token>"
-    # 3) Uncomment the three "secure" lines and paste the three generated hashed
+    # 2) Uncomment the three "secure" lines and paste the three generated hashed
     #    strings, which include each token's name, as parameters
     #- secure:
     #- secure:
@@ -1403,18 +1401,14 @@ $(project.GENERATED_WARNING_HEADER)
 # do NOT set -x or it will log the secret tokens!
 set -e
 
-if [ "$BUILD_TYPE" == "default" -a -n "${GH_TOKEN}" -a -n "${OBS_STABLE_TOKEN}" -a -n "${OBS_DRAFT_TOKEN}" ]; then
-    # Trigger source run on new tag on OBS. See travis.yml for token instructions.
-    # We have to create a temporary branch from the tag and delete it, as it is
-    # not possible to edit files on OBS with secure tokens, and it is not
-    # possible to dynamically fetch the latest git tag either.
-.  apiurl = string.search_replace (project.repository, "https://github.com/", "https://api.github.com/repos/")
-    TAG_SHA=\$(curl -s -H "Authorization: token ${GH_TOKEN}" -X GET $(apiurl)/git/refs/tags/${TRAVIS_TAG} | grep -o -P '(?<=sha":\\s).*(?=,)')
-    curl -H "Authorization: token ${GH_TOKEN}" -X DELETE $(apiurl)/git/refs/heads/latest_release
-    curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\\"ref\\":\\"refs/heads/latest_release\\",\\"sha\\":${TAG_SHA}}" $(apiurl)/git/refs
-    sleep 2 # try to avoid races if Github is slow
-    curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
-    curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+if [ "$BUILD_TYPE" == "default" ] && [ -n "${OBS_STABLE_TOKEN}" -o -n "${OBS_DRAFT_TOKEN}" ]; then
+    # Trigger source run on new tag on OBS. The latest tag will be fetched.
+    if [ -n "${OBS_STABLE_TOKEN}" ]; then
+        curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
+    if [ -n "${OBS_DRAFT_TOKEN}" ]; then
+        curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
 fi
 .close
 .chmod_x ("ci_deploy_obs.sh")


### PR DESCRIPTION
Solution: now that tar_scm supports @PARENT_TAG@ as a revision to
automatically fetch the most recent tag on the default branch, use
it to simplify everything

https://github.com/openSUSE/obs-service-tar_scm/pull/359