### PR TITLE
Problem: Symbol check requires knowledge about multiple build systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,22 @@ zproject's `project.xml` contains an extensive description of the available conf
     -->
 
     <!--
+        Check that the <symbol> is available after including a given <header>
+        and store the result in a macro HAVE_DECL_SYMBOL. When the symbol is
+        declared, HAVE_DECL_SYMBOL is defined to '1' otherwise '0'. Use
+        HAVE_DECL_SYMBOL in #if:
+
+          #if HAVE_DECL_SYMBOL
+            // Do something with the symbol
+          #endif
+
+          #if !HAVE_DECL_SYMBOL
+            // Alternative action without the symbol
+          #endif
+    <check_symbol_exists symbol = AI_V4MAPPED"" header = "netdb.h" />
+    -->
+
+    <!--
         Specify which other projects this depends on.
         These projects must be known by zproject, and the list of
         known projects is maintained in the zproject_known_projects.xml model.

--- a/project.xml
+++ b/project.xml
@@ -88,6 +88,22 @@
     -->
 
     <!--
+        Check that the <symbol> is available after including a given <header>
+        and store the result in a macro HAVE_DECL_SYMBOL. When the symbol is
+        declared, HAVE_DECL_SYMBOL is defined to '1' otherwise '0'. Use
+        HAVE_DECL_SYMBOL in #if:
+
+          #if HAVE_DECL_SYMBOL
+            // Do something with the symbol
+          #endif
+
+          #if !HAVE_DECL_SYMBOL
+            // Alternative action without the symbol
+          #endif
+    <check_symbol_exists symbol = AI_V4MAPPED"" header = "netdb.h" />
+    -->
+
+    <!--
         Specify which other projects this depends on.
         These projects must be known by zproject, and the list of
         known projects is maintained in the zproject_known_projects.xml model.

--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1042,6 +1042,13 @@ AC_TYPE_UINT32_T
 AC_C_VOLATILE
 AC_C_BIGENDIAN
 
+.for project.check_symbol_exists
+.if first()
+# Check for symbols (function, variable, or macro)
+.endif
+AC_CHECK_DECLS([$(symbol:)], [], [], [[#include <$(header:)>]])
+.endfor
+
 AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$$(project.name:c)_on_mingw32" = "xyes")
 AM_CONDITIONAL(ON_CYGWIN, test "x$$(project.name:c)_on_cygwin" = "xyes")

--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -97,6 +97,13 @@ if (NOT HAVE_NET_IF_H)
     CHECK_INCLUDE_FILE("net/if.h" HAVE_NET_IF_H)
 endif()
 
+.for project.check_symbol_exists
+.  if first()
+include(CheckSymbolExists)
+.  endif
+check_symbol_exists($(symbol:) "$(header:)" HAVE_DECL_$(SYMBOL:c))
+.endfor
+
 file(REMOVE "${SOURCE_DIR}/src/platform.h")
 
 file(WRITE "${PROJECT_BINARY_DIR}/platform.h.in" "
@@ -105,6 +112,9 @@ file(WRITE "${PROJECT_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_NET_IF_MEDIA_H
 #cmakedefine HAVE_GETIFADDRS
 #cmakedefine HAVE_FREEIFADDRS
+.for project.check_symbol_exists
+#cmakedefine01 HAVE_DECL_$(SYMBOL:c)
+.endfor
 ")
 
 configure_file("${PROJECT_BINARY_DIR}/platform.h.in" "${PROJECT_BINARY_DIR}/platform.h")


### PR DESCRIPTION
Solution: Declare the check in the project.xml and let zproject generate
the details.