### PR TITLE
Problem: SUSE builds fail due to empty changelog in spec file

### DIFF
--- a/packaging/redhat/zproject.spec
+++ b/packaging/redhat/zproject.spec
@@ -110,3 +110,5 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %{_bindir}/zproject_known_projects.xml
 
 %changelog
+* Wed Dec 31 2014 zproject Developers <zeromq-dev@lists.zeromq.org
+- Initial packaging.

--- a/zproject_redhat.gsl
+++ b/zproject_redhat.gsl
@@ -497,4 +497,6 @@ python3 setup.py install --root=%{buildroot} --skip-build --prefix %{_prefix}
 .endif
 
 %changelog
+* Wed Dec 31 2014 $(project.name) Developers <$(project.email)
+- Initial packaging.
 .endmacro


### PR DESCRIPTION
Solution: generate the same dummy entry as the Debian changelog