### PR TITLE
Problem: Android APP fails to load ZMQ since NDK r25.x

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -95,6 +95,12 @@ cd "\$( dirname "${BASH_SOURCE[0]}" )"
 # Get access to android_build functions and variables
 source ./android_build_helper.sh
 
+# Choose a C++ standard library implementation from the ndk
+export ANDROID_BUILD_CXXSTL="gnustl_shared_49"
+
+# Additional flags for LIBTOOL, for LIBZMQ and other dependencies.
+export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
+
 BUILD_ARCH=$1
 if [ -z $BUILD_ARCH ]; then
     usage
@@ -172,8 +178,6 @@ fi
 
     # Remove *.la files as they might cause errors with cross compiled libraries
     find ${ANDROID_BUILD_PREFIX} -name '*.la' -exec rm {} +
-
-    export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
     (
         CONFIG_OPTS=()
@@ -368,6 +372,18 @@ function android_build_set_env {
        export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/sysroot"
     fi
     export ANDROID_BUILD_PREFIX="${ANDROID_BUILD_DIR}/prefix/${TOOLCHAIN_ARCH}"
+
+    # Since NDK r25, libc++_shared.so is no more in 'sources/cxx-stl/...'
+    export ANDROID_STL="libc++_shared.so"
+    if [ -x "${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TOOLCHAIN_ABI}/${ANDROID_STL}" ] ; then
+        export ANDROID_STL_ROOT="${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TOOLCHAIN_ABI}"
+    else
+        export ANDROID_STL_ROOT="${ANDROID_BUILD_SYSROOT}/usr/lib/${TOOLCHAIN_HOST}"
+
+        # NDK 25 requires -L<path-to-libc.so> ...
+        # I don't understand why, but without it, ./configure fails to build a valid 'conftest'.
+        export ANDROID_LIBC_ROOT="${ANDROID_BUILD_SYSROOT}/usr/lib/${TOOLCHAIN_HOST}/${MIN_SDK_VERSION}"
+    fi
 }
 
 function android_build_env {
@@ -377,6 +393,16 @@ function android_build_env {
     if [ -z "$ANDROID_NDK_ROOT" ]; then
         ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_ROOT environment variable")
         ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25\")")
+    fi
+
+    if [ ! -d "$ANDROID_STL_ROOT" ]; then
+        ANDROID_BUILD_FAIL+=("The ANDROID_STL_ROOT directory does not exist")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_STL_ROOT}")
+    fi
+
+    if [ -n "${ANDROID_LIBC_ROOT}" ] && [ ! -d "${ANDROID_LIBC_ROOT}" ]; then
+        ANDROID_BUILD_FAIL+=("The ANDROID_LIBC_ROOT directory does not exist")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_LIBC_ROOT}")
     fi
 
     if [ -z "$TOOLCHAIN_PATH" ]; then
@@ -522,7 +548,10 @@ function android_build_opts {
         local LIBS="-lc -lgcc -ldl -lm -llog -lc++_shared"
     fi
     local LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
-    LDFLAGS+=" -L${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TOOLCHAIN_ABI}"
+    if [ -n "${ANDROID_LIBC_ROOT}" ] ; then
+        LDFLAGS+=" -L${ANDROID_LIBC_ROOT}"
+    fi
+    LDFLAGS+=" -L${ANDROID_STL_ROOT}"
     CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
     CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
 

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -828,11 +828,7 @@ unzip -qo "${$(USE.PROJECT)_ROOT:-../../../../../../$(use.project)}/bindings/jni
 mkdir -p lib/$TOOLCHAIN_ABI
 cp $(project.libname)jni.so lib/$TOOLCHAIN_ABI
 cp $ANDROID_BUILD_PREFIX/lib/*.so lib/$TOOLCHAIN_ABI
-if [ ! -x $ANDROID_NDK_ROOT/sources/cxx-stl/llvm-libc++/libs/$TOOLCHAIN_ABI/libc++_shared.so ]; then
-    cp $ANDROID_BUILD_SYSROOT/usr/lib/$TOOLCHAIN_HOST/libc++_shared.so lib/$TOOLCHAIN_ABI
-else
-    cp $ANDROID_NDK_ROOT/sources/cxx-stl/llvm-libc++/libs/$TOOLCHAIN_ABI/libc++_shared.so lib/$TOOLCHAIN_ABI
-fi
+cp ${ANDROID_STL_ROOT}/${ANDROID_STL} lib/$TOOLCHAIN_ABI
 
 #   Build android jar
 zip -r -m ../$(project.prefix)-android-$TOOLCHAIN_ABI-$(->version.major).$(->version.minor).$(->version.patch).jar lib/ org/ META-INF/


### PR DESCRIPTION
Same cause than explained in
https://github.com/zeromq/libzmq/pull/4437

Solution: Fix invalid LDFLAGS.

Notes:

- Still fails on physical devices.