### PR TITLE
Revert "Summary: Problem: Android build fails due to use of JCenter"

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -149,11 +149,7 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        // BINTRAY no more responding.
-        // JFROG announced JCENTER & BINTRAY shutdown in 2021.
-        // - What to do for the JFROG plugin ?
-        // - Is the README still valid ?
-        /* jcenter() */
+        jcenter()
     }
 
     group = '$(project.namespace)'


### PR DESCRIPTION
2 reasons to revert:
- Former PR is incomplete and breaks "release" Android builds ("snapshot" are not impacted).
A complete solution would involve another artifact repository.
- Jcenter/Bintray are back in service, after outage.
