### PR TITLE
Problem: Android build system needs some debug (./configure options)

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -175,8 +175,20 @@ fi
 
     export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
-    (cd "${cache}/$(project.name)" && $CI_TIME ./autogen.sh 2> /dev/null \\
-        && $CI_TIME ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" --without-docs \\
+    (
+        CONFIG_OPTS=()
+        CONFIG_OPTS+=("--quiet")
+        CONFIG_OPTS+=("${ANDROID_BUILD_OPTS[@]}")
+        CONFIG_OPTS+=("--without-docs")
+
+        cd "${cache}/$(project.name)" \\
+        && $CI_TIME ./autogen.sh 2> /dev/null \\
+.if defined (use.libname?)
+        && android_show_configure_opts "$(USE.LIBNAME)" "${CONFIG_OPTS[@]}" \\
+.else
+        && android_show_configure_opts "$(PROJECT.LIBNAME)" "${CONFIG_OPTS[@]}" \\
+.endif
+        && $CI_TIME ./configure "${CONFIG_OPTS[@]}" \\
         && $CI_TIME make -j 4 \\
         && $CI_TIME make install) || exit 1
 }
@@ -587,6 +599,16 @@ function android_build_verify_so {
 }
 
 .endliteral
+function android_show_configure_opts {
+    local tag=$1
+    shift
+    echo "$(PROJECT.PREFIX) (${BUILD_ARCH}) - ./configure options to build '${tag}':"
+    for opt in "$@"; do
+        echo "  > ${opt}"
+    done
+    echo ""
+}
+
 $(project.GENERATED_WARNING_HEADER:)
 .close
 .chmod_x ("builds/android/android_build_helper.sh")


### PR DESCRIPTION
Proposal is to dump ./configure options to have an output like below:

```
LIBZMQ (x86_64) - ./configure options to build 'LIBZMQ':
  > --quiet
  > TOOLCHAIN=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64
  > CC=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang
  > CXX=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang++
  > LD=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/ld
  > AS=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-as
  > AR=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
  > RANLIB=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib
  > STRIP=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip
  > CFLAGS= -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE
  > CPPFLAGS= -I/builds/CrisalidBox/zproject-android-testing/libzmq/builds/android/prefix/x86_64/include
  > CXXFLAGS=
  > LDFLAGS=-L/builds/CrisalidBox/zproject-android-testing/libzmq/builds/android/prefix/x86_64/lib -L/tmp/android-ndk-r25/sources/cxx-stl/llvm-libc++/libs/x86_64
  > LIBS=-lc -ldl -lm -llog -lc++_shared
  > PKG_CONFIG_LIBDIR=/tmp/android-ndk-r25/prebuilt/linux-x86_64/lib/pkgconfig
  > PKG_CONFIG_PATH=/builds/CrisalidBox/zproject-android-testing/libzmq/builds/android/prefix/x86_64/lib/pkgconfig
  > PKG_CONFIG_SYSROOT_DIR=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/sysroot
  > PKG_CONFIG_DIR=
  > --with-sysroot=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/sysroot
  > --host=x86_64-linux-android
  > --prefix=/builds/CrisalidBox/zproject-android-testing/libzmq/builds/android/prefix/x86_64
  > --disable-curve
  > --without-docs
```

Notes:

  This mechanism is already in place in LIBZMQ.

  This mechanism is added before every call of `./configure`.