### PR TITLE
Problem: builds/android/ci_build.sh must download tarball, when required.

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -218,7 +218,15 @@ fi
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 
-.for use where defined (use.repository)
+.for use where defined (use.tarball)
+export $(USE.PROJECT)_ROOT="/tmp/tmp-deps/$(use.project)"
+rm -f \$(basename "$(use.tarball)")
+wget $(use.tarball)
+tar -xzf \$(basename "$(use.tarball)")
+mv \$(basename "$(use.tarball)" .tar.gz) \$$(USE.PROJECT)_ROOT
+
+.endfor
+.for use where defined (use.repository) & ! defined (use.tarball)
 export $(USE.PROJECT)_ROOT="/tmp/tmp-deps/$(use.project)"
 .   if defined (use.release)
 git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $$(USE.PROJECT)_ROOT


### PR DESCRIPTION
A call to `<CZMQ>/builds/android/ci_build.sh` shows the following:
```
fatal: unable to update url base from redirection:
  asked for: https://gnunet.org/git/libmicrohttpd.git/info/refs?service=git-upload-pack
   redirect: https://git.gnunet.org/
```

The generated code in `<CZMQ>/builds/android/ci_build.sh` is:
```
export LIBMICROHTTPD_ROOT="/tmp/tmp-deps/libmicrohttpd"
git clone --quiet --depth 1 https://gnunet.org/git/libmicrohttpd.git $LIBMICROHTTPD_ROOT
```

The same kind of download in `<CZMQ>/bindings/jni/ci_build.sh` looks like:
```
export LIBMICROHTTPD_ROOT="/tmp/tmp-deps/libmicrohttpd"
wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
tar -xzf $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
mv $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz) $LIBMICROHTTPD_ROOT
```

Solution: The code generating `builds/android/ci_build.sh` should be similar to the one generating `bindings/jni/ci_build.sh`.