### PR TITLE
Problem: removing latest_branch breaks ABI CI job

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -1344,14 +1344,17 @@ function print_abi_api_breakages() {
    exit 1
 }
 
+git fetch --unshallow
+git fetch --all --tags
+LATEST_VERSION=\$(git describe --abbrev=0 --tags)
+
 \./autogen.sh
 \./configure "${CONFIG_OPTS[@]}"
 make VERBOSE=1 -j5
 abi-dumper -public-headers include src/.libs/$(project.libname).so -o ${BUILD_PREFIX}/$(project.libname).head.dump -lver HEAD
 
-git clone --depth 1 -b latest_release $(project.repository) latest_release
+git clone --depth 1 -b ${LATEST_VERSION} $(project.repository) latest_release
 cd latest_release
-LATEST_VERSION=\$(git describe --abbrev=0 --tags)
 \./autogen.sh
 \./configure "${CONFIG_OPTS[@]}"
 make VERBOSe=1 -j5


### PR DESCRIPTION
Solution: clone latest tag instead