### PR TITLE
Problem: Android generated code has inconsistent dependency ROOT variable names.

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -223,7 +223,7 @@ BUILD_ARCH="$1"
 [ -z "${BUILD_ARCH}" ] && usage
 
 .    for use where defined (use.repository)
-android_init_dependency_root "$(use.libname)"     # Check or initialize $(USE.LIBNAME)_ROOT
+android_init_dependency_root "$(use.project)"     # Check or initialize $(USE.PROJECT)_ROOT
 .    endfor
 
 case "$CI_TIME" in

--- a/zproject_java.gsl
+++ b/zproject_java.gsl
@@ -880,7 +880,7 @@ GRADLEW_OPTS+=("--info")
 #   Use a default value assuming that dependent libraries sit alongside this one
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-( cd ${$(USE.LIBNAME)_ROOT:-../../../../../$(use.project)}/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
+( cd ${$(USE.PROJECT)_ROOT:-../../../../../$(use.project)}/bindings/jni/$(use.prefix)-jni/android; ./build.sh $BUILD_ARCH )
 .   endif
 .endfor
 
@@ -917,7 +917,7 @@ android_build_trace "Building jar for $TOOLCHAIN_ABI"
 find ../../build/libs/ -type f -name '$(project.prefix)-jni-*.jar' ! -name '*javadoc.jar' ! -name '*sources.jar' -exec unzip -q {} +
 .for project.use
 .   if count (project->dependencies.class, class.project = use.project) > 0
-unzip -qo "${$(USE.LIBNAME)_ROOT:-../../../../../../$(use.project)}/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
+unzip -qo "${$(USE.PROJECT)_ROOT:-../../../../../../$(use.project)}/bindings/jni/$(use.project)-jni/android/$(use.project)-android*$TOOLCHAIN_ABI*.jar"
 .   endif
 .endfor
 
@@ -1036,7 +1036,7 @@ export CI_TRACE="${CI_TRACE:-no}"
 # If you have your own source tree for XXX, uncomment its
 # XXX_ROOT configuration line below, and provide its absolute tree:
 .for use where defined (use.repository)
-#    export $(USE.LIBNAME)_ROOT="<absolute_path_to_$(USE.PROJECT)_source_tree>"
+#    export $(USE.PROJECT)_ROOT="<absolute_path_to_$(USE.PROJECT)_source_tree>"
 .endfor
 
 ########################################################################
@@ -1047,7 +1047,7 @@ export CI_TRACE="${CI_TRACE:-no}"
 source "${PROJECT_ROOT}/builds/android/android_build_helper.sh"
 
 .for use where defined (use.repository)
-android_init_dependency_root "$(use.libname)"     # Check or initialize $(USE.LIBNAME)_ROOT
+android_init_dependency_root "$(use.project)"     # Check or initialize $(USE.PROJECT)_ROOT
 .endfor
 
 android_download_ndk
@@ -1091,11 +1091,11 @@ mkdir -p /tmp/tmp-deps
 .for use where defined (use.repository)
 ######################
 #  Build native '$(use.libname).so'
-if [ ! -d "${$(USE.LIBNAME)_ROOT}" ] ; then
+if [ ! -d "${$(USE.PROJECT)_ROOT}" ] ; then
 .    if defined (use.tarball)
-    android_download_library "$(USE.PROJECT)" "${$(USE.LIBNAME)_ROOT}" "$(use.tarball)"
+    android_download_library "$(USE.PROJECT)" "${$(USE.PROJECT)_ROOT}" "$(use.tarball)"
 .    else
-    android_clone_library "$(USE.PROJECT)" "${$(USE.LIBNAME)_ROOT}" "$(use.repository)" "$(use.release?)"
+    android_clone_library "$(USE.PROJECT)" "${$(USE.PROJECT)_ROOT}" "$(use.repository)" "$(use.release?)"
 .    endif
 fi
 
@@ -1107,12 +1107,12 @@ fi
 .       endfor
 
 .   endif
-    android_build_library "$(USE.PROJECT)" "${$(USE.LIBNAME)_ROOT}"
+    android_build_library "$(USE.PROJECT)" "${$(USE.PROJECT)_ROOT}"
 )
 
 .   if count (project->dependencies.class, class.project = use.project) > 0
 # Build jni dependency
-( cd ${$(USE.LIBNAME)_ROOT}/bindings/jni && TERM=dumb $CI_TIME ./gradlew publishToMavenLocal ${GRADLEW_OPTS[@]} ${$(USE.PREFIX)_GRADLEW_OPTS} )
+( cd ${$(USE.PROJECT)_ROOT}/bindings/jni && TERM=dumb $CI_TIME ./gradlew publishToMavenLocal ${GRADLEW_OPTS[@]} ${$(USE.PREFIX)_GRADLEW_OPTS} )
 .   endif
 
 .endfor


### PR DESCRIPTION
Some generated scripts are built with `$(USE.PROJECT)_ROOT` and some others are built with `$(USE.LIBNAME)_ROOT`

This inconsistency is not seen with CZMQ.

With ZYRE, this gives (for instance):

* bindings/jni/ci_build.sh set LIBCZMQ_ROOT:

    android_init_dependency_root "libczmq"   # Check or initialize LIBCZMQ_ROOT

* builds/android/build.sh expects CZMQ_ROOT:

    if [ ! -d "${CZMQ_ROOT}" ] ; then

Solution: Replace `$(USE.LIBNAME)_ROOT` by `$(USE.PROJECT)_ROOT` and similar.

**Important:**

This will affect ZYRE, when using recent commits, and especially like below:

    export LIBCZMQ_ROOT=xxx
    cd bindings/jni/zyre-jni/android/build.sh:
    ./build.sh [arm|arm64|x86|x86_64]

The same call becomes:

    export CZMQ_ROOT=xxx
    cd bindings/jni/zyre-jni/android/build.sh:
    ./build.sh [arm|arm64|x86|x86_64]

or similar with `bindings/jni/ci_build.sh`.

**Note:**

USE.LIBNAME was mistakenly introduced in a recent PR of mine.