### PR TITLE
Problem: project.prefix is used for the selftest binary, not project name

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1089,8 +1089,8 @@ AM_CONDITIONAL([ENABLE_$(NAME:c)], [test x$enable_$(name:c) != xno])
 AM_COND_IF([ENABLE_$(NAME:c)], [AC_MSG_NOTICE([ENABLE_$(NAME:c) defined])])
 
 .else
-AM_CONDITIONAL([ENABLE_$(PROJECT.NAME:c)_SELFTEST], [test x$enable_$(project.name:c)_selftest != xno])
-AM_COND_IF([ENABLE_$(PROJECT.NAME:c)_SELFTEST], [AC_MSG_NOTICE([ENABLE_$(PROJECT.NAME:c)_SELFTEST defined])])
+AM_CONDITIONAL([ENABLE_$(PROJECT.PREFIX:c)_SELFTEST], [test x$enable_$(project.prefix:c)_selftest != xno])
+AM_COND_IF([ENABLE_$(PROJECT.PREFIX:c)_SELFTEST], [AC_MSG_NOTICE([ENABLE_$(PROJECT.PREFIX:c)_SELFTEST defined])])
 
 .endfor
 # Checks for library functions.
@@ -1949,7 +1949,7 @@ code:
 .   endif
 .endfor
 
-if ENABLE_$(PROJECT.NAME)_SELFTEST
+if ENABLE_$(PROJECT.PREFIX)_SELFTEST
 # Directories with test fixtures optionally provided by the project,
 # and with volatile RW data possibly created by a selftest program.
 # It is up to the project authors to populate the RO directory with
@@ -2141,7 +2141,7 @@ coverage: src/$(project.prefix)_selftest
 \t@echo "call make clean && configure --with-gcov to enable code coverage"
 \t@exit 1
 endif
-endif #ENABLE_$(PROJECT.NAME)_SELFTEST
+endif #ENABLE_$(PROJECT.PREFIX)_SELFTEST
 
 bindings: python-bindings
 
@@ -2303,12 +2303,12 @@ check-gitignore:
 \t    echo "SKIP: $@ (no git)"; exit 0 ; \\
 \t  fi )
 
-if ENABLE_$(PROJECT.NAME)_SELFTEST
+if ENABLE_$(PROJECT.PREFIX)_SELFTEST
 # This calls the recipe above after building the project products and
 # the selftest binary, and preparing the workspace for self-testing:
 check-gitignore-all: all src/$(project.prefix)_selftest $\(top_builddir)/$\(SELFTEST_DIR_RW) $\(top_builddir)/$\(SELFTEST_DIR_RO)
 \t$@\$(MAKE) check-gitignore
-endif #ENABLE_$(PROJECT.NAME)_SELFTEST
+endif #ENABLE_$(PROJECT.PREFIX)_SELFTEST
 
 .insert_snippet ("Makemodule")
 


### PR DESCRIPTION
In some cases they don't match, like in malamute, so the check fails