### PR TITLE
Problem: Android helper has unexpected diff with LIBZMQ's one.

### DIFF
--- a/zproject_android.gsl
+++ b/zproject_android.gsl
@@ -65,7 +65,7 @@ to its default:
 
 To specify the minimum SDK version set the environment variable below:
 
-    export MIN_SDK_VERSION=$(project.android_min_sdk_version)   # Default value if unset
+    export MIN_SDK_VERSION=$(project.android_min_sdk_version)\ \ \ # Default value if unset
 
 To specify the build directory set the environment variable below:
 


### PR DESCRIPTION
Due to a kind of "padding" generated by GSL.

Solution: use escape '\' to avoid this padding.