### PR TITLE
Regression: CZMQ Java/Android bindings do not call zsys_set_handler() anymore.

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -1284,7 +1284,7 @@ $(jni_shim_signature_c:))
 .   endfor
 .#
 .   if name = "new"
-.     if project.has_czmq
+.     if project.has_czmq | project.prefix = "czmq"
     //  Disable CZMQ signal handling; allow Java to deal with it
     zsys_handler_set (NULL);
 .     endif


### PR DESCRIPTION
Re-ran last zproject on CZMQ and found many differences in JAVA bindings and
git diff show the following:
```
diff --git a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Ztimerset.c b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Ztimerset.c
index 67a05848..03d77f6c 100644
--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Ztimerset.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Ztimerset.c
@@ -13,8 +13,6 @@
 JNIEXPORT jlong JNICALL
 Java_org_zeromq_czmq_Ztimerset__1_1new (JNIEnv *env, jclass c)
 {
-    //  Disable CZMQ signal handling; allow Java to deal with it
-    zsys_handler_set (NULL);
     jlong new_ = (jlong) (intptr_t) ztimerset_new ();
     return new_;
 }
```

Reason is PR #1292:
This PR fixes some issues on project not using CZMQ, but should
not be applied on CZMQ itself !

Solution:
Do not apply PR 1292 on CZMQ itself ...