### PR TITLE
Problem: Android target needs options to specify project NDK & min SDK default values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 *  [Optional : Class filename configuration](#optional--class-filename-configuration)
 *  [Targets](#targets)
 &emsp;[Target Options](#target-options)
+&emsp;[Android target options](#android-target-options)
 &emsp;[Target Scopes](#target-scopes)
 *  [Modifying generated files in an already existent project](#modifying-generated-files-in-an-already-existent-project)
 
@@ -640,7 +641,7 @@ Model is described in `zproject_known_projects.xml` file:
 
         Proposed solution: project name should always be git repo
         name; prefix and libname should always be specified. For
-        compatibility we can define aliases. E.g.:
+        compatibility, we can define aliases. E.g.:
 
         Also, 'cmake name' is target specific and must go.
 
@@ -946,15 +947,19 @@ project.nuget_dependency.value = "4.2.0.0"
 
 The target `android` accepts the following options:
 
-    <target name = "android" >
-        <option name = "ndk_version" value = "nnn" />
-        <option name = "min_sdk_version" value = "sss" />
-    </target>
+```
+<target name = "android" >
+    <option name = "ndk_version" value = "nnn" />
+    <option name = "min_sdk_version" value = "sss" />
+</target>
+```
 
 Generated files will have their default values like:
 
-    project.android_ndk_version = "nnn"
-    project.android_min_sdk_version = "sss"
+```
+project.android_ndk_version = "nnn"
+project.android_min_sdk_version = "sss"
+```
 
 Note: these 2 default values can be overridden via the `export` mechanism
 as explained in generated `builds/android/README.md` and

--- a/README.md
+++ b/README.md
@@ -942,6 +942,27 @@ project.nuget_dependency.name = "libzmq_vc120"
 project.nuget_dependency.value = "4.2.0.0"
 ```
 
+##### Android target options
+
+The target `android` accepts the following options:
+
+    <target name = "android" >
+        <option name = "ndk_version" value = "nnn" />
+        <option name = "min_sdk_version" value = "sss" />
+    </target>
+
+Generated files will have their default values like:
+
+    project.android_ndk_version = "nnn"
+    project.android_min_sdk_version = "sss"
+
+Note: these 2 default values can be overridden via the `export` mechanism
+as explained in generated `builds/android/README.md` and
+`bindings/jni/README.md`.
+
+If these options are not provided, default hard-coded values are applied
+from `zproject_android.gsl` code.
+
 #### Target Scopes
 
 Each target works in its own copy of 'project'. It can therefore modify and extend 'project' as wanted, without affecting other targets.

--- a/README.txt
+++ b/README.txt
@@ -215,6 +215,31 @@ project.nuget_dependency.name = "libzmq_vc120"
 project.nuget_dependency.value = "4.2.0.0"
 ```
 
+##### Android target options
+
+The target `android` accepts the following options:
+
+```
+<target name = "android" >
+    <option name = "ndk_version" value = "nnn" />
+    <option name = "min_sdk_version" value = "sss" />
+</target>
+```
+
+Generated files will have their default values like:
+
+```
+project.android_ndk_version = "nnn"
+project.android_min_sdk_version = "sss"
+```
+
+Note: these 2 default values can be overridden via the `export` mechanism
+as explained in generated `builds/android/README.md` and
+`bindings/jni/README.md`.
+
+If these options are not provided, default hard-coded values are applied
+from `zproject_android.gsl` code.
+
 #### Target Scopes
 
 Each target works in its own copy of 'project'. It can therefore modify and extend 'project' as wanted, without affecting other targets.

--- a/project.xml
+++ b/project.xml
@@ -109,7 +109,7 @@
         Specify which other projects this depends on.
         These projects must be known by zproject, and the list of
         known projects is maintained in the zproject_known_projects.xml model.
-        You need not specify subdependencies if they are implied.
+        You need not specify sub-dependencies if they are implied.
         Dependencies that support the autotools build system are automatically
         built by travis ci if you supply a git repository or a tarball URI.
         Set type to "runtime" to have the packages install-depend on it rather
@@ -227,14 +227,14 @@
     -->
 
     <!-- Jenkins target creates jenkins pipeline
-         Pipeline file is not overwriten if it exists.
+         Pipeline file is not overwritten if it exists.
 
          Your projects can build under a docker container OR agents
          matched by a label OR under an "any" agent by default.
          If you specify a complex label expression, be sure to use
-         XML escaping of the amperesand character (&amp;) if some of
+         XML escaping of the ampersand character (&amp;) if some of
          your tooling expects project.xml to be valid XML (the GSL
-         parser accepts a verbatim amperesand character as well).
+         parser accepts a verbatim ampersand character as well).
 
          The agent_single option is a flag that enables parallel
          builds of this component on several agents (specified by
@@ -242,8 +242,8 @@
 
          Similarly, a check_sequential option can be defined so that
          self-testing stages would run sequentially. This can be needed
-         at early stages of a project's evolution, where hardcoding is
-         prevalent so parallel runs in same operating environemnt cause
+         at early stages of a project's evolution, where hard-coding is
+         prevalent so parallel runs in same operating environment cause
          conflicts to each other. Ultimately a project should remove
          this flag ;)
 
@@ -286,7 +286,7 @@
          except it is off by default to avoid churning CPUs with no tools.
          A further dist_docs enables preparation of a "dist" tarball from
          the workspace configured with docs, so you can forward it to the
-         publishing helper job and avoid rebuilding manpages for packaging.
+         publishing helper job and avoid rebuilding man pages for packaging.
 
          Similarly, a test_check_clang_format requires an external tool,
          the clang-format-5.0 (or newer) to process the codebase and decide

--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -44,7 +44,7 @@ Provided build scripts can mainly be used like
 
 $(PROJECT.NAME) is tested against Android NDK versions r19 to r25.
 
-By default, $(PROJECT.NAME) uses NDK `android-ndk-r25`, but you can specify
+By default, $(PROJECT.NAME) uses NDK `$(project.android_ndk_version)`, but you can specify
 a different one:
 
     export NDK_VERSION=android-ndk-r23c
@@ -65,7 +65,7 @@ to its default:
 
 To specify the minimum SDK version set the environment variable below:
 
-    export MIN_SDK_VERSION=21   # Default value if unset
+    export MIN_SDK_VERSION=$(project.android_min_sdk_version)   # Default value if unset
 
 To specify the build directory set the environment variable below:
 
@@ -162,7 +162,7 @@ PROJECT_ROOT="\$(cd ../.. && pwd)"
 # Configuration & tuning options.
 ########################################################################
 # Set default values used in ci builds
-export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export NDK_VERSION="${NDK_VERSION:-$(project.android_ndk_version)}"
 
 # Set default path to find Android NDK.
 # Must be of the form <path>/${NDK_VERSION} !!
@@ -171,7 +171,7 @@ export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
 # With NDK r22b, the minimum SDK version range is [16, 31].
 # Since NDK r24, the minimum SDK version range is [19, 31].
 # SDK version 21 is the minimum version for 64-bit builds.
-export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-$(project.android_min_sdk_version)}
 
 # Where to download our dependencies: default to /tmp/tmp-deps
 export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-/tmp/tmp-deps}"
@@ -350,9 +350,9 @@ set -e
 cd "\$( dirname "${BASH_SOURCE[0]}" )"
 
 # Configuration
-export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export NDK_VERSION="${NDK_VERSION:-$(project.android_ndk_version)}"
 export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
-export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-$(project.android_min_sdk_version)}
 export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}/.build}"
 export ANDROID_BUILD_CLEAN="${ANDROID_BUILD_CLEAN:-yes}"
 export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-${PWD}/.deps}"
@@ -546,21 +546,23 @@ function android_build_env {
     ##
     # Check that necessary environment variables are set
 
+.endliteral
     if [ -z "$ANDROID_NDK_ROOT" ]; then
         ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_ROOT environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \\"/home/user/android/$(project.android_ndk_version)\\")")
     fi
 
     if [ -z "$ANDROID_BUILD_TOOLCHAIN" ]; then
         ANDROID_BUILD_FAIL+=("Please set the ANDROID_BUILD_TOOLCHAIN environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \\"/home/user/android/$(project.android_ndk_version)/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64\\")")
     fi
 
     if [ -z "$TOOLCHAIN_PATH" ]; then
         ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_PATH environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \\"/home/user/android/$(project.android_ndk_version)/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin\\")")
     fi
 
+.literal << .endliteral
     if [ -z "$TOOLCHAIN_HOST" ]; then
         ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_HOST environment variable")
         ANDROID_BUILD_FAIL+=("  (eg. \"arm-linux-androideabi\")")
@@ -987,3 +989,7 @@ $(project.GENERATED_WARNING_HEADER:)
 .close
 .chmod_x ("builds/android/android_build_helper.sh")
 .endmacro
+
+# Set default NDK and min SDK.
+project.android_ndk_version ?= "android-ndk-r25"
+project.android_min_sdk_version ?= 21

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -806,7 +806,7 @@ $(project.GENERATED_WARNING_HEADER:)
 #
 #   Requires these environment variables be set, e.g.:
 #
-#     NDK_VERSION=android-ndk-r25
+#     NDK_VERSION=$(project.android_ndk_version)
 #
 #   Exit if any step fails
 set -e
@@ -816,9 +816,9 @@ cd "\$( dirname "${BASH_SOURCE[0]}" )"
 PROJECT_ROOT="\$(cd ../../../.. && pwd)"
 
 # Configuration
-export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export NDK_VERSION="${NDK_VERSION:-$(project.android_ndk_version)}"
 export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
-export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-$(project.android_min_sdk_version)}
 export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-/tmp/android_build}"
 export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-/tmp/tmp-deps}"
 
@@ -1017,9 +1017,9 @@ PROJECT_ROOT="\$(cd ../.. && pwd)"
 PROJECT_JNI_ROOT="${PROJECT_ROOT}/bindings/jni"
 
 # Configuration
-export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export NDK_VERSION="${NDK_VERSION:-$(project.android_ndk_version)}"
 export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
-export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-$(project.android_min_sdk_version)}
 export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}/.build}"
 export ANDROID_DEPENDENCIES_DIR="${ANDROID_DEPENDENCIES_DIR:-${PWD}/.deps}"
 export BUILD_PREFIX="${BUILD_PREFIX:-/tmp/jni_build}"


### PR DESCRIPTION
For an Android library, NDK and SDK can be considered as project-wide values. As such, they can be part of the project.xml, via 2 target options.

Solution: Create android target options "ndk_version" and "min_sdk_version".

Example in project.xml:

    <target name = "android" >
        <option name = "android_ndk_version" value = "android-dnk-r23"/>
        <option name = "min_sdk_version" value = "21"/>
    </ target>

If these options are not specified (like CZMQ & ZYRE), the ZProject hard coded values apply.

If specified, they can be overriden with the `export` mechanism already in place and explained in generated `builds/android/README.md` and `bindings/jni/README.md`.

ZProject documentation is updated with the same.