### PR TITLE
Problem:  autogen fails from SELFTEST missing in configure.am

### DIFF
--- a/zproject_autotools.gsl
+++ b/zproject_autotools.gsl
@@ -1088,7 +1088,6 @@ AC_ARG_ENABLE([$(name)],
 AM_CONDITIONAL([ENABLE_$(NAME:c)], [test x$enable_$(name:c) != xno])
 AM_COND_IF([ENABLE_$(NAME:c)], [AC_MSG_NOTICE([ENABLE_$(NAME:c) defined])])
 
-.else
 AM_CONDITIONAL([ENABLE_$(PROJECT.PREFIX:c)_SELFTEST], [test x$enable_$(project.prefix:c)_selftest != xno])
 AM_COND_IF([ENABLE_$(PROJECT.PREFIX:c)_SELFTEST], [AC_MSG_NOTICE([ENABLE_$(PROJECT.PREFIX:c)_SELFTEST defined])])
 


### PR DESCRIPTION
A basic project.xml fails with ENABLE_MYPROJECT_SELFTEST does not appear in AM_CONDITIONAL.

This project.xml:

```xml
<project script = "zproject.gsl">
    <main name = "hello" private = "1" />
</project>
```
results in the following error when `./autogen.sh` is executed:

```
configure.ac:55: installing 'config/compile'
configure.ac:58: installing 'config/config.guess'
configure.ac:58: installing 'config/config.sub'
configure.ac:21: installing 'config/install-sh'
configure.ac:21: installing 'config/missing'
src/Makemodule.am:20: error: ENABLE_MYPROJECT_SELFTEST does not appear in AM_CONDITIONAL
Makefile.am:44:   'src/Makemodule.am' included from here
src/Makemodule.am:319: error: ENABLE_MYPROJECT_SELFTEST does not appear in AM_CONDITIONAL
Makefile.am:44:   'src/Makemodule.am' included from here
Makefile.am: installing 'config/depcomp'
parallel-tests: installing 'config/test-driver'
autoreconf: error: automake failed with exit status: 1
autogen.sh: error: autoreconf exited with status 1
```

It seems that `zproject_autotools.gsl` had this added but with what seems to be a rogue .else in this commit: https://github.com/zeromq/zproject/commit/1487ad4d479c2b55f8a50f48bc8e8bdb5b44811e so therefore I am requesting @bluca to review

PS: I didn't use the exact basic example in the README because czmq fails to detect libzmq.

Solution: Remove rogue .else in autotools.gsl