### PR TITLE
Problem: Compilation fails on CentOS, due to duplicate lib entry.

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -432,13 +432,7 @@ dependencies {
 //  Build section
 
 task copyLibs(type: Copy) {
-    def libraryPaths = System.getProperty('java.library.path').split(File.pathSeparator).toList()
-    libraryPaths.add('/usr/local/lib')
-    if (osdetector.os == 'windows') {
-        libraryPaths.add("${rootDir}/$(project.prefix:c)-jni/build/Release")
-    } else {
-        libraryPaths.add("${rootDir}/$(project.prefix:c)-jni/build")
-    }
+    def libraryPaths = []
     if (project.hasProperty('buildPrefix')) {
         if (osdetector.os == 'windows') {
             // DLLs are installed to the bin directory by cmake
@@ -447,6 +441,18 @@ task copyLibs(type: Copy) {
         libraryPaths.add("${project.buildPrefix}/lib")
     }
 
+    def javaLibraryPaths = System.getProperty('java.library.path').split(File.pathSeparator).toList()
+    libraryPaths.addAll (javaLibraryPaths)
+
+    libraryPaths.add('/usr/local/lib')
+    if (osdetector.os == 'windows') {
+        libraryPaths.add("${rootDir}/$(project.prefix:c)-jni/build/Release")
+    } else {
+        libraryPaths.add("${rootDir}/$(project.prefix:c)-jni/build")
+    }
+
+    def oldStrategy = duplicatesStrategy
+    duplicatesStrategy = DuplicatesStrategy.WARN
     libraryPaths.each { path ->
         from path
             include '$(project.libname)jni.so'
@@ -462,6 +468,7 @@ task copyLibs(type: Copy) {
 .   endfor
         into 'build/natives'
     }
+    duplicatesStrategy = oldStrategy
 }
 
 jar.baseName = "$(project.prefix:c)-jni-${osdetector.classifier}"


### PR DESCRIPTION
ZYRE compilation started for Android, with a similar script to zyre/bingings/jni/ci_build.sh.

Compilation ends with:
```
> Task :czmq-jni-native:classes UP-TO-DATE
Skipping task ':czmq-jni-native:classes' as it has no actions.
:czmq-jni-native:classes (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:czmq-jni-native:copyLibs (Thread[Execution worker for ':',5,main]) started.

> Task :czmq-jni-native:copyLibs FAILED
Caching disabled for task ':czmq-jni-native:copyLibs' because:
  Build cache is disabled
Task ':czmq-jni-native:copyLibs' is not up-to-date because:
  No history is available.
file or directory '/usr/java/packages/lib', not found
:czmq-jni-native:copyLibs (Thread[Execution worker for ':',5,main]) completed. Took 0.062 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':czmq-jni-native:copyLibs'.
> Entry libcurl.so is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.4.2/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```

Investigation have shown 2 things:
- On CentOS, /lib and /lib64 point to /usr/lib and /usr/lib64: ``` prompt> ls -ald /lib /lib64 lrwxrwxrwx. 1 root root 7 12 janv.  2020 /lib -> usr/lib lrwxrwxrwx. 1 root root 9 12 janv.  2020 /lib64 -> usr/lib64 prompt> ```
- Since Gradle 7, one has to set a duplicate strategy, when using copyLibs: https://github.com/gradle/gradle/issues/17236

Solution: Set duplicate strategy to warn, not to stop the build.

Additionnally, add libraries found in $BUILD_PREFIX first, then, the system ones, in case one wants to have his own library version in the JAR.

This fixes CZMQ issue https://github.com/zeromq/czmq/issues/2231