### PR TITLE
Summary: Problem: Android build fails due to use of JCenter

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -149,7 +149,11 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
+        // BINTRAY no more responding.
+        // JFROG announced JCENTER & BINTRAY shutdown in 2021.
+        // - What to do for the JFROG plugin ?
+        // - Is the README still valid ?
+        /* jcenter() */
     }
 
     group = '$(project.namespace)'


### PR DESCRIPTION
Since last Saturday, Android build fails with:
FAILURE: Build failed with an exception.
    * Where:
    Build file '/builds/CrisalidBox/zproject-android-testing/zyre/bindings/jni/zyre-jni/build.gradle' line: 25
    * What went wrong:
    A problem occurred evaluating project ':zyre-jni'.
    > Could not resolve all files for configuration ':zyre-jni:runtimeClasspath'.
       > Could not resolve org.zeromq.czmq:czmq-jni:latest.integration.
         Required by:
             project :zyre-jni
          > Failed to list versions for org.zeromq.czmq:czmq-jni.
             > Unable to load Maven meta-data from https://jcenter.bintray.com/org/zeromq/czmq/czmq-jni/maven-metadata.xml.
                > Could not GET 'https://jcenter.bintray.com/org/zeromq/czmq/czmq-jni/maven-metadata.xml'.
                   > Read timed out

https://jcenter.bintray.com/ does not respond at all any more:

    prompt> wget https://jcenter.bintray.com/
    --2022-10-31 06:54:04--  https://jcenter.bintray.com/
    Resolving jcenter.bintray.com (jcenter.bintray.com)... 34.95.74.180
    Connecting to jcenter.bintray.com (jcenter.bintray.com)|34.95.74.180|:443... connected.
    HTTP request sent, awaiting response... 504 Gateway Time-out
    Retrying.
    prompt>

or

    prompt> get https://jcenter.bintray.com/index.html
    --2022-10-31 06:57:15--  https://jcenter.bintray.com/index.html
    Resolving jcenter.bintray.com (jcenter.bintray.com)... 34.95.74.180
    Connecting to jcenter.bintray.com (jcenter.bintray.com)|34.95.74.180|:443... connected.
    HTTP request sent, awaiting response... 404 Not Found
    2022-10-31 06:57:16 ERROR 404: Not Found.
    prompt>

From stackoverflow:

    https://stackoverflow.com/questions/66400264/jcenter-is-at-end-of-life-android-lint-warning-what-is-the-replacement

BINTRAY is stopped by JFROG, and is no more responding.

Solution: Remove `jcenter` from artifact search repositories.

As explained by stackoverflow, jcenter() should be replaced by mavenCentral(). This mavenCentral() is already available in ZPROJECT generated code.

Questions:

- What to do with JFROG plugins ?
- Are they still useful ?
- What to do with the extising 'publish' mechanism ?
- Is it still working ?
- README update ?