### PR TITLE
Problem: Ruby binding can't find lib without devel package installed

### DIFF
--- a/zproject_ruby.gsl
+++ b/zproject_ruby.gsl
@@ -281,12 +281,21 @@ module $(project.RubyName:)
     end
 
     begin
-      lib_name = '$(project.libname)'
-      lib_dirs = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64']
-      env_name = "#{lib_name.upcase}_PATH"
-      lib_dirs = [*ENV[env_name].split(':'), *lib_dirs] if ENV[env_name]
-      lib_paths = lib_dirs.map { |path| "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}" }
-      ffi_lib lib_paths + [lib_name]
+      lib_name      = '$(project.libname)'
+      major_version = '$(project->version.major)'
+      lib_dirs      = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64', '/usr/lib']
+      lib_dirs      = [*ENV['LD_LIBRARY_PATH'].split(':'), *lib_dirs] if ENV['LD_LIBRARY_PATH']
+      lib_dirs      = [*ENV["#{lib_name.upcase}_PATH"].split(':'), *lib_dirs] if ENV["#{lib_name.upcase}_PATH"]
+      lib_paths     = lib_dirs.map do |path|
+        [
+          "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}",
+          "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}.#{major_version}"
+        ]
+      end.flatten
+
+      lib_paths.concat [lib_name, "#{lib_name}.#{::FFI::Platform::LIBSUFFIX}.#{major_version}"]
+
+      ffi_lib lib_paths
       @available = true
     rescue LoadError
       warn ""


### PR DESCRIPTION
Solution: Also look for my_lib.so.X where X is the major version

* on Debian/Ubuntu, my_lib.so is only available with mylib-dev installed (e.g. libczmq-dev)
* it used to look just for my_lib.so in the search paths
* add LD_LIBRARY_PATH and /usr/lib to search paths