### PR TITLE
Problem: Android CI build need a way to disable GRADLE automatic tests.

### DIFF
--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -777,6 +777,10 @@ source ../../../../builds/android/android_build_helper.sh
 export MIN_SDK_VERSION=21
 export ANDROID_BUILD_DIR=/tmp/android_build
 
+GRADLEW_OPTS=()
+GRADLEW_OPTS+=("-PbuildPrefix=$BUILD_PREFIX")
+GRADLEW_OPTS+=("--info")
+
 #   Build any dependent libraries
 #   Use a default value assuming that dependent libraries sits alongside this one
 .for project.use
@@ -791,7 +795,7 @@ echo "********  Building $(project.name:) Android native libraries"
 
 #   Ensure we've built JNI interface
 echo "********  Building $(project.name:) JNI interface & classes"
-( cd ../.. && TERM=dumb ./gradlew build jar -PbuildPrefix=$BUILD_PREFIX --info )
+( cd ../.. && TERM=dumb ./gradlew build jar ${GRADLEW_OPTS[@]} ${$(PROJECT.PREFIX)_GRADLEW_OPTS} )
 
 echo "********  Building $(project.name:) JNI for Android"
 rm -rf build && mkdir build && cd build
@@ -954,6 +958,10 @@ if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CO
     CONFIG_OPTS+=("--quiet")
 fi
 
+GRADLEW_OPTS=()
+GRADLEW_OPTS+=("-PbuildPrefix=$BUILD_PREFIX")
+GRADLEW_OPTS+=("--info")
+
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 
@@ -995,7 +1003,7 @@ cd \$$(USE.PROJECT)_ROOT
 
 .       if count (project->dependencies.class, class.project = use.project) > 0
 # Build jni dependency
-( cd bindings/jni && TERM=dumb $CI_TIME ./gradlew publishToMavenLocal -PbuildPrefix=$BUILD_PREFIX --info )
+( cd bindings/jni && TERM=dumb $CI_TIME ./gradlew publishToMavenLocal ${GRADLEW_OPTS[@]} ${$(USE.PREFIX)_GRADLEW_OPTS} )
 .       endif
 
 .endfor
@@ -1007,7 +1015,7 @@ cd \$$(PROJECT.PREFIX)_ROOT
 cd ${$(PROJECT.PREFIX)_JNI_ROOT}
 [ -z "$TRAVIS_TAG" ] || IS_RELEASE="-PisRelease"
 
-TERM=dumb $CI_TIME ./gradlew build jar -PbuildPrefix=$BUILD_PREFIX $IS_RELEASE --info
+TERM=dumb $CI_TIME ./gradlew build jar ${GRADLEW_OPTS[@]} ${$(PROJECT.PREFIX)_GRADLEW_OPTS} $IS_RELEASE
 TERM=dumb $CI_TIME ./gradlew clean
 
 ########################################################################


### PR DESCRIPTION
Reasons:

- ZYRE tests fail if the host firewall blocks ZRE or any other required port.

- ZYRE tests may fail if 2 or more tests are launched in parallel (SHOUT messages are received by the wrong test client).

Solution: Provide a variable to pass specific options to GRADLEW.

How to use:

    export ZYRE_GRADLEW_OPTS="-x test"
    cd zyre/bindings/jni
    ./ci_build.sh

ZYRE CI build scripts also builds CZMQ, with a different call to GRADLEW. To pass options to CZMQ GRADLEW, use the following:

    export CZMQ_GRADLEW_OPTS="xxx"
    cd zyre/bindings/jni
    ./ci_build.sh

If one wants to disable ZYRE & CZMQ gradlew automatic tests, use the following:

    export CZMQ_GRADLEW_OPTS="-x test"
    export ZYRE_GRADLEW_OPTS="-x test"
    cd zyre/bindings/jni
    ./ci_build.sh

Note: This adds another possibility to build ZYRE JNI releases. Old way was like :

    export TRAVIS_TAG="yes"
    cd zyre/bindings/jni
    ./ci_build.sh

New way can be (with or without '-x test'):

    export ZYRE_GRADLEW_OPTS="-PisRelease"
    cd zyre/bindings/jni
    ./ci_build.sh