### PR TITLE
Problem: C Compilation fails in a few cases with global constants.

### DIFF
--- a/zproject_class.gsl
+++ b/zproject_class.gsl
@@ -161,17 +161,25 @@ typedef struct _$(class.c_name:)_t $(class.c_name:)_t;
 .endfor
 .if count (constant, scope = "public")
 //  Public constants
+
 .endif
 .for constant where scope = "public" & !draft
-#define $(CONSTANT.NAME)\
-                            $(constant.value)  //  $(constant.?'')
+.  if ("$(constant.description)" <> "")
+// $(constant.description:no,block)
+.  endif
+#define $(CONSTANT.NAME:c)\t$(constant.value)
+
 .endfor
 .for constant where scope = "public" & draft
 .   if first ()
 #ifdef $(PROJECT.PREFIX)_BUILD_DRAFT_API
+
 .   endif
-#define $(CONSTANT.NAME)\
-                            $(constant.value)  //  $(constant.?'')
+.  if ("$(constant.description)" <> "")
+// $(constant.description:no,block)
+.  endif
+#define $(CONSTANT.NAME:c)\t$(constant.value)
+
 .   if last ()
 #endif // $(PROJECT.PREFIX)_BUILD_DRAFT_API
 .   endif
@@ -607,8 +615,11 @@ $(VISIBILITY) $(c_method_signature (method):)\
 
 //  *** Draft global constants, defined for internal use only ***
 .   endif
-#define $(CONSTANT.NAME)\
-                            $(constant.value)  //  $(constant.?'')
+.   if ("$(constant.description)" <> "")
+// $(constant.description:no,block)
+.   endif
+#define $(CONSTANT.NAME:c)\t$(constant.value)
+
 .endfor
 .for class where draft = 0
 .   for constant where draft = 1
@@ -657,8 +668,13 @@ $(PROJECT.PREFIX)_PRIVATE void
 .for constant where scope = "private"
 .   if first ()
 //  Private constants
+
 .   endif
-#define $(CONSTANT.NAME)\t$(constant.value) //  $(constant.?'')
+.   if ("$(constant.description)" <> "")
+// $(constant.description:no,block)
+.   endif
+#define $(CONSTANT.NAME:c)\t$(constant.value)
+
 .endfor
 #endif
 .close


### PR DESCRIPTION
Project constant definition:
```
  <constant name = "global constant stuff" value = "123" type = "string" >
    this is a
    multi-line comment
    for global constant
  </constant>

```

Generated header file:
```
#define GLOBAL_CONSTANT_STUFF	"123" \\
    this is a
    multi-line comment
    for global constant
```

Compilation failure:
```
make[1]: Entering directory `/home/cbox_dev/git/zproject-issues-testing'
  CC       src/src_libfbp_la-foo.lo
In file included from src/../include/libfoobar.h:18:0,
                 from src/fbp_classes.h:35,
                 from src/foo.c:21:
src/../include/fbp_library.h:95:5: error: unknown type name 'this'
     this is a
     ^
src/../include/fbp_library.h:95:13: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'a'
     this is a
             ^
...
```

See #1291 for more details.

Solution: Apply a similar fix than #1283, but on global constants.
```
// this is a
// multi-line comment
// for global constant
#define GLOBAL_CONSTANT_STUFF	"123"
```

Additionnally, a few blank lines are added to separate the constants
definitions, from each other.

Note:
Global constants should be prefixed with `$(PROJECT.PREFIX:c)_`,
like for version constants, but this is not applied here.
