### PR TITLE
Problem: All resolved implied dependencies are taken as project dependencies

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -605,7 +605,7 @@ PKGCFG_NAMES_PRIVATE=""
 PREVIOUS_CFLAGS="${CFLAGS}"
 PREVIOUS_LIBS="${LIBS}"
 
-.for use
+.for use where !(implied & private)
 .# Far below, if the dependency search was not for a library, it will be done
 .# for a program.
 .# Debugging for using either a list of variants or a single name per legacy
@@ -1566,7 +1566,7 @@ AM_CXXFLAGS = \\
 .endif
 
 AM_CPPFLAGS = \\
-.for use where use.libname ?<> ""
+.for use where use.libname ?<> "" & !(implied & private)
     \${$(use.project:c)_CFLAGS} \\
 .endfor
 .if project.use_cxx
@@ -1575,7 +1575,7 @@ AM_CPPFLAGS = \\
     -I\$(srcdir)/include
 
 .libs = ""
-.for use where use.libname ?<> ""
+.for use where use.libname ?<> "" & !(implied & private)
 .   libs += " \${$(use.project:c)_LIBS}"
 .endfor
 project_libs =$(libs:)
@@ -1599,7 +1599,7 @@ DISTCLEANFILES =
 
 if ENABLE_DIST_CMAKEFILES
 EXTRA_DIST += \\
-.for use
+.for use where !(implied & private)
     Find$(use.project:c).cmake \\
 .endfor
 .if file.exists ("src/CMakeLists-local.txt")

--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -60,7 +60,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .endif
 
 //  External dependencies
-.for use where !defined (implied)
+.for use where !implied & !private
 .    if (use.optional = 1)
 .# TODO: Fix up GSL to only reference same macro once (e.g. if variants are
 .# defined for OS packages named vastly different in various distros, like lua)
@@ -514,6 +514,17 @@ $(project.GENERATED_WARNING_HEADER:)
 
 //  External API
 #include "../include/$(project.header:)"
+
+//  Private external dependencies
+.for use where !implied & private
+.    if (use.optional = 1)
+#if defined (HAVE_$(USE.AM_LIB_MACRO))
+#include <$(use.header:)>
+#endif
+.    else
+#include <$(use.header:)>
+.    endif
+.endfor
 
 //  Opaque class structures to allow forward references
 .for class where scope = "private"

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -147,7 +147,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${SOURCE_DIR}")
 set(OPTIONAL_LIBRARIES)
 set(OPTIONAL_LIBRARIES_STATIC)
-.for use
+.for use where !(implied & private)
 
 ########################################################################
 # $(USE.PROJECT) dependency
@@ -477,7 +477,7 @@ target_link_libraries(
 .if count (project.class)
     $(project.linkname)
 .endif
-.for project.use
+.for project.use where !(implied & private)
 .if use.optional = 0
     ${$(USE.PROJECT)_LIBRARIES}
 .endif
@@ -491,7 +491,7 @@ target_link_libraries(
 .if count (project.class)
     $(project.linkname)-static
 .endif
-.for project.use
+.for project.use where !(implied & private)
 .if use.optional = 0
     ${$(USE.PROJECT)_LIBRARIES}
 .endif
@@ -669,7 +669,7 @@ message (STATUS "")
 
 $(project.GENERATED_WARNING_HEADER:)
 .
-.for use
+.for use where !(implied & private)
 .output "Find$(use.project:c).cmake"
 $(project.GENERATED_WARNING_HEADER:)
 

--- a/zproject_projects.gsl
+++ b/zproject_projects.gsl
@@ -82,6 +82,8 @@ function resolve_project_dependency (use)
     my.use.pkgconfig ?= my.use.libname
     my.use.am_lib_macro ?= my.use.libname
     my.use.optional ?= 0
+    my.use.implied ?= 0
+    my.use.private ?= 0
     my.use.draft ?= 0
     my.use.min_major ?= 0
     my.use.min_minor ?= 0
@@ -135,7 +137,7 @@ function resolve_project_dependency (use)
             move implied_use before my.use as use
             implied_use.implied = "1"
             resolve_project_dependency (implied_use)
-        else 
+        else
             echo "[WARNING] Ignoring implied use definition '$(implied_use.project)' at '$(my.use.project)' because there is a non-implied definition."
         endif
     endfor

--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -1229,7 +1229,7 @@ set -ex
 # Note: certain zproject scripts that deal with deeper dependencies expect that
 # such checkouts are directly in the same parent directory as "this" project.
 cd "$REPO_DIR/.."
-.for project.use where !optional & defined (use.repository)
+.for project.use where !optional & defined (use.repository) & !private
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $(use.project)
 .   else


### PR DESCRIPTION
While resolving dependencies recursively is a nice feature there are
dependencies that are private for an dependency and the project itself
does not care for. But those private dependencies are important to know
in case we need to build them from source for a ci build.

Solution: Allow to declare dependencies as private

Implied and private dependencies are ignored as dependency but
considered for ci builds.

Includes for private dependencies are now placed in the private classes
header.