### PR TITLE
Fixed multi line constant description in C headers.

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -616,7 +616,11 @@ $(VISIBILITY) $(c_method_signature (method):)\
 
 //  *** Draft constants, defined for internal use only ***
 .      endif
-#define $(CLASS.NAME:c)_$(NAME:c) $(value)  // $(constant.description:no,block)
+
+.      if ("$(constant.description)" <> "")
+// $(constant.description:no,block)
+.      endif
+#define $(CLASS.NAME:c)_$(NAME:c) $(value)
 .   endfor
 .   for class.callback_type where draft = 1
 .      if first ()
@@ -673,7 +677,11 @@ $(PROJECT.PREFIX)_PRIVATE void
 .      visibility = "$(PROJECT.PREFIX)_EXPORT"
 .   endif
 .   for class.constant where draft = my.draft
-#define $(CLASS.NAME:c)_$(NAME:c) $(value:)  // $(constant.description:no,block)
+
+.      if ("$(constant.description)" <> "")
+// $(constant.description:no,block)
+.      endif
+#define $(CLASS.NAME:c)_$(NAME:c) $(value:)
 .   if last ()
 
 .   endif


### PR DESCRIPTION
PR for #1281 
With the following .api file : 
```
	<constant name = "cst1" value = "123" >
		Multi
		line 
		constant
		description.
	</constant>

	<constant name = "cst2 no description" value = "456" >
	</constant>
```

the .h header files are generated like below :
```

// Multi
// line
// constant
// description.
#define FOO_CST1 123

#define FOO_CST2_NO_DESCRIPTION 456
```

