### PR TITLE
Problem: cucumber selftest doesn't support multiple step def servers

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -247,7 +247,7 @@ typedef struct {
 
 static test_item_t
 all_tests [] = {
-.for class where selftest & private ?= 1
+.for class where selftest & private ?= 1 & (!defined (type) | type <> "cucumber")
 .   if first ()
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
 // Tests for stable/draft private classes:
@@ -460,14 +460,14 @@ $(project.GENERATED_WARNING_HEADER:)
 void
 $(project.prefix)_private_selftest (bool verbose, const char *subtest)
 {
-.for class where !draft & selftest & private ?= 1
+.for class where !draft & selftest & private ?= 1 & (!defined (type) | type <> "cucumber")
 .   if first ()
 // Tests for stable private classes:
 .   endif
     if (streq (subtest, "$ALL") || streq (subtest, "$(class.c_name)_test"))
         $(class.c_name)_test (verbose);
 .endfor
-.for class where draft & selftest & private ?= 1
+.for class where draft & selftest & private ?= 1 & (!defined (type) | type <> "cucumber")
 .   if first ()
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
 // Tests for draft private classes:

--- a/zproject_cucumber.gsl
+++ b/zproject_cucumber.gsl
@@ -28,9 +28,10 @@ function add_step_definitions (target)
         new project.class
             define class.name = "$(step_defs.name)_step_defs"
             define class.private = "1"
+            define class.type = "cucumber"
         endnew
         new project.main
-            define main.name = "$(step_defs.name)_step_defs"
+            define main.name = "$(step_defs.name)_step_runner"
             define main.private = "1"
         endnew
     endfor
@@ -94,31 +95,47 @@ $(project.GENERATED_WARNING_HEADER:)
 int main (int argc, char *argv [])
 {
     zargs_t *args = zargs_new (argc, argv);
-    zsock_t *client = zsock_new_dealer (">tcp://127.0.0.1:8888");
+    zsock_t *client = zsock_new_router ("@tcp://127.0.0.1:8888");
     assert (client);
-    zclock_sleep (250);
-    zlist_t *step_runners = zlist_new ();
 
+    zlist_t *step_runners = zlist_new ();
 .   for project.target where target.name = "cucumber"
 .       for target.step_defs
-    CREATE_STEP_RUNNER_ACTOR($(step_defs.name), consumer_protocol_state_new, consumer_protocol_state_destroy)
+    CREATE_STEP_RUNNER_ACTOR($(step_defs.name), $(step_defs.name)_state_new, $(step_defs.name)_state_destroy)
     zlist_append (step_runners, $(step_defs.name)_steps_runner);
 
 .       endfor
 .   endfor
+    zlist_t *step_runner_identities = zlist_new ();
+    while (zlist_size (step_runner_identities) < zlist_size (step_runners)) {
+        zframe_t *identity;
+        char *command;
+        zsock_recv (client, "fs", &identity, &command);
+        if (streq (command, "HELLO")) {
+            zlist_append (step_runner_identities, identity);
+        }
+        zstr_free (&command);
+    }
 
     const char *filename = zargs_first (args);
     cucumber_feature_runner_t *feature_runner = cucumber_feature_runner_new (filename);
-    bool rc = cucumber_feature_runner_run (feature_runner, client);
+    bool rc = cucumber_feature_runner_run (feature_runner, client, step_runner_identities);
 
     zactor_t *step_runner = (zactor_t *) zlist_first (step_runners);
     while (step_runner != NULL) {
         zstr_send (step_runner, "$TERM");
         zactor_destroy (&step_runner);
+        step_runner = (zactor_t *) zlist_next (step_runners);
     }
 
     zargs_destroy (&args);
     zlist_destroy (&step_runners);;
+    zframe_t *identity = (zframe_t *) zlist_first (step_runner_identities);
+    while (identity) {
+        zframe_destroy (&identity);
+        identity = (zframe_t *) zlist_next (step_runner_identities);
+    }
+    zlist_destroy (&step_runner_identities);
     zsock_destroy (&client);
     cucumber_feature_runner_destroy (&feature_runner);
     return rc ? 0 : 1;


### PR DESCRIPTION
Solution: Enhance the selftest to support talking to multiple step def servers.

Also there was a need to split the step defs server and the step def
server runner because of how zproject manages classes and mains