### PR TITLE
Problem: ZProject model has invalid info for libmicrohttpd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,8 @@ Model is described in `zproject_known_projects.xml` file:
     <use project = "libmicrohttpd"
          brew_name = "libmicrohttpd"
          prefix = "microhttpd"
-         repository = "https://gnunet.org/git/libmicrohttpd.git"
+         repository = "https://git.gnunet.org/libmicrohttpd.git"
+         tarball = "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
          test = "MHD_start_daemon" />
 
     <use project = "editline"

--- a/zproject_known_projects.xml
+++ b/zproject_known_projects.xml
@@ -121,7 +121,8 @@
     <use project = "libmicrohttpd"
          brew_name = "libmicrohttpd"
          prefix = "microhttpd"
-         repository = "https://gnunet.org/git/libmicrohttpd.git"
+         repository = "https://git.gnunet.org/libmicrohttpd.git"
+         tarball = "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
          test = "MHD_start_daemon" />
 
     <use project = "editline"


### PR DESCRIPTION
Solution: Fix repository and add tarball info

Got tarball info from CZMQ project.xml.