### PR TITLE
Problem: Android build helpers not in sync with LIBZMQ.

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -297,7 +297,6 @@ $(project.GENERATED_WARNING_HEADER:)
 .output "builds/android/android_build_helper.sh"
 #!/usr/bin/env bash
 $(project.GENERATED_WARNING_HEADER:)
-.literal << .endliteral
 #
 # Courtesy of Joe Eli McIlvain; original code at:
 # https://github.com/jemc/android_build_helper
@@ -319,19 +318,21 @@ $(project.GENERATED_WARNING_HEADER:)
 # This script is provided with no express or implied warranties.
 #
 
-# Get directory of current script (if not already set)
-# This directory is also the basis for the build directories the get created.
-if [ -z "$ANDROID_BUILD_DIR" ]; then
-    ANDROID_BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-fi
+########################################################################
+# Utilities & helper functions
+########################################################################
+function android_build_trace {
+    if [ -n "${BUILD_ARCH}" ] ; then
+        echo "$(PROJECT.PREFIX) (${BUILD_ARCH}) - \$*"
+    else
+        echo "$(PROJECT.PREFIX) - \$*"
+    fi
+}
 
-# Set up a variable to hold the global failure reasons, separated by newlines
-# (Empty string indicates no failure)
-ANDROID_BUILD_FAIL=()
-
+.literal << .endliteral
 function android_build_check_fail {
     if [ ! ${#ANDROID_BUILD_FAIL[@]} -eq 0 ]; then
-        echo "Android (${TOOLCHAIN_ARCH}) build failed for the following reasons:"
+        android_build_trace "Android build failed for the following reasons:"
         for reason in "${ANDROID_BUILD_FAIL[@]}"; do
             local formatted_reason="  ${reason}"
             echo "${formatted_reason}"
@@ -340,28 +341,85 @@ function android_build_check_fail {
     fi
 }
 
+function android_download_ndk {
+    if [ -d "${ANDROID_NDK_ROOT}" ] ; then
+        # NDK folder detected, let's assume it's valid ...
+        android_build_trace "Using existing NDK folder '${ANDROID_NDK_ROOT}'."
+        return
+    fi
+    if [ ! -d  "$(dirname "${ANDROID_NDK_ROOT}")" ] ; then
+        ANDROID_BUILD_FAIL+=("Cannot download NDK in a non existing folder")
+        ANDROID_BUILD_FAIL+=("  $(dirname "${ANDROID_NDK_ROOT}/")")
+    fi
+
+    if [ -z "${ANDROID_NDK_FILENAME}" ] ; then
+        ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_FILENAME environment variable")
+    fi
+
+    android_build_check_fail
+
+    android_build_trace "Downloading NDK '${NDK_VERSION}'..."
+    (
+        cd "$(dirname "${ANDROID_NDK_ROOT}")" \
+        && rm -f "${ANDROID_NDK_FILENAME}" \
+        && wget -q "http://dl.google.com/android/repository/${ANDROID_NDK_FILENAME}" -O "${ANDROID_NDK_FILENAME}" \
+        && android_build_trace "Extracting NDK '${ANDROID_NDK_FILENAME}'..." \
+        && unzip -q "${ANDROID_NDK_FILENAME}" \
+        && android_build_trace "NDK extracted under '${ANDROID_NDK_ROOT}'."
+    ) || {
+        ANDROID_BUILD_FAIL+=("Failed to install NDK ('${NDK_VERSION}')")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_NDK_FILENAME}")
+    }
+
+    android_build_check_fail
+}
+
 function android_build_set_env {
     BUILD_ARCH=$1
 
-    export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
+    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+    case "${platform}" in
+        linux*)
+            if [ "${NDK_NUMBER}" -ge 2300 ] ; then
+                # Since NDK 23, NDK archives are renamed.
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-linux.zip
+            else
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-linux-x86_64.zip
+            fi
+            export ANDROID_BUILD_PLATFORM=linux-x86_64
+            ;;
+        darwin*)
+            if [ "${NDK_NUMBER}" -ge 2300 ] ; then
+                # Since NDK 23, NDK archives are renamed.
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-darwin.zip
+            else
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-darwin-x86_64.zip
+            fi
+            export ANDROID_BUILD_PLATFORM=darwin-x86_64
+            ;;
+        *)    android_build_trace "Unsupported platform ('${platform}')" ; exit 1 ;;
+    esac
+
+    export ANDROID_BUILD_TOOLCHAIN="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_BUILD_PLATFORM}"
+    export TOOLCHAIN_PATH="${ANDROID_BUILD_TOOLCHAIN}/bin"
 
     # Set variables for each architecture
-    if [ $BUILD_ARCH == "arm" ]; then
+    if [ "${BUILD_ARCH}" == "arm" ]; then
         export TOOLCHAIN_HOST="arm-linux-androideabi"
         export TOOLCHAIN_COMP="armv7a-linux-androideabi${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="armeabi-v7a"
         export TOOLCHAIN_ARCH="arm"
-    elif [ $BUILD_ARCH == "x86" ]; then
+    elif [ "${BUILD_ARCH}" == "x86" ]; then
         export TOOLCHAIN_HOST="i686-linux-android"
         export TOOLCHAIN_COMP="i686-linux-android${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="x86"
         export TOOLCHAIN_ARCH="x86"
-    elif [ $BUILD_ARCH == "arm64" ]; then
+    elif [ "${BUILD_ARCH}" == "arm64" ]; then
         export TOOLCHAIN_HOST="aarch64-linux-android"
         export TOOLCHAIN_COMP="aarch64-linux-android${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="arm64-v8a"
         export TOOLCHAIN_ARCH="arm64"
-    elif [ $BUILD_ARCH == "x86_64" ]; then
+    elif [ "${BUILD_ARCH}" == "x86_64" ]; then
         export TOOLCHAIN_HOST="x86_64-linux-android"
         export TOOLCHAIN_COMP="x86_64-linux-android${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="x86_64"
@@ -370,9 +428,9 @@ function android_build_set_env {
 
     # Since NDK r22 the "platforms" dir got removed
     if [ -d "${ANDROID_NDK_ROOT}/platforms" ]; then
-       export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
+        export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
     else
-       export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/sysroot"
+        export ANDROID_BUILD_SYSROOT="${ANDROID_BUILD_TOOLCHAIN}/sysroot"
     fi
     export ANDROID_BUILD_PREFIX="${ANDROID_BUILD_DIR}/prefix/${TOOLCHAIN_ARCH}"
 
@@ -398,14 +456,9 @@ function android_build_env {
         ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25\")")
     fi
 
-    if [ ! -d "$ANDROID_STL_ROOT" ]; then
-        ANDROID_BUILD_FAIL+=("The ANDROID_STL_ROOT directory does not exist")
-        ANDROID_BUILD_FAIL+=("  ${ANDROID_STL_ROOT}")
-    fi
-
-    if [ -n "${ANDROID_LIBC_ROOT}" ] && [ ! -d "${ANDROID_LIBC_ROOT}" ]; then
-        ANDROID_BUILD_FAIL+=("The ANDROID_LIBC_ROOT directory does not exist")
-        ANDROID_BUILD_FAIL+=("  ${ANDROID_LIBC_ROOT}")
+    if [ -z "$ANDROID_BUILD_TOOLCHAIN" ]; then
+        ANDROID_BUILD_FAIL+=("Please set the ANDROID_BUILD_TOOLCHAIN environment variable")
+        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64\")")
     fi
 
     if [ -z "$TOOLCHAIN_PATH" ]; then
@@ -443,6 +496,21 @@ function android_build_env {
         ANDROID_BUILD_FAIL+=("  ${ANDROID_NDK_ROOT}")
     fi
 
+    if [ ! -d "$ANDROID_STL_ROOT" ]; then
+        ANDROID_BUILD_FAIL+=("The ANDROID_STL_ROOT directory does not exist")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_STL_ROOT}")
+    fi
+
+    if [ -n "${ANDROID_LIBC_ROOT}" ] && [ ! -d "${ANDROID_LIBC_ROOT}" ]; then
+        ANDROID_BUILD_FAIL+=("The ANDROID_LIBC_ROOT directory does not exist")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_LIBC_ROOT}")
+    fi
+
+    if [ ! -d "${ANDROID_BUILD_TOOLCHAIN}" ]; then
+        ANDROID_BUILD_FAIL+=("The ANDROID_BUILD_TOOLCHAIN directory does not exist")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_TOOLCHAIN}")
+    fi
+
     if [ ! -d "$TOOLCHAIN_PATH" ]; then
         ANDROID_BUILD_FAIL+=("The TOOLCHAIN_PATH directory does not exist")
         ANDROID_BUILD_FAIL+=("  ${TOOLCHAIN_PATH}")
@@ -465,75 +533,74 @@ function android_build_env {
 }
 
 function _android_build_opts_process_binaries {
-    local TOOLCHAIN="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}"
-    local CC="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang"
-    local CXX="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang++"
+    export ANDROID_BUILD_CC="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang"
+    export ANDROID_BUILD_CXX="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang++"
     # Since NDK r22 the "platforms" dir got removed and the default linker is LLD
     if [ -d "${ANDROID_NDK_ROOT}/platforms" ]; then
-       local LD="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ld"
+       export ANDROID_BUILD_LD="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ld"
     else
-       local LD="${TOOLCHAIN_PATH}/ld"
+       export ANDROID_BUILD_LD="${TOOLCHAIN_PATH}/ld"
     fi
     # Since NDK r24 this binary was removed due to LLVM being now the default
     if [ ! -x "${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-as" ]; then
-        local AS="${TOOLCHAIN_PATH}/llvm-as"
+        export ANDROID_BUILD_AS="${TOOLCHAIN_PATH}/llvm-as"
     else
-        local AS="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-as"
+        export ANDROID_BUILD_AS="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-as"
     fi
     # Since NDK r23 those binaries were removed due to LLVM being now the default
     if [ ! -x "${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar" ]; then
-        local AR="${TOOLCHAIN_PATH}/llvm-ar"
-        local RANLIB="${TOOLCHAIN_PATH}/llvm-ranlib"
-        local STRIP="${TOOLCHAIN_PATH}/llvm-strip"
+        export ANDROID_BUILD_AR="${TOOLCHAIN_PATH}/llvm-ar"
+        export ANDROID_BUILD_RANLIB="${TOOLCHAIN_PATH}/llvm-ranlib"
+        export ANDROID_BUILD_STRIP="${TOOLCHAIN_PATH}/llvm-strip"
     else
-        local AR="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar"
-        local RANLIB="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ranlib"
-        local STRIP="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-strip"
+        export ANDROID_BUILD_AR="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar"
+        export ANDROID_BUILD_RANLIB="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ranlib"
+        export ANDROID_BUILD_STRIP="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-strip"
     fi
 
-    if [ ! -x "${CC}" ]; then
+    if [ ! -x "${ANDROID_BUILD_CC}" ]; then
         ANDROID_BUILD_FAIL+=("The CC binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${CC}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_CC}")
     fi
 
-    if [ ! -x "${CXX}" ]; then
+    if [ ! -x "${ANDROID_BUILD_CXX}" ]; then
         ANDROID_BUILD_FAIL+=("The CXX binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${CXX}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_CXX}")
     fi
 
-    if [ ! -x "${LD}" ]; then
+    if [ ! -x "${ANDROID_BUILD_LD}" ]; then
         ANDROID_BUILD_FAIL+=("The LD binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${LD}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_LD}")
     fi
 
-    if [ ! -x "${AS}" ]; then
+    if [ ! -x "${ANDROID_BUILD_AS}" ]; then
         ANDROID_BUILD_FAIL+=("The AS binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${AS}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_AS}")
     fi
 
-    if [ ! -x "${AR}" ]; then
+    if [ ! -x "${ANDROID_BUILD_AR}" ]; then
         ANDROID_BUILD_FAIL+=("The AR binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${AR}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_AR}")
     fi
 
-    if [ ! -x "${RANLIB}" ]; then
+    if [ ! -x "${ANDROID_BUILD_RANLIB}" ]; then
         ANDROID_BUILD_FAIL+=("The RANLIB binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${RANLIB}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_RANLIB}")
     fi
 
-    if [ ! -x "${STRIP}" ]; then
+    if [ ! -x "${ANDROID_BUILD_STRIP}" ]; then
         ANDROID_BUILD_FAIL+=("The STRIP binary does not exist or is not executable")
-        ANDROID_BUILD_FAIL+=("  ${STRIP}")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_BUILD_STRIP}")
     fi
 
-    ANDROID_BUILD_OPTS+=("TOOLCHAIN=${TOOLCHAIN}")
-    ANDROID_BUILD_OPTS+=("CC=${CC}")
-    ANDROID_BUILD_OPTS+=("CXX=${CXX}")
-    ANDROID_BUILD_OPTS+=("LD=${LD}")
-    ANDROID_BUILD_OPTS+=("AS=${AS}")
-    ANDROID_BUILD_OPTS+=("AR=${AR}")
-    ANDROID_BUILD_OPTS+=("RANLIB=${RANLIB}")
-    ANDROID_BUILD_OPTS+=("STRIP=${STRIP}")
+    ANDROID_BUILD_OPTS+=("TOOLCHAIN=${ANDROID_BUILD_TOOLCHAIN}")
+    ANDROID_BUILD_OPTS+=("CC=${ANDROID_BUILD_CC}")
+    ANDROID_BUILD_OPTS+=("CXX=${ANDROID_BUILD_CXX}")
+    ANDROID_BUILD_OPTS+=("LD=${ANDROID_BUILD_LD}")
+    ANDROID_BUILD_OPTS+=("AS=${ANDROID_BUILD_AS}")
+    ANDROID_BUILD_OPTS+=("AR=${ANDROID_BUILD_AR}")
+    ANDROID_BUILD_OPTS+=("RANLIB=${ANDROID_BUILD_RANLIB}")
+    ANDROID_BUILD_OPTS+=("STRIP=${ANDROID_BUILD_STRIP}")
 
     android_build_check_fail
 }
@@ -546,25 +613,33 @@ function android_build_opts {
 
     # Since NDK r23 we don't need -lgcc due to LLVM being now the default
     if [ ! -x "${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar" ]; then
-        local LIBS="-lc -ldl -lm -llog -lc++_shared"
+        export ANDROID_BUILD_LIBS="-lc -ldl -lm -llog -lc++_shared"
     else
-        local LIBS="-lc -lgcc -ldl -lm -llog -lc++_shared"
+        export ANDROID_BUILD_LIBS="-lc -lgcc -ldl -lm -llog -lc++_shared"
     fi
-    local LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
+
+    export ANDROID_BUILD_LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
     if [ -n "${ANDROID_LIBC_ROOT}" ] ; then
-        LDFLAGS+=" -L${ANDROID_LIBC_ROOT}"
+        ANDROID_BUILD_LDFLAGS+=" -L${ANDROID_LIBC_ROOT}"
     fi
-    LDFLAGS+=" -L${ANDROID_STL_ROOT}"
-    CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
-    CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
+    ANDROID_BUILD_LDFLAGS+=" -L${ANDROID_STL_ROOT}"
 
-    ANDROID_BUILD_OPTS+=("CFLAGS=${CFLAGS} ${ANDROID_BUILD_EXTRA_CFLAGS}")
-    ANDROID_BUILD_OPTS+=("CPPFLAGS=${CPPFLAGS} ${ANDROID_BUILD_EXTRA_CPPFLAGS}")
-    ANDROID_BUILD_OPTS+=("CXXFLAGS=${CXXFLAGS} ${ANDROID_BUILD_EXTRA_CXXFLAGS}")
-    ANDROID_BUILD_OPTS+=("LDFLAGS=${LDFLAGS} ${ANDROID_BUILD_EXTRA_LDFLAGS}")
-    ANDROID_BUILD_OPTS+=("LIBS=${LIBS} ${ANDROID_BUILD_EXTRA_LIBS}")
+    export ANDROID_BUILD_CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
+    export ANDROID_BUILD_CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
 
-    ANDROID_BUILD_OPTS+=("PKG_CONFIG_LIBDIR=${ANDROID_NDK_ROOT}/prebuilt/${HOST_PLATFORM}/lib/pkgconfig")
+    if [ "${NDK_NUMBER}" -ge 2400 ] ; then
+        if [ "${BUILD_ARCH}" = "arm64" ] ; then
+            export ANDROID_BUILD_CXXFLAGS+=" -mno-outline-atomics"
+        fi
+    fi
+
+    ANDROID_BUILD_OPTS+=("CFLAGS=${ANDROID_BUILD_CFLAGS} ${ANDROID_BUILD_EXTRA_CFLAGS}")
+    ANDROID_BUILD_OPTS+=("CPPFLAGS=${ANDROID_BUILD_CPPFLAGS} ${ANDROID_BUILD_EXTRA_CPPFLAGS}")
+    ANDROID_BUILD_OPTS+=("CXXFLAGS=${ANDROID_BUILD_CXXFLAGS} ${ANDROID_BUILD_EXTRA_CXXFLAGS}")
+    ANDROID_BUILD_OPTS+=("LDFLAGS=${ANDROID_BUILD_LDFLAGS} ${ANDROID_BUILD_EXTRA_LDFLAGS}")
+    ANDROID_BUILD_OPTS+=("LIBS=${ANDROID_BUILD_LIBS} ${ANDROID_BUILD_EXTRA_LIBS}")
+
+    ANDROID_BUILD_OPTS+=("PKG_CONFIG_LIBDIR=${ANDROID_NDK_ROOT}/prebuilt/${ANDROID_BUILD_PLATFORM}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_PATH=${ANDROID_BUILD_PREFIX}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_SYSROOT_DIR=${ANDROID_BUILD_SYSROOT}")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_DIR=")
@@ -590,19 +665,20 @@ function android_build_verify_so {
     fi
     android_build_check_fail
 
-    local READELF="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-readelf"
-    if command -v ${READELF} >/dev/null 2>&1 ; then
-        local readelf_bin="${READELF}"
+    local readelf="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-readelf"
+    if command -v "${readelf}" >/dev/null 2>&1 ; then
+        export ANDROID_BUILD_READELF="${readelf}"
     elif command -v readelf >/dev/null 2>&1 ; then
-        local readelf_bin="readelf"
+        export ANDROID_BUILD_READELF="readelf"
     elif command -v greadelf >/dev/null 2>&1 ; then
-        local readelf_bin="greadelf"
+        export ANDROID_BUILD_READELF="greadelf"
     else
-        ANDROID_BUILD_FAIL+=("Could not find any of readelf, greadelf, or ${READELF}")
+        ANDROID_BUILD_FAIL+=("Could not find any of readelf, greadelf, or ${readelf}")
     fi
     android_build_check_fail
 
-    local elfoutput=$(LC_ALL=C $readelf_bin -d ${sofile})
+    local elfoutput
+    elfoutput=$(LC_ALL=C ${ANDROID_BUILD_READELF} -d "${sofile}")
 
     local soname_regexp='soname: \[([[:alnum:]\.]+)\]'
     if [[ $elfoutput =~ $soname_regexp ]]; then
@@ -630,17 +706,102 @@ function android_build_verify_so {
     android_build_check_fail
 }
 
-.endliteral
 function android_show_configure_opts {
     local tag=$1
     shift
-    echo "$(PROJECT.PREFIX) (${BUILD_ARCH}) - ./configure options to build '${tag}':"
+    android_build_trace "./configure options to build '${tag}':"
     for opt in "$@"; do
         echo "  > ${opt}"
     done
     echo ""
 }
 
+function android_clone_library {
+    local tag="$1" ; shift
+    local clone_root="$1" ; shift
+    local clone_url="$1" ; shift
+    local clone_branch="$1" ; shift
+
+    mkdir -p "$(dirname "${clone_root}")"
+    if [ -n "${clone_branch}" ] ; then
+        android_build_trace "Cloning '${clone_url}' (branch '${clone_branch}') under '${clone_root}'."
+        git clone --quiet --depth 1 -b "${clone_branch}" "${clone_url}" "${clone_root}"
+    else
+        android_build_trace "Cloning '${clone_url}' (default branch) under '${clone_root}'."
+        git clone --quiet --depth 1 "${clone_url}" "${clone_root}"
+    fi
+    ( cd "${clone_root}" && git log --oneline -n 1)  || exit 1
+}
+
+# Caller must set CONFIG_OPTS before call.
+function android_build_library {
+    local tag=$1 ; shift
+    local clone_root=$1 ; shift
+
+    android_build_trace "Cleaning library '${tag}'."
+    (
+        cd "${clone_root}" \
+        && ( make clean || : ) && \
+        rm -f config.status
+    ) || exit 1
+
+    (
+        # Remove *.la files as they might cause errors with cross compiled libraries
+        find "${ANDROID_BUILD_PREFIX}" -name '*.la' -exec rm {} +
+
+        cd "${clone_root}" \
+        && ./autogen.sh \
+        && android_show_configure_opts "${tag}" "${CONFIG_OPTS[@]}" \
+        && ./configure "${CONFIG_OPTS[@]}" \
+        && make -j 4 \
+        && make install
+    ) || exit 1
+}
+
+########################################################################
+# Initialization
+########################################################################
+# Get directory of current script (if not already set)
+# This directory is also the basis for the build directories the get created.
+if [ -z "$ANDROID_BUILD_DIR" ]; then
+    ANDROID_BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
+
+# Set up a variable to hold the global failure reasons, separated by newlines
+# (Empty string indicates no failure)
+ANDROID_BUILD_FAIL=()
+
+########################################################################
+# Sanity checks
+########################################################################
+if [ -z "${NDK_VERSION}" ] ; then
+    android_build_trace "NDK_VERSION not set !"
+    exit 1
+fi
+case "${NDK_VERSION}" in
+    "android-ndk-r"[0-9][0-9] ) : ;;
+    "android-ndk-r"[0-9][0-9][a-z] ) : ;;
+    * ) android_build_trace "Invalid format for NDK_VERSION ('${NDK_VERSION}')" ; exit 1 ;;
+esac
+
+if [ -z "${ANDROID_NDK_ROOT}" ] ; then
+    android_build_trace "ANDROID_NDK_ROOT not set !"
+    exit 1
+fi
+
+########################################################################
+# Compute NDK version into a numeric form:
+#   android-ndk-r21e -> 2105
+#   android-ndk-r25  -> 2500
+########################################################################
+export NDK_NUMBER="$(( $(echo "${NDK_VERSION}"|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
+NDK_VERSION_LETTER="$(echo "${NDK_VERSION}"|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[:lower:]' '[:upper:]')"
+if [ -n "${NDK_VERSION_LETTER}" ] ; then
+    NDK_NUMBER=$(( $(( NDK_NUMBER + $(printf '%d' \'"${NDK_VERSION_LETTER}") )) - 64 ))
+fi
+android_build_trace "Configured NDK_VERSION: ${NDK_VERSION} ($NDK_NUMBER)."
+
+.endliteral
 $(project.GENERATED_WARNING_HEADER:)
 .close
 .chmod_x ("builds/android/android_build_helper.sh")


### PR DESCRIPTION
A few enhancements/code review/shellcheck fixes have been applied recently to Android helpers in LIBZMQ. New helper functions, variables, checks,... were added. All can be of interest for CZMQ, ZYRE but also for any other zproject-generated ilbrary.

Solution: Report Android helper modifications in one shot from LIBZMQ to ZPROJECT.

This concerns only the helpers. CI build scripts are not impacted for now, as they may require more specific tests, but they will follow the same soon.

Method:
- Manual report of LIBZMQ helper modifications to CZMQ & ZYRE.
- Check all still compile fine. --> This gives CZMQ & ZYRE "expected source tree".
- Report the modifications to ZPROJECT.
- Call GSL to generate CZMQ & ZYRE bindings.
- Diff between generated code and their "expected source tree".
- Check all still compile fine.