### PR TITLE
Problem: ci scripts fail to build cmake only projects

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -905,13 +905,27 @@ if \
       $CI_TIME ./configure "${CONFIG_OPTS[@]}"
     )
 .   else
-    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    if [ -e ./configure ]; then
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    else
+        mkdir build
+        cd build
+        $CI_TIME cmake .. -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_PREFIX_PATH=$BUILD_PREFIX
+    fi
 .   endif
-    $CI_TIME make -j4
-    $CI_TIME make install
+    if [ -e ./configure ]; then
+        $CI_TIME make -j4
+        $CI_TIME make install
+    else
+        $CI_TIME cmake --build . --config Release --target install
+    fi
     cd "${BASE_PWD}"
+.   if use.optional
+    CONFIG_OPTS+=("--with-$(use.libname)=yes")
+.   endif
 fi
 .endfor
+
 .for use where defined (use.repository) & ! defined (use.tarball)
 .   if defined (use.debian_name)
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.debian_name) >/dev/null 2>&1) || \\
@@ -958,11 +972,24 @@ if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list $(use.project)
       $CI_TIME ./configure "${CONFIG_OPTS[@]}"
     )
 .   else
-    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    if [ -e ./configure ]; then
+        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    else
+        mkdir build
+        cd build
+        $CI_TIME cmake .. -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_PREFIX_PATH=$BUILD_PREFIX
+    fi
 .   endif
-    $CI_TIME make -j4
-    $CI_TIME make install
+    if [ -e ./configure ]; then
+        $CI_TIME make -j4
+        $CI_TIME make install
+    else
+        $CI_TIME cmake --build . --config Release --target install
+    fi
     cd "${BASE_PWD}"
+.   if use.optional
+    CONFIG_OPTS+=("--with-$(use.libname)=yes")
+.   endif
 fi
 .endfor
 

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -1104,10 +1104,20 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
             $CI_TIME ./configure "${CONFIG_OPTS[@]}"
         )
 .           else
-        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        if [ -e ./configure ]; then
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        else
+            mkdir build
+            cd build
+            $CI_TIME cmake .. -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_PREFIX_PATH=$BUILD_PREFIX
+        fi
 .           endif
-        $CI_TIME make -j4
-        $CI_TIME make install
+        if [ -e ./configure ]; then
+            $CI_TIME make -j4
+            $CI_TIME make install
+        else
+            $CI_TIME cmake --build . --config Release --target install
+        fi
         cd "${BASE_PWD}"
 .           if use.optional
         CONFIG_OPTS+=("--with-$(use.libname)=yes")


### PR DESCRIPTION
Solution: After we have taken every step to get an autotools script
going and weren't successful then fallback and use cmake to build the
project.