### PR TITLE
Problem: JAVA build fails, when project has a prefix

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -78,7 +78,7 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
 
 target_link_libraries ($(project.prefix)jni ${MORE_LIBRARIES})
 .
-.output "$(topdir)/$(project.prefix:c)-jni/Find$(project.name:c).cmake"
+.output "$(topdir)/$(project.prefix:c)-jni/Find$(project.prefix:c).cmake"
 $(project.GENERATED_WARNING_HEADER:)
 
 if (NOT MSVC)


### PR DESCRIPTION
Example project is defined like:
```
<project
    name = "Foo-Bar-Project"
    script = "zproject.gsl"
    url = "https://foo.bar.com//"
    description = "Testing project for ZProject code generator."
    prefix = "fbp"
    header = "libfoobar.h">
```

Because of project prefix, build fails.
If prefix is removed from project.xml, the build goes well.

Compilation error:
```
prompt> cd bindings/jni
prompt> ./ci_build.sh
...
CMake Error at CMakeLists.txt:23 (find_package):
  By not providing "Findfbp.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "fbp", but
  CMake did not find one.

  Could not find a package configuration file provided by "fbp" with any of
  the following names:

    fbpConfig.cmake
    fbp-config.cmake

  Add the installation prefix of "fbp" to CMAKE_PREFIX_PATH or set "fbp_DIR"
  to a directory containing one of the above files.  If "fbp" provides a
  separate development package or SDK, be sure it has been installed.

```

After investigation, CMakeLists.txt is generated like this:
```
prompt> grep find_package bindings/jni/fbp-jni/CMakeLists.txt
find_package (JNI REQUIRED)
find_package(fbp REQUIRED)
prompt>
```

But zproject generates the following file:
```
prompt> find . -name 'Find*'
./bindings/jni/fbp-jni/Findfoo_bar_project.cmake
prompt>
```

Solution: Fix Java build, when project.xml has a defined 'prefix'.