### PR TITLE
Problem: cmake Find files always search for header in lower case

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -502,11 +502,11 @@ $(project.GENERATED_WARNING_HEADER:)
 //  Platform definitions, must come first
 #include "platform.h"
 
-//  Asserts check the invariants of methods. If they're not                                                                                                                
-//  fulfilled the program should fail fast. Therefore enforce them!  
+//  Asserts check the invariants of methods. If they're not
+//  fulfilled the program should fail fast. Therefore enforce them!
 #ifdef NDEBUG
   #undef NDEBUG
-  #include <assert.h> 
+  #include <assert.h>
   #define NDEBUG
 #else
   #include <assert.h>

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -570,11 +570,11 @@ foreach(TEST_CLASS ${TEST_CLASSES})
         COMMAND $(project.prefix)_selftest --continue --verbose --test ${TEST_CLASS}
     )
     IF (WIN32 AND CMAKE_PREFIX_PATH)
-		file(TO_NATIVE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH_WIN)
-		set_tests_properties(
-			${TEST_CLASS}
-			PROPERTIES ENVIRONMENT "PATH=%PATH%\\;${CMAKE_PREFIX_PATH_WIN}\\\\bin"
-		)
+        file(TO_NATIVE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH_WIN)
+        set_tests_properties(
+            ${TEST_CLASS}
+            PROPERTIES ENVIRONMENT "PATH=%PATH%\\;${CMAKE_PREFIX_PATH_WIN}\\\\bin"
+        )
     ENDIF (WIN32 AND CMAKE_PREFIX_PATH)
     set_tests_properties(
         ${TEST_CLASS}

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -690,7 +690,7 @@ endif (NOT MSVC)
 
 find_path (
     $(USE.PROJECT)_INCLUDE_DIRS
-    NAMES $(use.header)
+    NAMES $(use.header:)
     HINTS ${PC_$(USE.PROJECT)_INCLUDE_HINTS}
 )
 


### PR DESCRIPTION
Solution: Use the header files as given instead.