### PR TITLE
Problem: ZProject ANDROID build scripts and documentations are not up-to-date, compared to LIBZMQ.

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -18,42 +18,133 @@ register_target ("android", "Native shared library for Android")
 .output "builds/android/README.md"
 # Android Build
 
-## Prerequisites
+## Preamble
 
-You need the Android Native Development Kit (NDK) installed. See
-[here](https://developer.android.com/ndk) to download it.
+The last known NDK is automatically downloaded, if not specified otherwise.
 
-This project is tested against Android NDK version r25.
+As indicated in LIBZMQ main [README](https://github.com/zeromq/libzmq/blob/master/README.md#supported-platforms-with-primary-CI),
+Android support is still DRAFT.
 
-If you installed version r25 all you have to do is to expose the NDK root
-directory as environment variable, e.g:
+## Configuration
 
-    export ANDROID_NDK_ROOT=$HOME/android-ndk-r25
+### Basics
 
-If you installed another version you have to expose the NDK root directory as
-well as the NDK version, e.g:
+Basically, $(PROJECT.NAME) build for Android, relies on exported variables.
 
-    export ANDROID_NDK_ROOT=$HOME/android-ndk-r17c
-    export NDK_VERSION=android-ndk-r17c
+Provided build scripts can mainly be used like
 
-To specify the minimum sdk version set the environment variable below:
+    export XXX=xxx
+    export YYY=yyy
+    ...
+    cd <$(project.name:c)>/builds/android
+    ./<build_script>
+
+
+### Android NDK
+
+$(PROJECT.NAME) is tested against Android NDK versions r19 to r25.
+
+By default, $(PROJECT.NAME) uses NDK `android-ndk-r25`, but you can specify
+a different one:
+
+    export NDK_VERSION=android-ndk-r23c
+
+If you already have installed your favorite NDK somewhere, all you have to
+do is to export and set NDK_VERSION and ANDROID_NDK_ROOT environment
+variables, e.g:
+
+    export NDK_VERSION="android-ndk-r23b"
+    export ANDROID_NDK_ROOT=$HOME/${NDK_VERSION}
+
+**Important:** ANDROID_NDK_ROOT must be an absolute path !
+
+If you specify only NDK_VERSION, ANDROID_NDK_ROOT will be automatically set
+to its default:
+
+    export ANDROID_NDK_ROOT=/tmp/${NDK_VERSION}
+
+To specify the minimum SDK version set the environment variable below:
 
     export MIN_SDK_VERSION=21   # Default value if unset
 
-To specify your own Android build directory, set the environment variable below:
+To specify the build directory set the environment variable below:
 
-    # ANDROID_BUILD_DIR must be an absolute path.
-    export ANDROID_BUILD_DIR=<$(project.prefix) absolute path>/builds/android   # Default value if unset
+    export ANDROID_BUILD_DIR=${HOME}/android_build
 
-This configuration will create a prefix folder, like:
+**Important:** ANDROID_BUILD_ROOT must be an absolute path !
 
-    $ANDROID_BUILD_DIR/prefix/<android_arch>.
+### Android build folder
+
+All Android libraries will be generated under:
+
+    ${ANDROID_BUILD_DIR}/prefix/<arch>/lib
+
+where <arch> is one of `arm`, `arm64`, `x86` or `x86_64`.
+
+### Android build cleanup
+
+Build and Dependency storage folders are automatically cleaned,
+by `ci_build.sh`. This can be avoided with the help of
+
+    ANDROID_BUILD_DIR="no"
+
+If you turn this to "no", make sure to clean what has to be, before
+calling `build.sh` or `ci_build.sh`.
+
+### Prebuilt Android libraries
+
+Android prebuilt libraries have to be stored under
+
+    ANDROID_BUILD_DIR/prefix/<arch>/lib
+
+Do not forget to disable [Android cleanup](#android-build-cleanup).
+
+### Dependencies
+
+By default, `build.sh` download dependencies under `/tmp/tmp-deps`.
+
+You can specify another folder with the help of ANDROID_DEPENDENCIES_DIR:
+
+   ANDROID_DEPENDENCIES_DIR=${HOME}/my_dependencies
+
+If you place your own dependency source trees there,
+do not forget to disable [Android cleanup](#android-build-cleanup).
 
 ## Build
 
-In the android directory, run:
+See chapter [Configuration](#configuration) for configuration options and
+other details.
 
-    \./build.sh [ arm | arm64 | x86 | x86_64 ]
+Select your preferred parameters:
+
+    export XXX=xxx
+    export YYY=yyy
+    ...
+
+and run:
+
+    cd <$(project.name:c)>/builds/android
+    ./build.sh [ arm | arm64 | x86 | x86_64 ]
+
+Parameter selection and the calls to build.sh can be located in a
+SHELL script, like in ci_build.sh.
+
+## CI build
+
+Basically, it will call `build.sh` once, for each Android target.
+
+This script accepts the same configuration variables, but some are set
+with different default values. For instance, the dependencies are not
+downloaded or cloned in `/tmp/tmp-deps, but inside LIBZMQ clone.
+
+It can be used in the same way as build.sh
+
+    export XXX=xxx
+    export YYY=yyy
+    cd <$(project.name:c)>/builds/android
+    ./ci_build.sh
+
+
 .close
 .
 .output "builds/android/build.sh"
@@ -63,12 +154,78 @@ $(project.GENERATED_WARNING_HEADER:)
 #   Exit if any step fails
 set -e
 
-# By default, use directory of current script as the Android build directory.
-# ANDROID_BUILD_DIR must be an absolute path:
-export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-\$(cd \$(dirname ${BASH_SOURCE[0]}) ; pwd)}"
+# Use directory of current script as the working directory
+cd "\$( dirname "${BASH_SOURCE[0]}" )"
+PROJECT_ROOT="\$(cd ../.. && pwd)"
+
+########################################################################
+# Configuration & tuning options.
+########################################################################
+# Set default values used in ci builds
+export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+
+# Set default path to find Android NDK.
+# Must be of the form <path>/${NDK_VERSION} !!
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
+
+# With NDK r22b, the minimum SDK version range is [16, 31].
+# Since NDK r24, the minimum SDK version range is [19, 31].
+# SDK version 21 is the minimum version for 64-bit builds.
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+
+# Where to download our dependencies: default to /tmp/tmp-deps
+export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-/tmp/tmp-deps}"
+
+# Use directory of current script as the build directory
+# ${ANDROID_BUILD_DIR}/prefix/<build_arch>/lib will contain produced libraries
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}}"
+
+# Clean before processing
+export ANDROID_BUILD_CLEAN="${ANDROID_BUILD_CLEAN:-no}"
+
+# Set this to 'no', to enable verbose ./configure
+export CI_CONFIG_QUIET="${CI_CONFIG_QUIET:-no}"
 
 # Set this to enable verbose profiling
-[ -n "${CI_TIME-}" ] || CI_TIME=""
+export CI_TIME="${CI_TIME:-}"
+
+# Set this to enable verbose tracing
+export CI_TRACE="${CI_TRACE:-no}"
+
+# By default, dependencies will be cloned to /tmp/tmp-deps.
+# If you have your own source tree for XXX, uncomment its
+# XXX_ROOT configuration line below, and provide its absolute tree:
+.for use where defined (use.repository)
+#    export $(USE.PROJECT)_ROOT="<absolute_path_to_$(USE.PROJECT)_source_tree>"
+.endfor
+
+########################################################################
+# Utilities
+########################################################################
+# Get access to android_build functions and variables
+# Perform some sanity checks and calculate some variables.
+source "${PROJECT_ROOT}/builds/android/android_build_helper.sh"
+
+function usage {
+    echo "$(PROJECT.NAME) - Usage:"
+    echo "  export XXX=xxx"
+    echo "  ./build.sh [ arm | arm64 | x86 | x86_64 ]"
+    echo ""
+    echo "See this file (configuration & tuning options) for details"
+    echo "on variables XXX and their values xxx"
+    exit 1
+}
+
+########################################################################
+# Sanity checks
+########################################################################
+BUILD_ARCH="$1"
+[ -z "${BUILD_ARCH}" ] && usage
+
+.    for use where defined (use.repository)
+android_init_dependency_root "$(use.libname)"     # Check or initialize $(USE.LIBNAME)_ROOT
+.    endfor
+
 case "$CI_TIME" in
     [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
         CI_TIME="time -p " ;;
@@ -76,8 +233,6 @@ case "$CI_TIME" in
         CI_TIME="" ;;
 esac
 
-# Set this to enable verbose tracing
-[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
 case "$CI_TRACE" in
     [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
         set +x ;;
@@ -85,131 +240,101 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
-function usage {
-    echo "Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
-}
-
-# Use directory of current script as the working directory
-cd "\$( dirname "${BASH_SOURCE[0]}" )"
-
-# Get access to android_build functions and variables
-source ./android_build_helper.sh
-
+########################################################################
+# Compilation
+########################################################################
 # Choose a C++ standard library implementation from the ndk
 export ANDROID_BUILD_CXXSTL="gnustl_shared_49"
 
 # Additional flags for LIBTOOL, for LIBZMQ and other dependencies.
 export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
-BUILD_ARCH=$1
-if [ -z $BUILD_ARCH ]; then
-    usage
-    exit 1
-fi
-
-case \$(uname | tr '[:upper:]' '[:lower:]') in
-  linux*)
-    export HOST_PLATFORM=linux-x86_64
-    ;;
-  darwin*)
-    export HOST_PLATFORM=darwin-x86_64
-    ;;
-  *)
-    echo "Unsupported platform"
-    exit 1
-    ;;
-esac
-
-# Set default values used in ci builds
-export NDK_VERSION=${NDK_VERSION:-android-ndk-r25}
-# With NDK r22b, the minimum SDK version range is [16, 31].
-# Since NDK r24, the minimum SDK version range is [19, 31].
-# SDK version 21 is the minimum version for 64-bit builds.
-export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
-
 # Set up android build environment and set ANDROID_BUILD_OPTS array
-android_build_set_env $BUILD_ARCH
+android_build_set_env "${BUILD_ARCH}"
+android_download_ndk
 android_build_env
 android_build_opts
 
-# Use a temporary build directory
-cache="/tmp/android_build/${TOOLCHAIN_ARCH}"
-rm -rf "${cache}"
-mkdir -p "${cache}"
-
 # Check for environment variable to clear the prefix and do a clean build
-if [[ $ANDROID_BUILD_CLEAN ]]; then
-    echo "Doing a clean build (removing previous build and depedencies)..."
+if [ "${ANDROID_BUILD_CLEAN}" = "yes" ]; then
+    android_build_trace "Doing a clean build (removing previous build and dependencies)..."
     rm -rf "${ANDROID_BUILD_PREFIX}"/*
+
+    # Called shells MUST not clean after ourselves !
+    export ANDROID_BUILD_CLEAN="no"
 fi
 
+DEPENDENCIES=()
+
 .for use where use.implied = 0
-##
-# Make sure $(use.project) is built and copy the prefix
+########################################################################
+# Make sure $(USE.PROJECT) is built and copy the prefix
 
+DEPENDENCIES+=("$(use.libname).so")
 (android_build_verify_so "$(use.libname).so" &> /dev/null) || {
-    # Use a default value assuming the $(use.project) project sits alongside this one
-    test -z "$$(USE.PROJECT)_ROOT" && $(USE.PROJECT)_ROOT="\$(cd ../../../$(use.project) && pwd)"
-
-    if [ ! -d "$$(USE.PROJECT)_ROOT" ]; then
-        echo "The $(USE.PROJECT)_ROOT directory does not exist"
-        echo "  ${$(USE.PROJECT)_ROOT}" run run
-        exit 1
+    if [ ! -d "${$(USE.PROJECT)_ROOT}" ] ; then
+.   if defined (use.tarball)
+        android_download_library "$(USE.PROJECT)" "${$(USE.PROJECT)_ROOT}" "$(use.tarball)"
+.   else
+        android_clone_library "$(USE.PROJECT)" "${$(USE.PROJECT)_ROOT}" "$(use.repository)" "$(use.release?)"
+.   endif
     fi
-    echo "Building $(use.project) in ${$(USE.PROJECT)_ROOT}..."
 
-    (bash ${$(USE.PROJECT)_ROOT}/builds/android/build.sh $BUILD_ARCH) || exit 1
-    UPSTREAM_PREFIX=${$(USE.PROJECT)_ROOT}/builds/android/prefix/${TOOLCHAIN_ARCH}
-    cp -rn ${UPSTREAM_PREFIX}/* ${ANDROID_BUILD_PREFIX} || :
+    if [ -f "${$(USE.PROJECT)_ROOT}/builds/android/build.sh" ] ; then
+        (
+            bash "${$(USE.PROJECT)_ROOT}/builds/android/build.sh" "${BUILD_ARCH}"
+        ) || exit 1
+    else
+        (
+            CONFIG_OPTS=()
+            [ "${CI_CONFIG_QUIET}" = "yes" ] && CONFIG_OPTS+=("--quiet")
+            CONFIG_OPTS+=("${ANDROID_BUILD_OPTS[@]}")
+            CONFIG_OPTS+=("--without-docs")
+.   if count (use.add_config_opts) > 0
+            # Custom additional options for $(USE.PROJECT)
+.       for use.add_config_opts as add_cfgopt
+            CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+.   endif
+
+            android_build_library "$(USE.PROJECT)" "${$(USE.PROJECT)_ROOT}"
+        ) || exit 1
+    fi
+
+    UPSTREAM_PREFIX="${$(USE.PROJECT)_ROOT}/builds/android/prefix/${TOOLCHAIN_ARCH}"
+    cp -rn "${UPSTREAM_PREFIX}"/* "${ANDROID_BUILD_PREFIX}" || :
 }
 
 .endfor
-##
+########################################################################
 [ -z "$CI_TIME" ] || echo "`date`: Build $(project.name) from local source"
 
-(android_build_verify_so "$(project.libname).so"\
-.for use where use.implied = 0
- "$(use.libname).so"\
-.endfor
- &> /dev/null) || {
-    rm -rf "${cache}/$(project.name)"
-    (cp -r ../.. "${cache}/$(project.name)" && cd "${cache}/$(project.name)" \\
-        && ( make clean || : ) && rm -f configure config.status)
-
-    # Remove *.la files as they might cause errors with cross compiled libraries
-    find ${ANDROID_BUILD_PREFIX} -name '*.la' -exec rm {} +
-
+(android_build_verify_so "$(project.libname).so" "${DEPENDENCIES[@]}" &> /dev/null) || {
     (
         CONFIG_OPTS=()
-        CONFIG_OPTS+=("--quiet")
+        [ "${CI_CONFIG_QUIET}" = "yes" ] && CONFIG_OPTS+=("--quiet")
         CONFIG_OPTS+=("${ANDROID_BUILD_OPTS[@]}")
         CONFIG_OPTS+=("--without-docs")
+.   if count (project.add_config_opts) > 0
+        # Custom additional options for $(PROJECT.LIBNAME)
+.       for project.add_config_opts as add_cfgopt
+        CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+.   endif
 
-        cd "${cache}/$(project.name)" \\
-        && $CI_TIME ./autogen.sh 2> /dev/null \\
-.if defined (use.libname?)
-        && android_show_configure_opts "$(USE.LIBNAME)" "${CONFIG_OPTS[@]}" \\
-.else
-        && android_show_configure_opts "$(PROJECT.LIBNAME)" "${CONFIG_OPTS[@]}" \\
-.endif
-        && $CI_TIME ./configure "${CONFIG_OPTS[@]}" \\
-        && $CI_TIME make -j 4 \\
-        && $CI_TIME make install
+        android_build_library "$(PROJECT.LIBNAME)" "${PROJECT_ROOT}"
     ) || exit 1
 }
 
 ##
 # Verify shared libraries in prefix
+for library in "$(project.libname).so" "${DEPENDENCIES[@]}" ; do
+    android_build_verify_so "${library}"
+done
 
-.for use where use.implied = 0
-android_build_verify_so "$(use.libname).so"
-.endfor
-android_build_verify_so "$(project.libname).so"\
-.for use where use.implied = 0
- "$(use.libname).so"\
-.endfor
+android_build_verify_so "$(project.libname).so" "${DEPENDENCIES[@]}"
+android_build_trace "Android build successful"
 
-echo "Android (${TOOLCHAIN_ARCH}) build successful"
 $(project.GENERATED_WARNING_HEADER:)
 .close
 .chmod_x ("builds/android/build.sh")
@@ -221,70 +346,28 @@ $(project.GENERATED_WARNING_HEADER:)
 #   Exit if any step fails
 set -e
 
-export NDK_VERSION=android-ndk-r25
-export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
+# Use directory of current script as the working directory
+cd "\$( dirname "${BASH_SOURCE[0]}" )"
 
-.for use where defined (use.repository)
-export $(USE.PROJECT)_ROOT="${$(USE.PROJECT)_ROOT:-/tmp/tmp-deps/$(use.project)}"
-.endfor
+# Configuration
+export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}/.build}"
+export ANDROID_BUILD_CLEAN="${ANDROID_BUILD_CLEAN:-yes}"
+export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-${PWD}/.deps}"
 
-case \$(uname | tr '[:upper:]' '[:lower:]') in
-  linux*)
-    HOST_PLATFORM=linux
-    ;;
-  darwin*)
-    HOST_PLATFORM=darwin
-    ;;
-  *)
-    echo "Unsupported platform"
-    exit 1
-    ;;
-esac
+# Cleanup.
+if [ "${ANDROID_BUILD_CLEAN}" = "yes" ] ; then
+    rm -rf   "${ANDROID_BUILD_DIR}/prefix"
+    mkdir -p "${ANDROID_BUILD_DIR}/prefix"
+    rm -rf   "${ANDROID_DEPENDENCIES_DIR}"
+    mkdir -p "${ANDROID_DEPENDENCIES_DIR}"
 
-if [ ! -d "${ANDROID_NDK_ROOT}" ]; then
-    export FILENAME=$NDK_VERSION-$HOST_PLATFORM.zip
-
-    (cd '/tmp' \\
-        && wget http://dl.google.com/android/repository/$FILENAME -O $FILENAME &> /dev/null \\
-        && unzip -q $FILENAME) || exit 1
-    unset FILENAME
+    # Called shells MUST not clean after ourselves !
+    export ANDROID_BUILD_CLEAN="no"
 fi
 
-rm -rf /tmp/tmp-deps
-mkdir -p /tmp/tmp-deps
-
-.for use where defined (use.tarball)
-if [ -d "${$(USE.PROJECT)_ROOT}" ] ; then
-    echo "$(PROJECT.PREFIX) - Cleaning $(USE.LIBNAME) folder '${$(USE.PROJECT)_ROOT}' ..."
-    ( cd "${$(USE.PROJECT)_ROOT}" && ( make clean || : ))
-else
-    echo "$(PROJECT.PREFIX) - Downloading $(USE.LIBNAME) from '$(use.tarball)' ..."
-    rm -f \$(basename "$(use.tarball)")
-    wget $(use.tarball)
-    tar -xzf \$(basename "$(use.tarball)")
-    mkdir -p "\$(dirname "${$(USE.PROJECT)_ROOT}")"
-    mv \$(basename "$(use.tarball)" .tar.gz) \$$(USE.PROJECT)_ROOT
-    echo "$(PROJECT.PREFIX) - $(USE.LIBNAME) extracted under under '${$(USE.PROJECT)_ROOT}' ..."
-fi
-
-.endfor
-.for use where defined (use.repository) & ! defined (use.tarball)
-if [ -d "${$(USE.PROJECT)_ROOT}" ] ; then
-    echo "$(PROJECT.PREFIX) - Cleaning $(USE.LIBNAME) folder '${$(USE.PROJECT)_ROOT}' ..."
-    ( cd "${$(USE.PROJECT)_ROOT}" && ( make clean || : ))
-else
-    mkdir -p "\$(dirname "${$(USE.PROJECT)_ROOT}")"
-.   if defined (use.release)
-    echo "$(PROJECT.PREFIX) - Cloning '$(use.repository)' (branch '$(use.release)') under '${$(USE.PROJECT)_ROOT}' ..."
-    git clone --quiet --depth 1 -b $(use.release:) $(use.repository) "${$(USE.PROJECT)_ROOT}"
-.   else
-    echo "$(PROJECT.PREFIX) - Cloning '$(use.repository)' (default branch) under '${$(USE.PROJECT)_ROOT}' ..."
-    git clone --quiet --depth 1 $(use.repository) "${$(USE.PROJECT)_ROOT}"
-.   endif
-    ( cd ${$(USE.PROJECT)_ROOT} && git log --oneline -n 1 )
-fi
-
-.endfor
 \./build.sh "arm"
 \./build.sh "arm64"
 \./build.sh "x86"
@@ -352,8 +435,32 @@ function android_download_ndk {
         ANDROID_BUILD_FAIL+=("  $(dirname "${ANDROID_NDK_ROOT}/")")
     fi
 
-    if [ -z "${ANDROID_NDK_FILENAME}" ] ; then
-        ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_FILENAME environment variable")
+    android_build_check_fail
+
+    local filename
+    local platform="$(uname | tr '[:upper:]' '[:lower:]')"
+    case "${platform}" in
+        linux*)
+            if [ "${NDK_NUMBER}" -ge 2300 ] ; then
+                # Since NDK 23, NDK archives are renamed.
+                filename=${NDK_VERSION}-linux.zip
+            else
+                filename=${NDK_VERSION}-linux-x86_64.zip
+            fi
+            ;;
+        darwin*)
+            if [ "${NDK_NUMBER}" -ge 2300 ] ; then
+                # Since NDK 23, NDK archives are renamed.
+                filename=${NDK_VERSION}-darwin.zip
+            else
+                filename=${NDK_VERSION}-darwin-x86_64.zip
+            fi
+            ;;
+        *)    android_build_trace "Unsupported platform ('${platform}')" ; exit 1 ;;
+    esac
+
+    if [ -z "${filename}" ] ; then
+        ANDROID_BUILD_FAIL+=("Unable to detect NDK filename.")
     fi
 
     android_build_check_fail
@@ -361,14 +468,14 @@ function android_download_ndk {
     android_build_trace "Downloading NDK '${NDK_VERSION}'..."
     (
         cd "$(dirname "${ANDROID_NDK_ROOT}")" \
-        && rm -f "${ANDROID_NDK_FILENAME}" \
-        && wget -q "http://dl.google.com/android/repository/${ANDROID_NDK_FILENAME}" -O "${ANDROID_NDK_FILENAME}" \
-        && android_build_trace "Extracting NDK '${ANDROID_NDK_FILENAME}'..." \
-        && unzip -q "${ANDROID_NDK_FILENAME}" \
+        && rm -f "${filename}" \
+        && wget -q "http://dl.google.com/android/repository/${filename}" -O "${filename}" \
+        && android_build_trace "Extracting NDK '${filename}'..." \
+        && unzip -q "${filename}" \
         && android_build_trace "NDK extracted under '${ANDROID_NDK_ROOT}'."
     ) || {
         ANDROID_BUILD_FAIL+=("Failed to install NDK ('${NDK_VERSION}')")
-        ANDROID_BUILD_FAIL+=("  ${ANDROID_NDK_FILENAME}")
+        ANDROID_BUILD_FAIL+=("  ${filename}")
     }
 
     android_build_check_fail
@@ -377,24 +484,12 @@ function android_download_ndk {
 function android_build_set_env {
     BUILD_ARCH=$1
 
-    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+    local platform="$(uname | tr '[:upper:]' '[:lower:]')"
     case "${platform}" in
         linux*)
-            if [ "${NDK_NUMBER}" -ge 2300 ] ; then
-                # Since NDK 23, NDK archives are renamed.
-                export ANDROID_NDK_FILENAME=${NDK_VERSION}-linux.zip
-            else
-                export ANDROID_NDK_FILENAME=${NDK_VERSION}-linux-x86_64.zip
-            fi
             export ANDROID_BUILD_PLATFORM=linux-x86_64
             ;;
         darwin*)
-            if [ "${NDK_NUMBER}" -ge 2300 ] ; then
-                # Since NDK 23, NDK archives are renamed.
-                export ANDROID_NDK_FILENAME=${NDK_VERSION}-darwin.zip
-            else
-                export ANDROID_NDK_FILENAME=${NDK_VERSION}-darwin-x86_64.zip
-            fi
             export ANDROID_BUILD_PLATFORM=darwin-x86_64
             ;;
         *)    android_build_trace "Unsupported platform ('${platform}')" ; exit 1 ;;
@@ -716,46 +811,132 @@ function android_show_configure_opts {
     echo ""
 }
 
-function android_clone_library {
-    local tag="$1" ; shift
-    local clone_root="$1" ; shift
-    local clone_url="$1" ; shift
-    local clone_branch="$1" ; shift
+# Initialize env variable XXX_ROOT, given dependency name "xxx".
+# If XXX_ROOT is not set:
+#    If ${PROJECT_ROOT}/../xxx exists
+#        set XXX_ROOT with it.
+#    Else
+#        set XXX_ROOT with ${ANDROID_DEPENDENCIES_DIR}/xxx.
+# Else
+#    Verify that folder XXX_ROOT exists.
+function android_init_dependency_root {
+    local lib_name
+    lib_name="$1"
+    local variable_name
+    variable_name="$(echo "${lib_name}" | tr '[:lower:]' '[:upper:]')_ROOT"
+    local variable_value
+    variable_value="$(eval echo "\${${variable_name}}")"
 
-    mkdir -p "$(dirname "${clone_root}")"
-    if [ -n "${clone_branch}" ] ; then
-        android_build_trace "Cloning '${clone_url}' (branch '${clone_branch}') under '${clone_root}'."
-        git clone --quiet --depth 1 -b "${clone_branch}" "${clone_url}" "${clone_root}"
-    else
-        android_build_trace "Cloning '${clone_url}' (default branch) under '${clone_root}'."
-        git clone --quiet --depth 1 "${clone_url}" "${clone_root}"
+    if [ -z "${PROJECT_ROOT}" ] ; then
+        android_build_trace "Error: Variable PROJECT_ROOT is not set."
+        exit 1
     fi
-    ( cd "${clone_root}" && git log --oneline -n 1)  || exit 1
+    if [ ! -d "${PROJECT_ROOT}" ] ; then
+        android_build_trace "Error: Cannot find folder '${PROJECT_ROOT}'."
+        exit 1
+    fi
+
+    if [ -z "${variable_value}" ] ; then
+        if [ -d "${PROJECT_ROOT}/../${lib_name}" ] ; then
+            eval "export ${variable_name}=\"$(cd "${PROJECT_ROOT}/../${lib_name}" && pwd)\""
+        else
+            eval "export ${variable_name}=\"${ANDROID_DEPENDENCIES_DIR}/${lib_name}\""
+        fi
+        variable_value="$(eval echo "\${${variable_name}}")"
+    elif [ ! -d "${variable_value}" ] ; then
+        android_build_trace "Error: Folder '${variable_value}' does not exist."
+        exit 1
+    fi
+
+    android_build_trace "${variable_name}=${variable_value}"
 }
 
-# Caller must set CONFIG_OPTS before call.
+function android_download_library {
+    local tag="$1" ; shift
+    local root="$1" ; shift
+    local url="$1" ; shift
+    local parent="$(dirname "${root}")"
+    local archive="$(basename "${url}")"
+
+    mkdir -p "${parent}"
+    cd "${parent}"
+
+    android_build_trace "Downloading ${tag} from '${url}' ..."
+    rm -f "${archive}"
+    wget -q "${url}"
+    case "${archive}" in
+        *."tar.gz" ) folder="$(basename "${archive}" ".tar.gz")" ;;
+        *."tgz" )    folder="$(basename "${archive}" ".tgz")" ;;
+        * ) android_build_trace "Unsupported extension for '${archive}'." ; exit 1 ;;
+    esac
+    android_build_trace "Extracting '${archive}' ..."
+    tar -xzf "${archive}"
+    if [ ! -d "${root}" ] ; then
+	mv "${folder}" "${root}"
+    fi
+    android_build_trace "${tag} extracted under under '${root}'."
+}
+
+function android_clone_library {
+    local tag="$1" ; shift
+    local root="$1" ; shift
+    local url="$1" ; shift
+    local branch="$1" ; shift
+
+    mkdir -p "$(dirname "${root}")"
+    if [ -n "${branch}" ] ; then
+        android_build_trace "Cloning '${url}' (branch '${branch}') under '${root}'."
+        git clone --quiet --depth 1 -b "${branch}" "${url}" "${root}"
+    else
+        android_build_trace "Cloning '${url}' (default branch) under '${root}'."
+        git clone --quiet --depth 1 "${url}" "${root}"
+    fi
+    ( cd "${root}" && git log --oneline -n 1)  || exit 1
+}
+
+# Caller must set CONFIG_OPTS[], before call.
 function android_build_library {
     local tag=$1 ; shift
-    local clone_root=$1 ; shift
+    local root=$1 ; shift
 
     android_build_trace "Cleaning library '${tag}'."
     (
-        cd "${clone_root}" \
-        && ( make clean || : ) && \
-        rm -f config.status
-    ) || exit 1
+        if [ -n "${ANDROID_BUILD_PREFIX}" ] && [ -d "${ANDROID_BUILD_PREFIX}" ] ; then
+            # Remove *.la files as they might cause errors with cross compiled libraries
+            find "${ANDROID_BUILD_PREFIX}" -name '*.la' -exec rm {} +
+        fi
 
+        cd "${root}" \
+        && ( make clean || : ) \
+        && rm -f config.status
+    ) &> /dev/null
+
+    android_build_trace "Building library '${tag}'."
     (
-        # Remove *.la files as they might cause errors with cross compiled libraries
-        find "${ANDROID_BUILD_PREFIX}" -name '*.la' -exec rm {} +
+        set -e
 
-        cd "${clone_root}" \
-        && ./autogen.sh \
-        && android_show_configure_opts "${tag}" "${CONFIG_OPTS[@]}" \
-        && ./configure "${CONFIG_OPTS[@]}" \
-        && make -j 4 \
-        && make install
-    ) || exit 1
+        android_show_configure_opts "${tag}" "${CONFIG_OPTS[@]}"
+
+        cd "${root}"
+        if [ -e autogen.sh ]; then
+            ./autogen.sh 2> /dev/null
+        fi
+        if [ -e buildconf ]; then
+            ./buildconf 2> /dev/null
+        fi
+        if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ] ; then
+            libtoolize --copy --force && \
+            aclocal -I . && \
+            autoheader && \
+            automake --add-missing --copy && \
+            autoconf || \
+            autoreconf -fiv
+        fi
+
+        ./configure "${CONFIG_OPTS[@]}"
+        make -j 4
+        make install
+    )
 }
 
 ########################################################################
@@ -764,8 +945,11 @@ function android_build_library {
 # Get directory of current script (if not already set)
 # This directory is also the basis for the build directories the get created.
 if [ -z "$ANDROID_BUILD_DIR" ]; then
-    ANDROID_BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    export ANDROID_BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 fi
+
+# Where to download our dependencies
+export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-/tmp/tmp-deps}"
 
 # Set up a variable to hold the global failure reasons, separated by newlines
 # (Empty string indicates no failure)
@@ -774,13 +958,10 @@ ANDROID_BUILD_FAIL=()
 ########################################################################
 # Sanity checks
 ########################################################################
-if [ -z "${NDK_VERSION}" ] ; then
-    android_build_trace "NDK_VERSION not set !"
-    exit 1
-fi
 case "${NDK_VERSION}" in
     "android-ndk-r"[0-9][0-9] ) : ;;
     "android-ndk-r"[0-9][0-9][a-z] ) : ;;
+    "" ) android_build_trace "Variable NDK_VERSION not set." ; exit 1 ;;
     * ) android_build_trace "Invalid format for NDK_VERSION ('${NDK_VERSION}')" ; exit 1 ;;
 esac
 

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -550,9 +550,26 @@ clean.doFirst {
 .output "$(topdir)/README.md"
 # $(project.prefix)-jni
 
-[ ![Download](https://api.bintray.com/packages/zeromq/maven/$(project.prefix)-jni/images/download.svg) ](https://bintray.com/zeromq/maven/$(project.prefix)-jni/_latestVersion)
-
 JNI Binding for $(project.name:)
+
+## Preamble
+
+As stated in LIBZMQ documentation, Android build systems are still DRAFT.
+
+[ZActor & ZLoop](https://github.com/zeromq/czmq/issues/2214) are not (yet ?) supported.
+It's also probably the case for a few other features.
+
+This being said, CZMQ can already be used for Android.
+
+
+## Prerequisites
+
+GRADLE need to be installed on your system.
+
+Note also that GRADLE requires CMake 3.6. For old distributions, this
+may mean an upgrade of CMake. This can do done from sources and is rather
+easy to rebuild/install though (tested on CentOS 7, Fedora 24, ...)
+
 
 ## Building the JNI Layer for Linux and OSX
 
@@ -580,14 +597,19 @@ If libraries of dependent projects are not installed in any of the default locat
 
 ## Building the JNI Layer for Android
 
+### Manual build
+
 Before you start make sure that you've built the JNI Layer for your current OS.
 
-Please read the prerequisites section of the [README](../../builds/android/README.md) in the android build directory.
+Please read the preamble section of the [README](../../builds/android/README.md) in the android build directory.
 
 You only need to set the environment variables.
 
 Then in the jni's android directory ($(project.prefix)-jni/android), run:
 
+    export XXX=xxx
+    export YYY=yyy
+    cd <$(project.name:c)>/bindings/jni/$(project.prefix)-jni/android
     ./build.sh [ arm | arm64 | x86 | x86_64 ]
 
 This does the following:
@@ -602,6 +624,56 @@ This does the following:
 .endfor
 * It combines all these into jar file for the built architecture, which you can use in your Android projects.
 * It merges the jar files built for the different architectures into one jar file.
+
+
+### More automated build mecanism
+
+You may also use `bindings/jni/ci_build.sh`:
+
+    export XXX=xxx
+    export YYY=yyy
+    ./ci_build.sh
+
+Basically, this script builds the whole for JAVA and but also for Android,
+but generated libraries are available in a different place:
+
+* bindings/jni/.deps         # all required dependencies
+
+* bindings/jni/.build/       # all generated native libraries
+
+* bindings/jni/.build/prefix # all generated android libraries
+
+
+If you have your own `prebuilt` Android libraries, place them under
+
+* bindings/jni/.build/prefix/{arm,arm6,x86,x86_64}/lib/.
+
+They will be automatically packed in generated JAR files.
+
+
+### Compatibility
+
+This build system is tested on a few recent distributions:
+
+* CentOS 7 (see [PREREQUISITES](#prerequisites)
+
+* Fedora (24 to 37 and see [PREREQUISITES](#prerequisites)
+
+* Rocky Linux (8 & 9)
+
+* Debian (9 to 11)
+
+* Ubuntu (16, 18, 20 & 22.04)
+
+Both build systems (`build.sh` and `ci_build.sh`) are tested with NDK 19 to 25,
+with current default of `android-ndk-25`.
+
+
+### Configuration
+
+Both come with many different configuration possibilities.
+Again, refer to [builds/android/README](../../builds/android/README.md) for details.
+
 
 ## Building the JNI Layer for Windows
 
@@ -628,6 +700,7 @@ Now run:
     gradlew build jar -PbuildPrefix=C:\\tmp\\deps
     gradlew test -PbuildPrefix=C:\\tmp\\deps
 
+
 ## Installing the JNI Layer
 
 If you like to use this JNI Layer in another project you'll need to distribute it
@@ -642,15 +715,22 @@ like to build a release version you need the set the release switch:
 
     ./gradlew publishToMavenLocal -PisRelease
 
+
 ## Using the JNI API
 
 - to be written.
+
 
 ## License
 
 $(project->license.:)
 
 ## Information for maintainers
+
+BINTRAY is no more accepting PUBLISH. Hence, this chapter has to be reviewed.
+
+See [CZMQ issue #2249](https://github.com/zeromq/czmq/issues/2249) and probably a few others.
+
 
 ### Create or update the gradle wrapper
 
@@ -665,12 +745,14 @@ Now commit all generated files to the project. Yes the jar file as well! Users
 will now be able to call the gradle wrapper (gradlew) which will install gradle
 for them.
 
+
 ### Travis build
 
 Travis can build and check this jni layer there add the following line to your
 travis environment matrix
 
     - BUILD_TYPE=bindings BINDING=jni
+
 
 ### Deploy to bintray with Travis CI
 
@@ -724,13 +806,53 @@ $(project.GENERATED_WARNING_HEADER:)
 #
 #   Requires these environment variables be set, e.g.:
 #
-#     ANDROID_NDK_ROOT=$HOME/android-ndk-r25
+#     NDK_VERSION=android-ndk-r25
 #
 #   Exit if any step fails
 set -e
 
-# Set this to enable verbose profiling
-[ -n "${CI_TIME-}" ] || CI_TIME=""
+# Use directory of current script as the working directory
+cd "\$( dirname "${BASH_SOURCE[0]}" )"
+PROJECT_ROOT="\$(cd ../../../.. && pwd)"
+
+# Configuration
+export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-/tmp/android_build}"
+export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-/tmp/tmp-deps}"
+
+export CI_CONFIG_QUIET="${CI_CONFIG_QUIET:-yes}"
+export CI_TIME="${CI_TIME:-}"
+export CI_TRACE="${CI_TRACE:-no}"
+
+########################################################################
+# Utilities
+########################################################################
+# Get access to android_build functions and variables
+# Perform some sanity checks and calculate some variables.
+source "${PROJECT_ROOT}/builds/android/android_build_helper.sh"
+
+function usage {
+    echo "$(PROJECT.NAME) - Usage:"
+    echo "  export XXX=xxx"
+    echo "  ./build.sh [ arm | arm64 | x86 | x86_64 ]"
+    echo ""
+    echo "See this file (configuration & tuning options) for details"
+    echo "on variables XXX and their values xxx"
+    exit 1
+}
+
+########################################################################
+# Sanity checks
+########################################################################
+BUILD_ARCH="$1"
+[ -z "${BUILD_ARCH}" ] && usage
+
+# Export android build's environment variables for cmake
+android_build_set_env "${BUILD_ARCH}"
+android_download_ndk
+
 case "$CI_TIME" in
     [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
         CI_TIME="time -p " ;;
@@ -738,8 +860,6 @@ case "$CI_TIME" in
         CI_TIME="" ;;
 esac
 
-# Set this to enable verbose tracing
-[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
 case "$CI_TRACE" in
     [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
         set +x ;;
@@ -749,58 +869,31 @@ case "$CI_TRACE" in
         ;;
 esac
 
-function usage {
-    echo "Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
-}
-
-BUILD_ARCH=$1
-if [ -z $BUILD_ARCH ]; then
-    usage
-    exit 1
-fi
-
-case \$(uname | tr '[:upper:]' '[:lower:]') in
-  linux*)
-    export HOST_PLATFORM=linux-x86_64
-    ;;
-  darwin*)
-    export HOST_PLATFORM=darwin-x86_64
-    ;;
-  *)
-    echo "Unsupported platform"
-    exit 1
-    ;;
-esac
-
-source ../../../../builds/android/android_build_helper.sh
-
-export MIN_SDK_VERSION=21
-export ANDROID_BUILD_DIR=/tmp/android_build
-
+########################################################################
+# Compilation
+########################################################################
 GRADLEW_OPTS=()
 GRADLEW_OPTS+=("-PbuildPrefix=$BUILD_PREFIX")
 GRADLEW_OPTS+=("--info")
 
 #   Build any dependent libraries
-#   Use a default value assuming that dependent libraries sits alongside this one
+#   Use a default value assuming that dependent libraries sit alongside this one
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-( cd ${$(USE.PROJECT)_ROOT:-../../../../../$(use.project)}/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
+( cd ${$(USE.LIBNAME)_ROOT:-../../../../../$(use.project)}/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
 .   endif
 .endfor
 
 #   Ensure we've built dependencies for Android
-echo "********  Building $(project.name:) Android native libraries"
+android_build_trace "Building Android native libraries"
 ( cd ../../../../builds/android && ./build.sh $BUILD_ARCH )
 
 #   Ensure we've built JNI interface
-echo "********  Building $(project.name:) JNI interface & classes"
+android_build_trace "Building JNI interface & classes"
 ( cd ../.. && TERM=dumb ./gradlew build jar ${GRADLEW_OPTS[@]} ${$(PROJECT.PREFIX)_GRADLEW_OPTS} )
 
-echo "********  Building $(project.name:) JNI for Android"
+android_build_trace "Building JNI for Android"
 rm -rf build && mkdir build && cd build
-# Export android build's environment variables for cmake
-android_build_set_env $BUILD_ARCH
 (
     VERBOSE=1 \\
     cmake \\
@@ -819,12 +912,12 @@ ln -s $ANDROID_SYS_ROOT/usr/lib/crtbegin_so.o
 
 make $MAKE_OPTIONS
 
-echo "********  Building jar for $TOOLCHAIN_ABI"
+android_build_trace "Building jar for $TOOLCHAIN_ABI"
 #   Copy class files into org/zeromq/etc.
 find ../../build/libs/ -type f -name '$(project.prefix)-jni-*.jar' ! -name '*javadoc.jar' ! -name '*sources.jar' -exec unzip -q {} +
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-unzip -qo "${$(USE.PROJECT)_ROOT:-../../../../../../$(use.project)}/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
+unzip -qo "${$(USE.LIBNAME)_ROOT:-../../../../../../$(use.project)}/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
 .   endif
 .endfor
 
@@ -839,7 +932,7 @@ zip -r -m ../$(project.prefix)-android-$TOOLCHAIN_ABI-$(->version.major).$(->ver
 cd ..
 rm -rf build
 
-echo "********  Merging ABI jars"
+android_build_trace "Merging ABI jars"
 mkdir build && cd build
 #   Copy contents from all ABI jar - overwriting class files and manifest
 unzip -qo '../$(project.prefix)-android-*$(->version.major).$(->version.minor).$(->version.patch).jar'
@@ -848,7 +941,9 @@ zip -r -m ../$(project.prefix)-android-$(->version.major).$(->version.minor).$(-
 cd ..
 rm -rf build
 
-echo "********  Complete"
+android_build_trace "Android JNI build successful"
+
+$(project.GENERATED_WARNING_HEADER:)
 .chmod_x ("$(topdir)/$(project.prefix:c)-jni/android/build.sh")
 .
 .output "$(topdir)/$(project.prefix:c)-jni/android/CMakeLists.txt"
@@ -916,12 +1011,47 @@ $(project.GENERATED_WARNING_HEADER:)
 #   Exit if any step fails
 set -e
 
+# Use directory of current script as the working directory
+cd "\$( dirname "${BASH_SOURCE[0]}" )"
+PROJECT_ROOT="\$(cd ../.. && pwd)"
+PROJECT_JNI_ROOT="${PROJECT_ROOT}/bindings/jni"
+
+# Configuration
+export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}/.build}"
+export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-${PWD}/.deps}"
+export BUILD_PREFIX="${BUILD_PREFIX:-/tmp/jni_build}"
+
+export TRAVIS_TAG="${TRAVIS_TAG:-no}"
+export TRAVIS_OS_NAME="${TRAVIS_OS_NAME:-}"
+export BINDING_OPTS="${BINDING_OPTS:-}"
+
+export CI_CONFIG_QUIET="${CI_CONFIG_QUIET:-yes}"
+export CI_TIME="${CI_TIME:-}"
+export CI_TRACE="${CI_TRACE:-no}"
+
+# By default, dependencies will be cloned to /tmp/tmp-deps.
+# If you have your own source tree for XXX, uncomment its
+# XXX_ROOT configuration line below, and provide its absolute tree:
 .for use where defined (use.repository)
-export $(USE.PROJECT)_ROOT="${$(USE.PROJECT)_ROOT:-/tmp/tmp-deps/$(use.project)}"
+#    export $(USE.LIBNAME)_ROOT="<absolute_path_to_$(USE.PROJECT)_source_tree>"
 .endfor
 
-# Set this to enable verbose profiling
-[ -n "${CI_TIME-}" ] || CI_TIME=""
+########################################################################
+# Preparation
+########################################################################
+# Get access to android_build functions and variables
+# Perform some sanity checks and calculate some variables.
+source "${PROJECT_ROOT}/builds/android/android_build_helper.sh"
+
+.for use where defined (use.repository)
+android_init_dependency_root "$(use.libname)"     # Check or initialize $(USE.LIBNAME)_ROOT
+.endfor
+
+android_download_ndk
+
 case "$CI_TIME" in
     [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
         CI_TIME="time -p " ;;
@@ -929,22 +1059,12 @@ case "$CI_TIME" in
         CI_TIME="" ;;
 esac
 
-# Set this to enable verbose tracing
-[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
 case "$CI_TRACE" in
     [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
         set +x ;;
     [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
         set -x ;;
 esac
-
-########################################################################
-# Build and check the jni binding
-########################################################################
-
-export BUILD_PREFIX=/tmp/jni_build
-$(PROJECT.PREFIX)_JNI_ROOT=${PWD}
-$(PROJECT.PREFIX)_ROOT=${PWD}/../..
 
 CONFIG_OPTS=()
 CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
@@ -954,9 +1074,7 @@ CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
 CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
 CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
 CONFIG_OPTS+=("--with-docs=no")
-if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
-    CONFIG_OPTS+=("--quiet")
-fi
+[ "${CI_CONFIG_QUIET}" = "yes" ] && CONFIG_OPTS+=("--quiet")
 
 GRADLEW_OPTS=()
 GRADLEW_OPTS+=("-PbuildPrefix=$BUILD_PREFIX")
@@ -965,91 +1083,67 @@ GRADLEW_OPTS+=("--info")
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 
-# Clone and build dependencies
+########################################################################
+# Clone and build native dependencies
+########################################################################
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."
-.for use where defined (use.tarball)
-if [ -d "${$(USE.PROJECT)_ROOT}" ] ; then
-    echo "$(PROJECT.PREFIX) - Cleaning $(USE.LIBNAME) folder '${$(USE.PROJECT)_ROOT}' ..."
-    ( cd "${$(USE.PROJECT)_ROOT}" && ( make clean || : ))
-else
-    echo "$(PROJECT.PREFIX) - Downloading $(USE.LIBNAME) from '$(use.tarball)' ..."
-    rm -f \$(basename "$(use.tarball)")
-    wget $(use.tarball)
-    tar -xzf \$(basename "$(use.tarball)")
-    mkdir -p "\$(dirname "${$(USE.PROJECT)_ROOT}")"
-    mv \$(basename "$(use.tarball)" .tar.gz) \$$(USE.PROJECT)_ROOT
-    echo "$(PROJECT.PREFIX) - $(USE.LIBNAME) extracted under under '${$(USE.PROJECT)_ROOT}'."
-fi
-cd \$$(USE.PROJECT)_ROOT
-.       generate_compile_script (use, "tarball")
 
-.endfor
-.for use where defined (use.repository) & ! defined (use.tarball)
-if [ -d "${$(USE.PROJECT)_ROOT}" ] ; then
-    echo "$(PROJECT.PREFIX) - Cleaning $(USE.LIBNAME) folder '${$(USE.PROJECT)_ROOT}' ..."
-    ( cd "${$(USE.PROJECT)_ROOT}" && ( make clean || : ))
-else
-    mkdir -p "\$(dirname "${$(USE.PROJECT)_ROOT}")"
-.   if defined (use.release)
-    echo "$(PROJECT.PREFIX) - Cloning '$(use.repository)' (branch '$(use.release)') under '${$(USE.PROJECT)_ROOT}' ..."
-    $CI_TIME git clone --quiet --depth 1 -b $(use.release:) $(use.repository) $$(USE.PROJECT)_ROOT
-.   else
-    echo "$(PROJECT.PREFIX) - Cloning '$(use.repository)' (default branch) under '${$(USE.PROJECT)_ROOT}' ..."
-    $CI_TIME git clone --quiet --depth 1 $(use.repository) $$(USE.PROJECT)_ROOT
+.for use where defined (use.repository)
+######################
+#  Build native '$(use.libname).so'
+if [ ! -d "${$(USE.LIBNAME)_ROOT}" ] ; then
+.    if defined (use.tarball)
+    android_download_library "$(USE.PROJECT)" "${$(USE.LIBNAME)_ROOT}" "$(use.tarball)"
+.    else
+    android_clone_library "$(USE.PROJECT)" "${$(USE.LIBNAME)_ROOT}" "$(use.repository)" "$(use.release?)"
+.    endif
+fi
+
+(
+.   if count(use.add_config_opts) > 0
+    # Custom additional options for $(use.project)
+.       for use.add_config_opts as add_cfgopt
+    CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+
 .   endif
-fi
-cd \$$(USE.PROJECT)_ROOT
-.   generate_compile_script (use, "git")
+    android_build_library "$(USE.PROJECT)" "${$(USE.LIBNAME)_ROOT}"
+)
 
-.       if count (project->dependencies.class, class.project = use.project) > 0
+.   if count (project->dependencies.class, class.project = use.project) > 0
 # Build jni dependency
-( cd bindings/jni && TERM=dumb $CI_TIME ./gradlew publishToMavenLocal ${GRADLEW_OPTS[@]} ${$(USE.PREFIX)_GRADLEW_OPTS} )
-.       endif
+( cd ${$(USE.LIBNAME)_ROOT}/bindings/jni && TERM=dumb $CI_TIME ./gradlew publishToMavenLocal ${GRADLEW_OPTS[@]} ${$(USE.PREFIX)_GRADLEW_OPTS} )
+.   endif
 
 .endfor
-cd \$$(PROJECT.PREFIX)_ROOT
+######################
+# Build native '$(project.libname).so'
+cd "${PROJECT_ROOT}"
 [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
-.generate_compile_script (project, "git")
+
+(
+.   if count(project.add_config_opts) > 0
+    # Custom additional options for $(my.use.project)
+.       for project.add_config_opts as add_cfgopt
+    CONFIG_OPTS+=("$(add_cfgopt)")
+.       endfor
+
+.   endif
+    android_build_library "$(PROJECT.LIBNAME)" "${PROJECT_ROOT}"
+)
+
 [ -z "$CI_TIME" ] || echo "`date`: Build completed without fatal errors!"
-
-cd ${$(PROJECT.PREFIX)_JNI_ROOT}
-[ -z "$TRAVIS_TAG" ] || IS_RELEASE="-PisRelease"
-
-TERM=dumb $CI_TIME ./gradlew build jar ${GRADLEW_OPTS[@]} ${$(PROJECT.PREFIX)_GRADLEW_OPTS} $IS_RELEASE
-TERM=dumb $CI_TIME ./gradlew clean
 
 ########################################################################
 #  Build and check the jni android binding
 ########################################################################
+cd "${PROJECT_JNI_ROOT}"
+[ "${TRAVIS_TAG}" = "yes" ] && IS_RELEASE="-PisRelease"
+
+TERM=dumb $CI_TIME ./gradlew build jar ${GRADLEW_OPTS[@]} ${$(PROJECT.PREFIX)_GRADLEW_OPTS} $IS_RELEASE
+TERM=dumb $CI_TIME ./gradlew clean
 
 if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$BINDING_OPTS" == "android" ]; then
-    pushd ../../builds/android
-        export NDK_VERSION=android-ndk-r25
-        export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
-
-        case \$(uname | tr '[:upper:]' '[:lower:]') in
-          linux*)
-            HOST_PLATFORM=linux
-            ;;
-          darwin*)
-            HOST_PLATFORM=darwin
-            ;;
-          *)
-            echo "Unsupported platform"
-            exit 1
-            ;;
-        esac
-
-        if [ ! -d "${ANDROID_NDK_ROOT}" ]; then
-            export FILENAME=$NDK_VERSION-$HOST_PLATFORM.zip
-
-            (cd '/tmp' \\
-                && wget http://dl.google.com/android/repository/$FILENAME -O $FILENAME &> /dev/null \\
-                && unzip -q $FILENAME) || exit 1
-            unset FILENAME
-        fi
-    popd
-
     pushd $(project.prefix)-jni/android
         $CI_TIME ./build.sh "arm"
         $CI_TIME ./build.sh "arm64"
@@ -1057,6 +1151,8 @@ if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$BINDING_OPTS" == "android" ]; then
         $CI_TIME ./build.sh "x86_64"
     popd
 fi
+
+$(project.GENERATED_WARNING_HEADER:)
 .close
 .chmod_x ("$(topdir)/ci_build.sh")
 .if ! file.exists ("$(topdir)/gradle/wrapper/gradle-wrapper.jar")
@@ -1417,38 +1513,6 @@ public class $(my.class.name:pascal)Test {
     }
 
 }
-.endmacro
-
-.macro generate_compile_script (use, target)
-.   if my.target = "git"
-git --no-pager log --oneline -n1
-if [ -e autogen.sh ]; then
-    $CI_TIME ./autogen.sh 2> /dev/null
-fi
-if [ -e buildconf ]; then
-    $CI_TIME ./buildconf 2> /dev/null
-fi
-if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./configure.ac ]; then
-    $CI_TIME libtoolize --copy --force && \\
-    $CI_TIME aclocal -I . && \\
-    $CI_TIME autoheader && \\
-    $CI_TIME automake --add-missing --copy && \\
-    $CI_TIME autoconf || \\
-    $CI_TIME autoreconf -fiv
-fi
-.   endif
-.   if count(my.use.add_config_opts) > 0
-( # Custom additional options for $(my.use.project)
-.       for my.use.add_config_opts as add_cfgopt
-  CONFIG_OPTS+=("$(add_cfgopt)")
-.       endfor
-  $CI_TIME ./configure "${CONFIG_OPTS[@]}"
-)
-.   else
-$CI_TIME ./configure "${CONFIG_OPTS[@]}"
-.   endif
-$CI_TIME make -j4
-$CI_TIME make install
 .endmacro
 
     project.namespace ?= switches.namespace? "org.zeromq.$(project.prefix)"


### PR DESCRIPTION
Solution: Apply similar modifications than in LIBZMQ.

Modificationts & enhancements apply in:

* builds/android/*

* bindings/jni/ci_build.sh

* bindings/jni/README.md

* bindings/jni/xxx-jni/android/build.sh

Android helpers do not use /tmp anymore to clone & build dependencies. This was causing conflicts, when there were 2 parallel compilations:

* builds/android/.deps: used to specify a path, where to download dependencies (instead of /tmp/tmp-deps).

* builds/android/.build: used to "install" the dependency binaries (instead of /tmp/android_build).

* /tmp/cache: no more used

Android helpers are enriched with new functions to download & build dependencies.

* The new build function is able to (and used to) perform native and cross-compilation of dependencies.

* Added ANDROID_DEPENDENCIES_DIR to specify where to download/clone dependencies.

* Documentation update with more existing variables & scripts.

* Documentation update with builds/android/ci_build.sh references.

Documentation update:

* builds/android/README.md

* bindings/jni/README.md

Note that JNI documentation still refers to JAR publication to BINTRAY, which is no more possible.