### PR TITLE
Check in CMake if dependency is already found.

### DIFF
--- a/zproject_cmake.gsl
+++ b/zproject_cmake.gsl
@@ -165,10 +165,14 @@ set(OPTIONAL_LIBRARIES_STATIC)
 # $(USE.PROJECT) dependency
 ########################################################################
 .if use.optional = 0
-find_package($(use.project) REQUIRED)
+IF (NOT $(use.project)_FOUND)
+    find_package($(use.project) REQUIRED)
+ENDIF(NOT $(use.project)_FOUND)
 IF ($(use.project)_FOUND)
 .else
-find_package($(use.project))
+IF (NOT $(use.project)_FOUND)
+    find_package($(use.project))
+ENDIF(NOT $(use.project)_FOUND)
 option($(PROJECT.PREFIX)_WITH_$(USE.PROJECT) "Build $(project.linkname) with $(use.project)" ${$(USE.PROJECT)_FOUND})
 IF ($(PROJECT.PREFIX)_WITH_$(USE.PROJECT) AND $(use.project)_FOUND)
 .endif


### PR DESCRIPTION
This prevents redundant calls to `find_package` and allows for projects including this as a subdirectory to define their own parameters for finding the dependency if CMake's `find_package` functionality is not adequate for the situation.

This applies to both required and optional packages due to CMake `find_package` not having the most graceful way of including non-system installed dependencies that are included as source in the parent project (such as a git submodule, or via `FetchContent` in CMake).

A more in-depth fix might also involve the custom `.cmake` package modules generated by `zproject` to do more checking on existing CMake package variables and not overridethem if they are already set, but that would ultimately yield the same functional result as this patch.