### PR TITLE
Problem: Android - Build failure on Ubuntu 22.04

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -790,13 +790,16 @@ echo "********  Building $(project.name:) JNI for Android"
 rm -rf build && mkdir build && cd build
 # Export android build's environment variables for cmake
 android_build_set_env $BUILD_ARCH
-cmake -v \\
-    -DANDROID_ABI=$TOOLCHAIN_ABI \\
-    -DANDROID_PLATFORM=$MIN_SDK_VERSION \\
-    -DANDROID_STL=c++_shared \\
-    -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake \\
-    -DCMAKE_FIND_ROOT_PATH=$ANDROID_BUILD_PREFIX \\
-    ..
+(
+    VERBOSE=1 \\
+    cmake \\
+        -DANDROID_ABI=$TOOLCHAIN_ABI \\
+        -DANDROID_PLATFORM=$MIN_SDK_VERSION \\
+        -DANDROID_STL=c++_shared \\
+        -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake \\
+        -DCMAKE_FIND_ROOT_PATH=$ANDROID_BUILD_PREFIX \\
+        ..
+)
 
 #   CMake wrongly searches current directory and then toolchain path instead
 #   of lib path for these files, so make them available temporarily


### PR DESCRIPTION
Modified zyre/bindings/jni_ci_build.sh script ends with
```
> Task :czmq-jni-native:build
Skipping task ':czmq-jni-native:build' as it has no actions.
:czmq-jni-native:build (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.0 secs.
producer locations for task group 0 (Thread[Execution worker for ':' Thread 3,5,main]) started.
producer locations for task group 0 (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.0 secs.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 27s
11 actionable tasks: 11 executed
********  Building CZMQ JNI for Android
CMake Error: Unknown argument -v
CMake Error: Run 'cmake --help' for all supported options.
```

Reason is due to option '-v' no more supported by cmake on Ubuntu 22.04, when it was on earlier versions.

On Ubuntu 22.04 `man cmake` shows this:
```
       --verbose, -v
              Enable verbose output - if supported - including the build commands to be executed.

              This option can be omitted if VERBOSE environment variable or CMAKE_VERBOSE_MAKEFILE cached variable is set.

       --     Pass remaining options to the native tool.
```

Solution: Replace option `cmake -v` by `export VERBOSE=1 ; cmake`.

Note:
    Found no easy way to detect if `-v` is supported or not.
    At least, if VERBOSE is not supported, this won't break the build.

Tests:
    Regenerated ZYRE & CZMQ with this fix.
    Called the same build method.