### PR TITLE
Problem: Delphi - No code is generated for global constants.

### DIFF
--- a/zproject_delphi.gsl
+++ b/zproject_delphi.gsl
@@ -705,14 +705,20 @@ function target_delphi
     endfor
   endfunction
 
-  function generate_c_const(class)
-    if count(my.class.constant) > 0
+  function generate_project_const()
+    for project.constant
       >
-      for my.class.constant
-        >  // $(constant.description:no,block)
-        >  $(project.name:UPPER)_$(my.class.name:UPPER)_$(CONSTANT.NAME:c) = $(constant.value);
-      endfor
-    endif
+      >  // $(constant.description:no,block)
+      >  $(PROJECT.NAME:c)_$(CONSTANT.NAME:c) = $(constant.value);
+    endfor
+  endfunction
+
+  function generate_c_const(class)
+    for my.class.constant
+      >
+      >  // $(constant.description:no,block)
+      >  $(PROJECT.NAME:c)_$(my.class.name:UPPER)_$(CONSTANT.NAME:c) = $(constant.value);
+    endfor
   endfunction
 
   function generate_c_binding()
@@ -744,6 +750,7 @@ function target_delphi
     >
     >const
     >  lib_$(project.name:c) = 'lib$(project.name:c).dll';
+    generate_project_const()
     for project.class where scope = "public" & !draft
       generate_c_const(class)
     endfor


### PR DESCRIPTION
Solution: Generate missing code.

Additionnally, this fixes also global/class constant names when project
name is like 'foo-bar-project' or 'Foo Bar Project'.
In both cases, we now have:

* Global constants:

```
  // this is a
  // multi-line comment
  // for global constant
  FOO_BAR_PROJECT_GLOBAL_CONSTANT_STUFF = "123";
```

* Class constants:
```
  // multi-line comment
  // for class constant
  FOO_BAR_PROJECT_FOO_CLASS_CONSTANT_STUFF = 234;
```

Instead of invalid constant names...

Note:
There might be many more issues to solve with such project names ...