### PR TITLE
Problem: ZProject fails to regenerate ZYRE/include/zyre.h

### DIFF
--- a/zproject_skeletons.gsl
+++ b/zproject_skeletons.gsl
@@ -355,7 +355,7 @@ extern "C" {
 
 .   if class.c_name = project.name
 //  Include the library file with typdefs, public includes and public constants
-#include "$(class.name)_library.$(project.headerext)"
+#include "$(class.name)_library.$(project.header_ext)"
 
 .   endif
 //  @interface


### PR DESCRIPTION
Scenario:
```
cd zyre
rm -f include/zyre.h
(export PATH=$PWD/../zproject:$PATH; ./generate.sh)
```

Result:
```
...
gsl/4 M: W: in zyre event: 'zmsg' does not resolve to a class
gsl/4 M: W: in zyre event: 'zmsg' does not resolve to a class
gsl/4 M: NOT regenerating an existing include/zyre.h skeleton file; but you probably should not care
gsl/4 M: Generating skeleton for include/zyre.h
(zproject_skeletons.gsl 358) Undefined expression: project.headerext
```

Reason:
Typo introduced in zproject_skeletons.gsl:
https://github.com/zeromq/zproject/blame/master/zproject_skeletons.gsl#L358

Instead of:
```
#include "$(class.name)_library.$(project.headerext)"
```

it should be (like in other places):
```
#include "$(class.name)_library.$(project.header_ext)"
```

Solution: Fix typo.