### PR TITLE
Problem: Java bindings still call zsys_handler_set (from CZMQ), when project has no CZMQ.

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -1267,8 +1267,10 @@ $(jni_shim_signature_c:))
 .   endfor
 .#
 .   if name = "new"
+.     if project.has_czmq
     //  Disable CZMQ signal handling; allow Java to deal with it
     zsys_handler_set (NULL);
+.     endif
 .   endif
 .   if ->return.type = "nothing"
     $(class.c_name)_$(c_name) ($(jni_native_invocation_c:));


### PR DESCRIPTION
Solution: Do not call zsys_handler_set() when CZMQ is not used.

Details:
Create or use a project.xml with no <use project = "czmq" />

Generate JAVA target, as usual.
Each constructor shows the following:
```
    //  Disable CZMQ signal handling; allow Java to deal with it
    zsys_handler_set (NULL);
```
which is buggy, since no CZMQ library will not be linked with.