### PR TITLE
Problem: Zyre travis build status is showing as failing.

### DIFF
--- a/zproject_travis.gsl
+++ b/zproject_travis.gsl
@@ -1339,7 +1339,8 @@ set -ex
 [ -n "${REPO_DIR-}" ] || exit 1
 
 .for model
-docker run -e GSL_BUILD_DIR=/code/src -v "$REPO_DIR":/code zeromqorg/zproto -zproject:1 -q $(name).xml
+docker run -e GSL_BUILD_DIR=/code/src -e BUILD_DIR=/code/src \\
+    -v "$REPO_DIR":/code zeromqorg/zproto -zproject:1 -q $(name).xml
 .endfor
 
 # keep an eye on git version used by CI


### PR DESCRIPTION
Solution: Pass BUILD_DIR as environment variable to the docker run command in the travis generator.